### PR TITLE
feat: Storage Profiles In Blender Submitter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = ""
 requires-python = ">=3.7"
 
 dependencies = [
-    "deadline == 0.16.*",
+    "deadline == 0.17.*",
     "openjobio == 0.8.*",
 ]
 

--- a/src/deadline_submitter_for_blender/data_classes/submitter_properties.py
+++ b/src/deadline_submitter_for_blender/data_classes/submitter_properties.py
@@ -41,6 +41,17 @@ def queue_callback(self, context):
         return ()
 
 
+def storage_profile_callback(self, context):
+    wm_type = bpy.types.WindowManager
+    wm_instance = context.window_manager
+    if hasattr(wm_type, "deadline_storage_profile_lookup"):
+        return wm_type.deadline_storage_profile_lookup[
+            (wm_instance.deadline_farm, wm_instance.deadline_queue)
+        ]
+    else:
+        return ()
+
+
 def submission_status_callback(self, context):
     return (
         ("READY", "Ready", "Ready"),
@@ -136,6 +147,17 @@ def create():  # pragma: no cover
         items=queue_callback,
         name="Queue",
         description="Deadline queue to submit the job to.",
+        default=None,
+        options=set(),
+        update=None,
+        get=None,
+        set=None,
+    )
+
+    wm.deadline_storage_profile = bpy.props.EnumProperty(
+        items=storage_profile_callback,
+        name="Storage Profile",
+        description="Deadline storage profile to submit the job with.",
         default=None,
         options=set(),
         update=None,
@@ -254,6 +276,7 @@ def delete():  # pragma: no cover
     del wm.deadline_job_description
     del wm.deadline_farm
     del wm.deadline_queue
+    del wm.deadline_storage_profile
     del wm.deadline_submission_status
     del wm.deadline_max_retries_per_task
     del wm.deadline_priority

--- a/src/deadline_submitter_for_blender/ui/components/deadline_settings.py
+++ b/src/deadline_submitter_for_blender/ui/components/deadline_settings.py
@@ -47,6 +47,7 @@ class DEADLINE_PT_Deadline_Settings(bpy.types.Panel):
 
         sub_col.prop(wm, "deadline_farm")
         sub_col.prop(wm, "deadline_queue")
+        sub_col.prop(wm, "deadline_storage_profile")
 
         enabled_section = sub_col.row(align=True)
         enabled_section.alignment = "RIGHT"

--- a/src/deadline_submitter_for_blender/utilities/submission_functions.py
+++ b/src/deadline_submitter_for_blender/utilities/submission_functions.py
@@ -380,6 +380,7 @@ def build_config() -> ConfigParser:
     config_file = ConfigParser()
     config.set_setting("defaults.farm_id", wm.deadline_farm, config_file)
     config.set_setting("defaults.queue_id", wm.deadline_queue, config_file)
+    config.set_setting("settings.storage_profile_id", wm.deadline_storage_profile, config_file)
     endpoint_url = config.get_setting("settings.deadline_endpoint_url")
     config.set_setting("settings.deadline_endpoint_url", endpoint_url, config_file)
     active_profile(config=config_file)

--- a/src/deadline_submitter_for_blender/utilities/submitter_operations.py
+++ b/src/deadline_submitter_for_blender/utilities/submitter_operations.py
@@ -22,7 +22,7 @@ from .utility_functions import (
     deadline_login,
     deadline_logout,
     get_assets,
-    set_farm_and_queue_lookups,
+    set_farm_queue_and_storage_profile_lookups,
 )
 
 
@@ -129,7 +129,7 @@ class DeadlineSubmit:
         if wm.deadline_project_path == "":
             bpy.ops.deadline.set_project_path()
 
-        # Build a temp config file for setting the selected farm and queue
+        # Build a temp config file for setting the selected farm, queue, and storage profile
         config = build_config()
 
         # Generate the job bundle files required for submitting with DeadlineClientLib
@@ -193,7 +193,7 @@ class DEADLINE_OT_Refresh_Deadline(bpy.types.Operator):  # pragma: no cover
     bl_option = {"REGISTER"}
 
     def execute(self, context):
-        set_farm_and_queue_lookups()
+        set_farm_queue_and_storage_profile_lookups()
         return {"FINISHED"}
 
 
@@ -214,6 +214,7 @@ class DeadlineExport:
         data["deadline_job_description"] = wm.deadline_job_description
         data["deadline_farm"] = wm.deadline_farm
         data["deadline_queue"] = wm.deadline_queue
+        data["deadline_storage_profile"] = wm.deadline_storage_profile
         data["deadline_submission_status"] = wm.deadline_submission_status
         data["deadline_max_retries_per_task"] = wm.deadline_max_retries_per_task
         data["deadline_priority"] = wm.deadline_priority
@@ -297,6 +298,7 @@ class DeadlineImport:
                 "deadline_job_output_attachments",
                 "deadline_farm",
                 "deadline_queue",
+                "deadline_storage_profile",
                 "deadline_scene",
                 "deadline_layer",
             ]:
@@ -324,6 +326,17 @@ class DeadlineImport:
                 )
             ):
                 setattr(wm, "deadline_queue", data["deadline_queue"])
+
+                if (
+                    wm.get("deadline_storage_profile_lookup", None)
+                    and wm.deadline_storage_profile_lookup(
+                        (data["deadline_farm"], data["deadline_queue"]), None
+                    )
+                    and wm.deadline_storage_profile_lookup(
+                        (data["deadline_farm"], data["deadline_queue"])
+                    ).get(data["deadline_storage_profile"], None)
+                ):
+                    setattr(wm, "deadline_storage_profile", data["deadline_storage_profile"])
 
         # handle file attachments
         bpy.ops.deadline.clear_assets()

--- a/test/deadline_submitter_for_blender/unit/data_classes/test_submitter_properties.py
+++ b/test/deadline_submitter_for_blender/unit/data_classes/test_submitter_properties.py
@@ -62,6 +62,39 @@ def test_queue_callback_has_no_queues(mock_wm_type):
     assert result == ()
 
 
+@patch.object(submitter_properties.bpy.types, "WindowManager")
+def test_storage_profile_callback_has_storage_profiles(mock_wm_type):
+    # GIVEN
+    storage_profiles = [("sp1", "sp2", "sp3")]
+
+    mock_wm_context = Mock()
+    mock_wm_context.deadline_farm = "farm1"
+    mock_wm_context.deadline_queue = "queue1"
+    mock_context = Mock()
+    mock_context.window_manager = mock_wm_context
+
+    mock_wm_type.deadline_storage_profile_lookup = {("farm1", "queue1"): storage_profiles}
+
+    # WHEN
+    result = submitter_properties.storage_profile_callback(None, mock_context)
+
+    # THEN
+    assert result == storage_profiles
+
+
+@patch.object(submitter_properties.bpy.types, "WindowManager")
+def test_storage_profile_callback_has_no_storage_profiles(mock_wm_type):
+    # GIVEN
+    mock_context = Mock()
+    del mock_wm_type.deadline_storage_profile_lookup
+
+    # WHEN
+    result = submitter_properties.storage_profile_callback(None, mock_context)
+
+    # THEN
+    assert result == ()
+
+
 def test_submission_status_callback():
     # GIVEN
     submission_statuses = (

--- a/test/deadline_submitter_for_blender/unit/utilities/test_utility_functions.py
+++ b/test/deadline_submitter_for_blender/unit/utilities/test_utility_functions.py
@@ -100,11 +100,12 @@ def test_get_queues(mock_api):
 
 @patch.object(utility_functions, "active_profile")
 @patch.object(utility_functions.bpy.context, "window_manager")
+@patch.object(utility_functions, "get_storage_profiles")
 @patch.object(utility_functions, "get_queues")
 @patch.object(utility_functions, "get_farms")
 @patch.object(utility_functions.bpy.types, "WindowManager")
-def test_set_farm_and_queue_lookups(
-    mock_wm, mock_farms, mock_queues, mock_wm_context, mock_active_profile
+def test_set_farm_queue_and_storage_profile_lookups(
+    mock_wm, mock_farms, mock_queues, mock_storage_profiles, mock_wm_context, mock_active_profile
 ):
     # GIVEN
     mock_wm_context.deadline_logged_in = True
@@ -112,22 +113,29 @@ def test_set_farm_and_queue_lookups(
 
     returned_farms = [("farm-1", "farm", "farm")]
     returned_queues = [("queue-1", "queue", "queue")]
+    returned_storage_profiles = [("sp-1", "storage profile", "storage profile")]
 
     mock_farms.return_value = returned_farms
     mock_queues.return_value = returned_queues
+    mock_storage_profiles.return_value = returned_storage_profiles
 
     initial_farm_lookup = Mock()
     initial_queue_lookup = Mock()
+    initial_storage_profile_lookup = Mock()
 
     mock_wm.deadline_farm_lookup = initial_farm_lookup
     mock_wm.deadline_queue_lookup = initial_queue_lookup
+    mock_wm.deadline_storage_profile_lookup = initial_storage_profile_lookup
 
     # WHEN
-    utility_functions.set_farm_and_queue_lookups()
+    utility_functions.set_farm_queue_and_storage_profile_lookups()
 
     # THEN
     assert mock_wm.deadline_farm_lookup == returned_farms
     assert mock_wm.deadline_queue_lookup == {"farm-1": returned_queues}
+    assert mock_wm.deadline_storage_profile_lookup == {
+        ("farm-1", "queue-1"): returned_storage_profiles
+    }
 
 
 @patch.object(utility_functions, "deadline_api")
@@ -199,6 +207,7 @@ def test_deadline_logout(
     # GIVEN
     initial_farm_lookup = Mock()
     initial_queue_lookup = Mock()
+    initial_storage_profile_lookup = Mock()
 
     expected_creds = "NEEDS_LOGIN"
     expected_type = "SSO_LOGIN"
@@ -211,6 +220,7 @@ def test_deadline_logout(
 
     mock_wm_type.deadline_farm_lookup = initial_farm_lookup
     mock_wm_type.deadline_queue_lookup = initial_queue_lookup
+    mock_wm_type.deadline_storage_profile_lookup = initial_storage_profile_lookup
 
     # WHEN
     utility_functions.deadline_logout()
@@ -227,10 +237,11 @@ def test_deadline_logout(
 
     assert not hasattr(mock_wm_type, "deadline_farm_lookup")
     assert not hasattr(mock_wm_type, "deadline_queue_lookup")
+    assert not hasattr(mock_wm_type, "deadline_storage_profile_lookup")
 
 
 @patch.object(utility_functions, "active_profile")
-@patch.object(utility_functions, "set_farm_and_queue_lookups")
+@patch.object(utility_functions, "set_farm_queue_and_storage_profile_lookups")
 @patch.object(utility_functions, "get_deadline_api_available")
 @patch.object(utility_functions, "get_credentials_type")
 @patch.object(utility_functions, "get_credentials_status")
@@ -274,7 +285,7 @@ def test_deadline_login_success(
 
 
 @patch.object(utility_functions, "active_profile")
-@patch.object(utility_functions, "set_farm_and_queue_lookups")
+@patch.object(utility_functions, "set_farm_queue_and_storage_profile_lookups")
 @patch.object(utility_functions, "get_deadline_api_available")
 @patch.object(utility_functions, "get_credentials_type")
 @patch.object(utility_functions, "get_credentials_status")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Storage Profiles facilitate path mapping on both the submitting machine and on worker nodes in customer managed fleets. Storage Profiles are locked to a Farm/Queue and a user should be able to configure which storage profile will be used when submitting a job.

### What was the solution? (How)

A change was added to the CLI which includes a `list_storage_profiles_for_queue` call. We leverage that here and allow the user to select the Storage Profile to use during submission.

### What is the impact of this change?

The user can now select Storage Profiles from the main Blender submission UI. The submitter doesn't currently have a Config/Settings UI so at least for now, the dropdown lives in the main submitter panel.

### How was this change tested?

Ran the unit tests and I injected fake data in to the `deadline-cloud` library to return when calling `list_storage_profiles_for_queue`. I verified the UI was populated correctly and that the Storage Profiles were properly filtered by the `osFamily` field. I also ensured that the `storage_profile_id` was passed along to the `deadline-cloud` library when calling submit

### Was this change documented?

No

### Is this a breaking change?

No