### PR TITLE
fix(hidden): make frame progress regex more accurate

### DIFF
--- a/src/deadline/blender_adaptor/BlenderAdaptor/adaptor.py
+++ b/src/deadline/blender_adaptor/BlenderAdaptor/adaptor.py
@@ -178,8 +178,8 @@ class BlenderAdaptor(Adaptor[AdaptorConfiguration]):
         # Completion message is emitted by default_blender_handler.py::start_render
         completed_regexes = [re.compile("BlenderClient: Finished Rendering Frame [0-9]+")]
         progress_regexes = [
-            re.compile(r"^Fra:[\d+\s].*Sample\s(\d+)\/(\d+)$"),  # Cycles
-            re.compile(r"^Fra:[\d+\s].*Rendering\s(\d+)\s/\s(\d+)\ssamples$"),  # Eevee
+            re.compile(r"^Fra:.*Sample\s(\d+)\/(\d+)$"),  # Cycles
+            re.compile(r"^Fra:.*Rendering\s(\d+)\s/\s(\d+)\ssamples$"),  # Eevee
             # Workbench renderer has no progress output
         ]
         error_regexes = [re.compile(".*Exception:.*|.*Error:.*|.*Warning.*")]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

frame progress message regex was inaccurate with the character class `Fra:[\d+\s]`. This means it accepted a number, whitespace, OR a plus sign. What was originally intended was at least 1 number (perhaps more) followed by whitespace, ie. `Fra:1 ...`.

### What was the solution? (How)

I'm simplifying the regex by no longer caring about the frame number since we weren't doing anything with it. We're already locking pretty on the start and end of the regex with specific messages, so it's a pretty safe change.

### What is the impact of this change?

should be next to no impact, it's just more correct.

### How was this change tested?

We have tests for these regexes using known blender output from eevee and cycles that still pass

```
hatch run fmt
hatch build
hatch run lint
hatch run test
```

### Was this change documented?

N/A

### Is this a breaking change?

Nope