### PR TITLE
feat: Adds telemetry events to submitter and adaptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ You can download this package from:
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
 
+## Telemetry
+
+This library collects telemetry data by default. Telemetry events contain non-personally-identifiable information that helps us understand how users interact with our software so we know what features our customers use, and/or what existing pain points are.
+
+You can opt out of telemetry data collection by either:
+
+1. Setting the environment variable: `DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true`
+2. Setting the config file: `deadline config set telemetry.opt_out true`
+
+Note that setting the environment variable supersedes the config file setting.
+
 ## License
 
 This project is licensed under the Apache-2.0 License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 # Blender 3.1+ uses Python version 3.10+ (https://vfxplatform.com/ 2023)
 
 dependencies = [
-    "deadline == 0.40.*", 
+    "deadline == 0.42.*", 
     "openjd-adaptor-runtime == 0.5.*",
 ]
 

--- a/src/deadline/blender_adaptor/BlenderClient/blender_client.py
+++ b/src/deadline/blender_adaptor/BlenderClient/blender_client.py
@@ -22,6 +22,7 @@ except (ImportError, ModuleNotFoundError):
 class BlenderClient(ClientInterface):
     def __init__(self, server_path: str) -> None:
         super().__init__(server_path=server_path)
+        print(f"BlenderClient: Blender Version {bpy.app.version_string}")
         self.actions.update({"render_engine": self.set_renderer})
 
     def set_renderer(self, renderer: dict):

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import bpy
+from deadline.client import api
 from deadline.client.job_bundle._yaml import deadline_yaml_dump
 from deadline.client.job_bundle.submission import AssetReferences
 from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import SubmitJobToDeadlineDialog
@@ -15,6 +16,8 @@ from deadline_cloud_blender_submitter import template_filling as tf
 from deadline_cloud_blender_submitter._version import version_tuple as adaptor_version_tuple
 
 from PySide2.QtCore import Qt
+
+from ._version import version
 
 
 def create_deadline_dialog(parent=None) -> SubmitJobToDeadlineDialog:
@@ -30,6 +33,14 @@ def create_deadline_dialog(parent=None) -> SubmitJobToDeadlineDialog:
         raise RuntimeError(
             "The Blender scene is not saved to disk. Please save it before opening the submitter dialog."
         )
+
+    # Initialize telemetry client, opt-out is respected
+    api.get_deadline_cloud_library_telemetry_client().update_common_details(
+        {
+            "deadline-cloud-for-blender-submitter-version": version,
+            "blender-version": bpy.app.version_string,
+        }
+    )
 
     # Initialize render settings with default values.
     settings = tf.BlenderSubmitterUISettings()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We can't currently tell if anyone is using blender submitters / adaptors

### What was the solution? (How)
Uses changes from https://github.com/casillas2/deadline-cloud/pull/205 to capture more package information when sending telemetry data, and changes from https://github.com/casillas2/deadline-cloud/pull/212 to opt out of telemetry from an environment variable.

### What is the impact of this change?
We can better tell how customers use our software and if they use Blender

### How was this change tested?
 - thanks @epmog for running the manual tests!
 - ran the integrated submitter, and submitted a job, verifying it wrote telemetry
 - ran the adaptor locally, confirming it wrote telemetry

### Was this change documented?
Updated README with opt out instructions

### Is this a breaking change?
No