### PR TITLE
fix: include the adaptor deps in the package

### DIFF
--- a/scripts/create_adaptor_packaging_artifact.sh
+++ b/scripts/create_adaptor_packaging_artifact.sh
@@ -115,7 +115,7 @@ else
         --platform $PYPI_PLATFORM \
         --python-version $PYTHON_VERSION \
         --ignore-installed \
-        --only-binary=:all: \
+        --no-deps \
         $RUNTIME_INSTALLABLE
 
     # Install these two at the same time otherwise they overwrite eachother
@@ -124,7 +124,7 @@ else
         --platform $PYPI_PLATFORM \
         --python-version $PYTHON_VERSION \
         --ignore-installed \
-        --no-deps \
+        --only-binary=:all: \
         $ADAPTOR_INSTALLABLE $CLIENT_INSTALLABLE
 fi
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to include deadline-cloud deps with the adaptor package

### What was the solution? (How)
remove --no-deps

### How was this change tested?
built the package and confirmed it includes deadline-cloud deps

### Was this change documented?
No

### Is this a breaking change?
No