### PR TITLE
docs: clean-up manual installation documentation

### DIFF
--- a/.github/workflows/reuse_python_build.yml
+++ b/.github/workflows/reuse_python_build.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, windows-latest, macOS-latest]
     env:
       PYTHON: ${{ matrix.python-version }}
@@ -37,7 +37,7 @@ jobs:
     - name: Install Hatch
       shell: bash
       run: |
-        pip install --upgrade hatch
+        pip install --upgrade -r requirements-development.txt
 
     - name: Run Linting
       run: hatch -v run lint

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -61,29 +61,34 @@ hatch run all:test
 
 ##### Manual Installation
 
-1. Install `deadline[gui]` and `blender-qt-stylesheet` packages to `~/DeadlineCloudSubmitter/Submitters/Blender/python/modules`.
-  - For Windows: `pip install deadline[gui] blender-qt-stylesheet -t %USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python\modules`
-  - For Unix: `pip install deadline[gui] blender-qt-stylesheet -t ~/DeadlineCloudSubmitter/Submitters/Blender/python/modules`
+These instructions make the following assumptions:
+  * You have a [git clone of this repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository#cloning-a-repository)
+  * You have `pip` available in your terminal
 
-  Currently, Python 3.10 is the Python version used by the latest Blender release.
+1. Set-up development environment:
+    - `pip install --upgrade -r requirements-development.txt`
+1. Install addon in Blender
+    - run `hatch build` in your local git repository
+    - `cp -r src/deadline/blender_submitter/addons/ ~/DeadlineCloudSubmitter/Submitters/Blender/python/addons`
+1. Install addon dependencies:
+    - For Blender 3.6-4.0 (uses python 3.10):
+        - Windows: `pip install --python-version 3.10 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t %USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python\modules`
+        - Linux/macOS: `pip install --python-version 3.10 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t ~/DeadlineCloudSubmitter/Submitters/Blender/python/modules`
+    - For Blender 4.1 (uses python 3.11):
+        - Windows: `pip install --python-version 3.11 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t %USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python\modules`
+        - Linux/macOS: `pip install --python-version 3.11 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t ~/DeadlineCloudSubmitter/Submitters/Blender/python/modules`
+1. Add a script directory in Blender by "Edit" > "Preferences" > "File Paths" > "Script Directories"
+    * Windows: `%USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python`
+    * Linux/macOS: `~/DeadlineCloudSubmitter/Submitters/Blender/python`
 
-2. Install addon in Blender
+    Or run this script from Blender
 
-  Copy the contents of `src/deadline/blender_submitter/addons` to `~/DeadlineCloudSubmitter/Submitters/Blender/python/addons`
-
-3. Add a script directory in Blender by "Edit" > "Preferences" > "File Paths" > "Script Directories"
-  * Windows: `%USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python`
-  * Linux: `~/DeadlineCloudSubmitter/Submitters/Blender/python`
-
-  Or run this script from Blender
-
-  ```
-  import bpy
-  import os
-  bpy.ops.preferences.script_directory_add(directory=os.path.expanduser(os.path.normpath('~/DeadlineCloudSubmitter/Submitters/Blender/python')))
-  ```
-
-4. Restart Blender - changes to the script directory won't take effect until Blender has been restarted.
+    ```
+    import bpy
+    from os.path import expanduser, normpath
+    bpy.ops.preferences.script_directory_add(directory=expanduser(normpath('~/DeadlineCloudSubmitter/Submitters/Blender/python')))
+    ```
+1. Restart Blender - changes to the script directory won't take effect until Blender has been restarted.
 
 #### Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "deadline-cloud-for-blender"
 dynamic = ["version"]
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 description = "AWS Deadline Cloud for Blender"
 authors = [
   {name = "Amazon Web Services"},
@@ -17,6 +17,7 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -27,8 +28,8 @@ classifiers = [
   "Intended Audience :: Developers",
   "Intended Audience :: End Users/Desktop",
 ]
-# Blender 3.1+ uses Python version 3.10+ (https://vfxplatform.com/ 2023)
-
+# Blender 3.1-4.0 uses Python version 3.10
+# Blender 4.1+ uses Python version 3.11
 
 dependencies = [
     "deadline == 0.47.*", 

--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -1,0 +1,2 @@
+hatch == 1.9.*
+hatch-vcs == 0.4.*


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

By default, a user couldn't successfully run the manual installation instructions as there's a lot of assumptions being made about the current set-up (ie. someone developing the integration)

In the manual installation instructions:
1. We weren't specifying python version in the pip install, causing issues if the user's pip didn't match blender's python version.
2. We weren't telling users of the requirements to be able to run `hatch build` to generate the _version.py file.

### What was the solution? (How)

The real solution in the future will be to make the installation script outside of install builder, and make the package properly pip installable. Until then I've updated the instructions to get it to work for curious parties.

### What is the impact of this change?

You can run through the installation instructions and get it working!

### How was this change tested?

N/A

### Was this change documented?

Yes

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*