### PR TITLE
chore: add windows and mac to github workflows

### DIFF
--- a/.github/workflows/reuse_python_build.yml
+++ b/.github/workflows/reuse_python_build.yml
@@ -9,13 +9,14 @@ on:
 
 jobs:
   Python:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     permissions:
       id-token: write
       contents: read
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11']
+        os: [ubuntu-latest, macOS-latest]
     env:
       PYTHON: ${{ matrix.python-version }}
       CODEARTIFACT_REGION: "us-west-2"
@@ -25,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       if: ${{ !inputs.branch }}
-      
+
     - uses: actions/checkout@v3
       if: ${{ inputs.branch }}
       with:
@@ -36,7 +37,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v2
       with:
@@ -44,6 +45,7 @@ jobs:
         aws-region: us-west-2
 
     - name: Install Hatch
+      shell: bash
       run: |
         CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
         echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We should be building & testing our code on Windows and Mac

### What was the solution? (How)
Modify GitHub workflows so they are building & testing our code on Windows and Mac. Made similar changes done in https://github.com/casillas2/deadline-cloud/commit/afef801cf3cf2392b53ab36115dc7a4756116a5f#diff-a1a47fe3f012a1f3ed362997e7d812693102beecce28d3eebbd7f446795d84d5

### What is the impact of this change?
GitHub workflows are building & testing our code on Windows and Mac

### How was this change tested?
GitHub workflows are building & testing our code on Windows and Mac

### Was this change documented?
No

### Is this a breaking change?
No