### PR TITLE
fix: Prevents the submission dialog from locking Blender on Linux

### DIFF
--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py
@@ -89,7 +89,7 @@ class DEADLINE_CLOUD_OT_open_dialog(Operator):
         # self.widget.setWindowFlags(self.widget.windowFlags() | QtCore.Qt.Tool)
         _logger.debug(flag_info)
 
-        self.widget.show()
+        self.widget.exec_()
         self.report({"INFO"}, "OK!")
         return {"FINISHED"}
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Linux integrated submitter would fail to load and lock up Blender.

### What was the solution? (How)
Switch to use the modal `QDialog::exec()` function to display the window instead of `QWidget::show()`

### What is the impact of this change?
Can submit Jobs from Blender without locking up the process.

### How was this change tested?
Tested on Ubuntu 22 instance with Blender and confirmed the change successfully submits Jobs.

### Was this change documented?
No.

### Is this a breaking change?
No.