### PR TITLE
fix: adaptor changes for windows

### DIFF
--- a/src/deadline/blender_adaptor/BlenderAdaptor/adaptor.py
+++ b/src/deadline/blender_adaptor/BlenderAdaptor/adaptor.py
@@ -174,7 +174,8 @@ class BlenderAdaptor(Adaptor[AdaptorConfiguration]):
         # Completion message is emitted by default_blender_handler.py::start_render
         completed_regexes = [re.compile("BlenderClient: Finished Rendering Frame [0-9]+")]
         progress_regexes = [
-            re.compile(r".*Fra:[\d\s]*.*(\d+)\s*/\s*(\d+)\s*(?:samples)?$"),  # Cycles / Eevee
+            re.compile(r"^Fra:[\d+\s].*Sample\s(\d+)\/(\d+)$"),  # Cycles
+            re.compile(r"^Fra:[\d+\s].*Rendering\s(\d+)\s/\s(\d+)\ssamples$"),  # Eevee
             # Workbench renderer has no progress output
         ]
         error_regexes = [re.compile(".*Exception:.*|.*Error:.*|.*Warning.*")]

--- a/src/deadline/blender_adaptor/BlenderClient/blender_client.py
+++ b/src/deadline/blender_adaptor/BlenderClient/blender_client.py
@@ -11,15 +11,15 @@ import bpy
 # The blender Adaptor adds the `openjd` namespace directory to PYTHONPATH,
 # so that importing just the adaptor_runtime_client should work.
 try:
-    from adaptor_runtime_client import HTTPClientInterface
+    from adaptor_runtime_client import ClientInterface
     from blender_adaptor.BlenderClient.render_handlers import get_render_handler
 except (ImportError, ModuleNotFoundError):
-    from openjd.adaptor_runtime_client import HTTPClientInterface
+    from openjd.adaptor_runtime_client import ClientInterface
 
     from deadline.blender_adaptor.BlenderClient.render_handlers import get_render_handler
 
 
-class BlenderClient(HTTPClientInterface):
+class BlenderClient(ClientInterface):
     def __init__(self, server_path: str) -> None:
         super().__init__(server_path=server_path)
         self.actions.update({"render_engine": self.set_renderer})
@@ -36,7 +36,7 @@ class BlenderClient(HTTPClientInterface):
 
 
 def main():
-    server_path = os.environ.get("BLENDER_ADAPTOR_SERVER")
+    server_path = os.environ.get("BLENDER_ADAPTOR_SERVER_PATH")
     if not server_path:
         raise OSError(
             "BlenderClient cannot connect to the Adaptor because the environment variable "

--- a/test/unit/__init__.py
+++ b/test/unit/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/test/unit/deadline_adaptor_for_blender/__init__.py
+++ b/test/unit/deadline_adaptor_for_blender/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/test/unit/deadline_adaptor_for_blender/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_blender/test_adaptor.py
@@ -1,0 +1,62 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+from unittest.mock import Mock, patch
+import pytest
+
+from deadline.blender_adaptor.BlenderAdaptor import BlenderAdaptor
+
+
+@pytest.fixture()
+def init_data() -> dict:
+    """
+    Pytest Fixture to return an init_data dictionary that passes validation
+
+    Returns:
+        dict: An init_data dictionary
+    """
+    return {
+        "scene_file": "C:\\This\\Is\\A\\Path\\test.blend",
+        "render_engine": "cycles",
+    }
+
+
+class TestBlenderAdaptor:
+    handle_progess_params = [
+        pytest.param(
+            0,
+            "Fra:2 Mem:48.09M (Peak 48.09M) | Time:00:03.01 | Remaining:00:13.01 | Mem:38.37M, Peak:38.37M | Scene, ViewLayer | Sample 768/4096",
+            18,
+            id="TestCyclesProgressReporting",
+        ),
+        pytest.param(
+            1,
+            "Fra:1 Mem:43.82M (Peak 44.36M) | Time:00:00.28 | Rendering 17 / 64 samples",
+            26,
+            id="TestEeveeProgressReporting",
+        ),
+    ]
+
+    @pytest.mark.parametrize("regex_index, stdout, expected_progress", handle_progess_params)
+    @patch("deadline.blender_adaptor.BlenderAdaptor.BlenderAdaptor.update_status")
+    def test_handle_progress(
+        self,
+        mock_update_status: Mock,
+        regex_index: int,
+        stdout: str,
+        expected_progress: float,
+        init_data: dict,
+    ) -> None:
+        """Tests that the _handle_progress method updates the progress correctly"""
+        # GIVEN
+        adaptor = BlenderAdaptor(init_data)
+        regex_callbacks = adaptor._get_regex_callbacks()
+        progress_regex = regex_callbacks[1].regex_list[regex_index]
+
+        # WHEN
+        match = progress_regex.search(stdout)
+        assert match is not None
+        adaptor._handle_progress(match)
+
+        # THEN
+        mock_update_status.assert_called_once_with(progress=expected_progress)

--- a/test/unit/deadline_submitter_for_blender/__init__.py
+++ b/test/unit/deadline_submitter_for_blender/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/test/unit/deadline_submitter_for_blender/test_submitter.py
+++ b/test/unit/deadline_submitter_for_blender/test_submitter.py
@@ -11,7 +11,7 @@ from deadline.client.exceptions import DeadlineOperationError
 
 # Ensure the submitter can be imported.
 SUBMITTER_DIR = (
-    Path(__file__).parent.parent
+    Path(__file__).parent.parent.parent.parent
     / "src"
     / "deadline"
     / "blender_submitter"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The blender adaptor would not run on windows as it was using the HTTPClientInterface only for Linux.
### What was the solution? (How)
- Changed to use ClientInterface
- Fixed a env variable that was missing _PATH and causing the adaptor to crash
- Fixed the progress handling regex to properly grab the groups from Blender output
  - Added tests for Eevee and Cycles progress reporting and reorganized the tests folder 
### What is the impact of this change?
Blender adaptor can work on Windows
### How was this change tested?
Ran the adaptor locally and verified the progress reporting and the output render
### Was this change documented?
No
### Is this a breaking change?
No