### PR TITLE
fix: create module dir if it doesn't exist in installation

### DIFF
--- a/install_builder/deadline-cloud-for-blender.xml
+++ b/install_builder/deadline-cloud-for-blender.xml
@@ -42,8 +42,8 @@
     </initializationActionList>
     <readyToInstallActionList>
         <setInstallerVariable name="blender_installdir" value="${installdir}/Submitters/Blender/python"/>
-        <setInstallerVariable name="blender_addondir" value="${blender_installdir}/python/addons"/>
-        <setInstallerVariable name="blender_moduledir" value="${blender_installdir}/python/modules"/>
+        <setInstallerVariable name="blender_addondir" value="${blender_installdir}/addons"/>
+        <setInstallerVariable name="blender_moduledir" value="${blender_installdir}/modules"/>
         <if>
             <conditionRuleList>
                 <platformTest type="windows"/>
@@ -82,6 +82,14 @@
         </if>
     </readyToInstallActionList>
     <postInstallationActionList>
+        <if>
+            <conditionRuleList>
+                <fileExists path="${blender_moduledir}" negate="1" />
+            </conditionRuleList>
+            <actionList>
+                <createDirectory path="${blender_moduledir}" />
+            </actionList>
+        </if>
         <unzip>
             <destinationDirectory>${blender_moduledir}</destinationDirectory>
             <zipFile>${installdir}/tmp/blender_deps/dependency_bundle/deadline_cloud_for_blender_submitter-deps-${blender_deps_platform}.zip</zipFile>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

we were putting files in `.../python/python/...`, and the module directory was not being created since it wasn't a destination for the distribution list

### What was the solution? (How)

conditionally create the module directory before unzipping to it, and remove the extra python folder

### What is the impact of this change?

submitter installer won't error!

### How was this change tested?
N/A

### Was this change documented?
N/A

### Is this a breaking change?
N/A