### PR TITLE
feat!: updated openjd-runtime to 0.5.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 
 dependencies = [
     "deadline == 0.38.*", 
-    "openjd-adaptor-runtime == 0.4.*",
+    "openjd-adaptor-runtime == 0.5.*",
 ]
 
 [project.scripts]

--- a/src/deadline/blender_adaptor/BlenderAdaptor/adaptor.py
+++ b/src/deadline/blender_adaptor/BlenderAdaptor/adaptor.py
@@ -10,7 +10,7 @@ import threading
 import time
 from typing import Callable
 
-from openjd.adaptor_runtime.adaptors import Adaptor, AdaptorDataValidators
+from openjd.adaptor_runtime.adaptors import Adaptor, AdaptorDataValidators, SemanticVersion
 from openjd.adaptor_runtime.adaptors.configuration import AdaptorConfiguration
 from openjd.adaptor_runtime.app_handlers import RegexCallback, RegexHandler
 from openjd.adaptor_runtime.application_ipc import ActionsQueue, AdaptorServer
@@ -72,6 +72,10 @@ class BlenderAdaptor(Adaptor[AdaptorConfiguration]):
     # If a thread raises an exception we will update this to raise in the main thread
     _exc_info: Exception | None = None
     _performing_cleanup = False
+
+    @property
+    def integration_data_interface_version(self) -> SemanticVersion:
+        return SemanticVersion(major=0, minor=1)
 
     @staticmethod
     def _get_timer(timeout: int | float) -> Callable[[], bool]:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There's a newer version of the openjd-adaptor-runtime

### What was the solution? (How)

update to it! To do this, we must specify a semantic version of the init/run data interfaces

### What is the impact of this change?

We're on latest and have a versioned API for the adaptor!

### How was this change tested?

```
hatch fun fmt
hatch run lint
hatch build
hatch run test
```

I then also manually ran the adaptor locally with the init/run data

### Was this change documented?

N/A

### Is this a breaking change?

Yes, the default action of the adaptor is no longer run