### PR TITLE
fix: include the adaptor deps in the package

### DIFF
--- a/scripts/create_adaptor_packaging_artifact.sh
+++ b/scripts/create_adaptor_packaging_artifact.sh
@@ -100,8 +100,8 @@ if [ $SOURCE = 1 ]; then
         --target $PACKAGEDIR \
         --platform $PYPI_PLATFORM \
         --python-version $PYTHON_VERSION \
+        --only-binary=:all: \
         --ignore-installed \
-        --no-deps \
         $ADAPTOR_INSTALLABLE $CLIENT_INSTALLABLE
 
 else


### PR DESCRIPTION
We also need the deps for the client package when packaging the adaptor