### PR TITLE
chore: update deadline-cloud dependency 0.44.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ requires-python = ">=3.10"
 # Blender 3.1+ uses Python version 3.10+ (https://vfxplatform.com/ 2023)
 
 dependencies = [
-    "deadline == 0.42.*", 
-    "openjd-adaptor-runtime == 0.5.*",
+    "deadline == 0.44.*", 
+    "openjd-adaptor-runtime == 0.6.*",
 ]
 
 [project.scripts]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Out of date dependency of the deadline-cloud client lib
### What was the solution? (How)
update dependency
### What is the impact of this change?
qtpy changes in deadline-cloud will be available in submitters
### How was this change tested?
`hatch build` and `hatch run test`

### Was this change documented?

### Is this a breaking change?
no