### PR TITLE
fix: override frame range checkbox

### DIFF
--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/scene_settings_widget.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/scene_settings_widget.py
@@ -50,7 +50,6 @@ class SceneSettingsWidget(QWidget):
 
     def _build_ui(self):
         """Set up the UI."""
-
         layout = QGridLayout(self)
 
         qt_pos_index = 0
@@ -228,7 +227,7 @@ class SceneSettingsWidget(QWidget):
 
     def activate_frame_override_changed(self, state):
         """Set the activated/deactivated status of the Frame override text box."""
-        self.frame_override_txt.setEnabled(state == Qt.Checked)
+        self.frame_override_txt.setEnabled(Qt.CheckState(state) == Qt.Checked)
 
 
 class FileSearchLineEdit(QWidget):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The override frame range checkbox was not toggling the frame override field between editable and not.

This seems to be an issue only when using Pyside6. Pyside6 introduced [changes to how enums are handled](https://doc.qt.io/qtforpython-6/considerations.html#the-new-python-enums) which seems to be the culprit.
### What was the solution? (How)
Convert the int received from the `stateChanged` signal on the checkbox to a `CheckState` enum to compare against `Qt.Checked`.
### What is the impact of this change?
Toggle works again when using Pyside6 and also Pyside2
### How was this change tested?
- Tested **without** the change using Pyside6 and verified the checkbox didn't work
- Tested **with** the change using Pyside6 I verified that the checkbox now correctly made the field editable and not
- Tested **with** the change using Pyside2 and verified that the checkbox still made the field editable and not
### Was this change documented?
No
### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*