### PR TITLE
feat: update to qtpy (pyside6)

### DIFF
--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1
+        uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR

--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -63,6 +63,7 @@ jobs:
           # Run semantic-release to generate new changelog
           pip install --upgrade hatch
           hatch env create release
+          hatch run release:deps
           NEXT_SEMVER=$(hatch run release:bump $BUMP_ARGS)
 
           # Grab the new version's changelog and prepend it to the original changelog contents

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,9 +4,29 @@
 
 #### Install for Production
 
-1. Install `deadline` and `PySide2` and `blender-qt-stylesheet` packages to `~/DeadlineCloudSubmitter/Submitters/Blender/python/modules`.
-  - For Windows: `pip install deadline PySide2 blender-qt-stylesheet -t %USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python\modules`
-  - For Unix: `pip install deadline PySide2 blender-qt-stylesheet -t ~/DeadlineCloudSubmitter/Submitters/Blender/python/modules`
+##### Submitter Installer
+
+1. Run the submitter installer and ensure you select Blender
+
+2. Add a script directory in Blender by "Edit" > "Preferences" > "File Paths" > "Script Directories"
+  * Windows: `%USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python`
+  * Linux: `~/DeadlineCloudSubmitter/Submitters/Blender/python`
+
+  Or run this script from Blender
+
+  ```
+  import bpy
+  import os
+  bpy.ops.preferences.script_directory_add(directory=os.path.expanduser(os.path.normpath('~/DeadlineCloudSubmitter/Submitters/Blender/python')))
+  ```
+
+3. Restart Blender - changes to the script directory won't take effect until Blender has been restarted.
+
+##### Manual Installation
+
+1. Install `deadline[gui]` and `blender-qt-stylesheet` packages to `~/DeadlineCloudSubmitter/Submitters/Blender/python/modules`.
+  - For Windows: `pip install deadline[gui] blender-qt-stylesheet -t %USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python\modules`
+  - For Unix: `pip install deadline[gui] blender-qt-stylesheet -t ~/DeadlineCloudSubmitter/Submitters/Blender/python/modules`
 
   Currently, Python 3.10 is the Python version used by the latest Blender release.
 
@@ -14,79 +34,30 @@
 
   Copy the contents of `src/deadline/blender_submitter/addons` to `~/DeadlineCloudSubmitter/Submitters/Blender/python/addons`
 
-3. Add path to Blender script directory
+3. Add a script directory in Blender by "Edit" > "Preferences" > "File Paths" > "Script Directories"
+  * Windows: `%USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python`
+  * Linux: `~/DeadlineCloudSubmitter/Submitters/Blender/python`
 
-  The path to add is `%USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python` or `~/DeadlineCloudSubmitter/Submitters/Blender/python`
-  depending on your OS.
-
-  This can be done manually in Blender under "Edit" > "Preferences" > "File Paths" > "Script Directories".
-
-  Alternatively, you can run this `bpy` command:
+  Or run this script from Blender
 
   ```
+  import bpy
   import os
   bpy.ops.preferences.script_directory_add(directory=os.path.expanduser(os.path.normpath('~/DeadlineCloudSubmitter/Submitters/Blender/python')))
   ```
 
-  Changes to the script directory won't take effect until Blender has been restarted.
-
-
-#### Install for Development
-
-1. Install required packages. Same as step 1 for Production.
-
-2. Install addon for development
-
-You can run the addon directly from this repository by configuring `src/deadline/blender_submitter` 
-of this repository as a script directory in Blender.
-
-You can find this setting under "Edit > Preferences... > File Paths > Script Directories".
-
-Make sure to add the `blender_submitter` directory, not the addons folder!
-
-See: https://docs.blender.org/manual/en/latest/editors/preferences/addons.html#installing-add-ons
-
-Note that the addons directory from the Production installation will conflict with this. It will need to be removed if it exists.
-
-3. Add path to Blender script directory
-
-  The path to add is `%USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python` or `~/DeadlineCloudSubmitter/Submitters/Blender/python`
-  depending on your OS.
-
-  This can be done manually in Blender under "Edit" > "Preferences" > "File Paths" > "Script Directories".
-
-  Alternatively, you can run this `bpy` command:
-
-  ```
-  import os
-  bpy.ops.preferences.script_directory_add(directory=os.path.expanduser(os.path.normpath('~/DeadlineCloudSubmitter/Submitters/Blender/python')))
-  ```
-
-  Changes to the script directory won't take effect until Blender has been restarted.
+4. Restart Blender - changes to the script directory won't take effect until Blender has been restarted.
 
 #### Usage
 
-This repository comes with two addons: `deadline_cloud_blender_submitter` and `addonreloader`.
+This repository comes with the addon: `deadline_cloud_blender_submitter`
 
 You can enable this in "Edit" menu > "Preferences" menu item > "addons" tab.
 
-* The `addonreloader` is for development purposes only. It is not intended to
-  be shipped with the installation. It allows for hot-reloading of the submitter
-  addon during development.
-
 ## Deadline Cloud for Blender Adaptor
 
-The deadline-cloud-for-blender Adaptor only supports Linux.
+The deadline-cloud-for-blender Adaptor supports Linux and macOS.
 
 ### Installation
 
 Build a wheel with `hatch build` and install it as a normal Python package.
-
-## Development notes
-
-### Blender addon version
-
-The Blender addon version is set during the build process via a custom hatch hook.
-For new versions, this will require a separate commit after the fact to be tracked properly.
-
-This should instead be done as a pre-build step instead.

--- a/hatch.toml
+++ b/hatch.toml
@@ -8,7 +8,7 @@ sync = "pip install -r requirements-testing.txt"
 test = "pytest --cov-config pyproject.toml {args:test}"
 typing = "mypy {args:src test}"
 style = [
-  "ruff {args:.}",
+  "ruff check {args:.}",
   "black --check --diff {args:.}",
 ]
 fmt = [
@@ -26,6 +26,7 @@ python = ["3.10", "3.11", "3.12"]
 [envs.default.env-vars]
 PIP_INDEX_URL="https://aws:{env:CODEARTIFACT_AUTH_TOKEN}@{env:CODEARTIFACT_DOMAIN}-{env:CODEARTIFACT_ACCOUNT_ID}.d.codeartifact.{env:CODEARTIFACT_REGION}.amazonaws.com/pypi/{env:CODEARTIFACT_REPOSITORY}/simple/"
 SKIP_BOOTSTRAP_TEST_RESOURCES="True"
+DEADLINE_ENABLE_DEVELOPER_OPTIONS="True"
 
 [envs.codebuild.scripts]
 build = "hatch build"
@@ -42,10 +43,8 @@ test = "pytest --no-cov {args:test/*/e2e}"
 
 [envs.release]
 detached = true
-dependencies = [
-  "python-semantic-release == 8.7.*"
-]
 
 [envs.release.scripts]
+deps = "pip install -r requirements-release.txt"
 bump = "semantic-release -v --strict version --no-push --no-commit --no-tag --skip-build {args}"
 version = "semantic-release -v --strict version --print {args}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,12 @@ build-backend = "hatchling.build"
 name = "deadline-cloud-for-blender"
 dynamic = ["version"]
 readme = "README.md"
-license = ""
+license = "Apache-2.0"
 requires-python = ">=3.10"
 # Blender 3.1+ uses Python version 3.10+ (https://vfxplatform.com/ 2023)
 
 dependencies = [
-    "deadline == 0.44.*", 
+    "deadline == 0.45.*", 
     "openjd-adaptor-runtime == 0.6.*",
 ]
 
@@ -65,17 +65,19 @@ namespace_packages = true
 explicit_package_bases = true
 mypy_path = "src"
 
-# [[tool.mypy.overrides]]
-# module = ["bpy.*","PySide2.*"]
+[[tool.mypy.overrides]]
+module = ["bpy.*", "qtpy.*"]
 
 # --- RUFF / BLACK ---
 
 [tool.ruff]
-ignore = ["E501"]
 line-length = 100
 
-[tool.ruff.isort]
-known-first-party = ["deadline_worker_agent"]
+[tool.ruff.lint]
+ignore = ["E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["deadline"]
 
 [tool.black]
 line-length = 100

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,3 +1,1 @@
-# HACK: This file solely exists for dependabot checks. The actual dependencies are in `hatch.toml` in the `release` environment.
-# If dependabot opens a PR that modifies this file, please make sure to update the coresponding dependency in `hatch.toml` as well.
-python-semantic-release == 8.7.*
+python-semantic-release == 9.3.*

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,4 +1,4 @@
-black == 23.*
+black == 24.*
 coverage[toml] == 7.*
 deadline-cloud-test-fixtures == 0.5.*
 moto[s3,sts] == 5.*
@@ -6,6 +6,6 @@ mypy == 1.*
 pytest == 8.*
 pytest-cov == 4.*
 pytest-xdist == 3.*
-ruff == 0.1.*
+ruff == 0.3.*
 twine == 5.*
 types-pyyaml == 6.*

--- a/src/deadline/blender_adaptor/BlenderAdaptor/adaptor.py
+++ b/src/deadline/blender_adaptor/BlenderAdaptor/adaptor.py
@@ -287,9 +287,9 @@ class BlenderAdaptor(Adaptor[AdaptorConfiguration]):
         deadline_namespace_dir = os.path.dirname(os.path.dirname(blender_adaptor.__file__))
         python_path_addition = f"{openjd_namespace_dir}{os.pathsep}{deadline_namespace_dir}"
         if "PYTHONPATH" in os.environ:
-            os.environ[
-                "PYTHONPATH"
-            ] = f"{os.environ['PYTHONPATH']}{os.pathsep}{python_path_addition}"
+            os.environ["PYTHONPATH"] = (
+                f"{os.environ['PYTHONPATH']}{os.pathsep}{python_path_addition}"
+            )
         else:
             os.environ["PYTHONPATH"] = python_path_addition
 

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py
@@ -4,21 +4,25 @@
 Registration of Deadline Cloud Submitter Addon + activate logger
 """
 import logging
+from pathlib import Path
+import subprocess
+import sys
 
 import bpy  # noqa
 from bpy.types import Operator
+
 from deadline_cloud_blender_submitter import logutil
 
 # NOTE: Variables are NOT allowed to be in bl_info since
-#       blender parses the __init__.py for this variable
+#       blender parses this __init__.py source for this variable
 #       and is not aware of any additional context.
 #       ref: https://developer.blender.org/docs/handbook/addons/addon_meta_info/
 bl_info = {
     "name": "Deadline Cloud for Blender",
     "description": "Submit to AWS Deadline Cloud",
     "author": "AWS",
-    "version": (0, 1, 1),
-    "blender": (3, 5, 0),
+    "version": (0, 3, 0),
+    "blender": (3, 6, 0),
     "category": "Render",
 }
 
@@ -34,7 +38,7 @@ class DEADLINE_CLOUD_OT_open_dialog(Operator):
     """Open deadline cloud dialog."""
 
     bl_idname = "ops.open_deadline_cloud_dialog"
-    bl_label = "Deadline Cloud pop-out"
+    bl_label = "AWS Deadline Cloud"
     bl_options = {"REGISTER"}
 
     # Execution after the window was closed with ok button.
@@ -43,18 +47,17 @@ class DEADLINE_CLOUD_OT_open_dialog(Operator):
 
         See the bpy Operator docs: https://docs.blender.org/api/current/bpy.types.Operator.html
         """
-        try:
-            from deadline_cloud_blender_submitter.open_deadline_cloud_dialog import (
-                create_deadline_dialog,
-            )
-            from PySide2 import QtCore, QtWidgets
-        except ImportError as e:
-            self.report({"ERROR"}, f"The submitter installation is incomplete. {e} .")
-            return {"CANCELLED"}
+        if not self.has_gui_deps():
+            self.install_gui()
+
+        from qtpy import QtCore, QtWidgets
+        from deadline_cloud_blender_submitter.open_deadline_cloud_dialog import (
+            create_deadline_dialog,
+        )
 
         self.app = QtWidgets.QApplication.instance()
         if not self.app:
-            self.app = QtWidgets.QApplication(["Deadline Cloud Submitter"])
+            self.app = QtWidgets.QApplication(sys.argv)
 
         try:
             # optionally use the blender_stylesheet if it exists
@@ -77,7 +80,7 @@ class DEADLINE_CLOUD_OT_open_dialog(Operator):
         # Option 0: Default behaviour: window will always stay on top of other windows.
         # self.widget.setWindowFlags(self.widget.windowFlags() | QtCore.Qt.WindowStaysOnTopHint)
         # Option 1: go into background when focus is lost, keep a taskbar entry.
-        self.widget.setWindowFlags(self.widget.windowFlags() & ~QtCore.Qt.WindowStaysOnTopHint)
+        self.widget.setWindowFlags(self.widget.windowFlags() & ~QtCore.Qt.WindowStaysOnTopHint)  # type: ignore
         # Option 2: tool window.
         # Setting the window to be a tool window has the desired effect of making it stay on top
         # of the Blender window only. But the disadvantage that, without a presence in the menu bar,
@@ -89,6 +92,58 @@ class DEADLINE_CLOUD_OT_open_dialog(Operator):
         self.widget.show()
         self.report({"INFO"}, "OK!")
         return {"FINISHED"}
+
+    def draw(self, context):
+        layout = self.layout
+        col = layout.column()
+        col.label(text="Press 'OK' to install GUI dependencies. Please wait...")
+
+    def invoke(self, context, event):
+        if self.has_gui_deps():
+            # don't prompt user if gui deps exist
+            return self.execute(context)
+        wm = context.window_manager
+        return wm.invoke_props_dialog(self)
+
+    def has_gui_deps(self):
+        try:
+            import qtpy  # noqa
+            from deadline_cloud_blender_submitter.open_deadline_cloud_dialog import (  # noqa
+                create_deadline_dialog,
+            )
+        except Exception as e:
+            # qtpy throws a QtBindingsNotFoundError when running
+            # from qtpy import QtBindingsNotFoundError
+            if not (type(e).__name__ == "QtBindingsNotFoundError" or isinstance(e, ImportError)):
+                raise
+            return False
+
+        return True
+
+    def install_gui(self):
+        import deadline.client
+
+        deadline.client.version
+        pip_install_command = [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            f"deadline[gui]=={deadline.client.version}",
+        ]
+        # module_directory assumes relative install location of:
+        #   * [installdir]/Submitters/Blender/python/addons/deadline_cloud_blender_submitter/__init__.py
+        #   * [installdir]/Submitters/Blender/python/modules/
+        module_directory = Path(__file__).parent.parent.parent / "modules"
+        if module_directory.exists():
+            _logger.info(f"Missing GUI libraries, installing deadline[gui] to {module_directory}")
+            pip_install_command.extend(["--target", str(module_directory)])
+        else:
+            _logger.info(
+                "Missing GUI libraries with non-standard set-up, installing deadline[gui] into Blender's python"
+            )
+
+        subprocess.run(pip_install_command)
 
 
 def deadline_cloud_dialog_topbar_btn(self, context):

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
@@ -15,7 +15,7 @@ from deadline_cloud_blender_submitter import scene_settings_widget as ssw
 from deadline_cloud_blender_submitter import template_filling as tf
 from deadline_cloud_blender_submitter._version import version_tuple as adaptor_version_tuple
 
-from PySide2.QtCore import Qt
+from qtpy.QtCore import Qt  # type: ignore
 
 from ._version import version
 

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/sanity_checks.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/sanity_checks.py
@@ -6,7 +6,7 @@ Sanity checks done on submit or export bundle
 from typing import Union
 
 import bpy
-from PySide2 import QtWidgets
+from qtpy import QtWidgets
 
 from deadline_cloud_blender_submitter import blender_utils
 from deadline_cloud_blender_submitter import scene_settings_widget as ssw

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/scene_settings_widget.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/scene_settings_widget.py
@@ -10,9 +10,9 @@ import os
 from deadline.client.ui import block_signals
 from deadline_cloud_blender_submitter import blender_utils
 from deadline_cloud_blender_submitter.template_filling import BlenderSubmitterUISettings
-from PySide2.QtCore import QRegularExpression, QSize, Qt
-from PySide2.QtGui import QRegularExpressionValidator
-from PySide2.QtWidgets import (
+from qtpy.QtCore import QRegularExpression, QSize, Qt  # type: ignore
+from qtpy.QtGui import QRegularExpressionValidator  # type: ignore
+from qtpy.QtWidgets import (  # type: ignore
     QCheckBox,
     QComboBox,
     QFileDialog,
@@ -247,7 +247,6 @@ class FileSearchLineEdit(QWidget):
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setMargin(0)
         layout.addWidget(self.text_line)
         layout.addWidget(self.button)
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Update to latest deadline that uses qtpy. This allows us to use pyside6

### What was the solution? (How)

Do the update! I also added the ability to check if we have the GUI dependencies and install them if we don't

### What is the impact of this change?

Users can use Blender without pip installing themselves (if they so choose)

### How was this change tested?

```
hatch run fmt
hatch build
hatch run lint
hatch run test
```

I installed the submitter normally, which didn't include pyside6. A pop-up came up and prompted me to press Ok and wait for the install. Then the submitter showed up!

Subsequent runs did not have a pop-up!

### Was this change documented?

N/A

### Is this a breaking change?

N/A