### PR TITLE
fix!: exclude view layers if not used for rendering

### DIFF
--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/blender_utils.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/blender_utils.py
@@ -13,14 +13,15 @@ import bpy
 _logger = logging.getLogger(__name__)
 
 
-def get_view_layers(saved_scene_name) -> list[str]:
-    """Get the view layers associated with a scene.
+def get_renderable_view_layers(saved_scene_name) -> list[str]:
+    """Get the view layers associated with a scene that are selected to use
+    during rendering.
 
     Args:
         saved_scene_name: The name of the scene.
     """
     scene_name = bpy.data.scenes[saved_scene_name].name
-    layers = [layer.name for layer in bpy.data.scenes[scene_name].view_layers]
+    layers = [layer.name for layer in bpy.data.scenes[scene_name].view_layers if layer.use]
     return layers
 
 

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
@@ -148,7 +148,7 @@ def _create_bundle(
     # Add selected layers to the list of layers to render.
     layers: list[tf.Layer] = []
     if settings.view_layer_selection == ssw.COMBO_DEFAULT_ALL_RENDERABLE_LAYERS:
-        for layer in bu.get_view_layers(settings.scene_name):
+        for layer in bu.get_renderable_view_layers(settings.scene_name):
             layers.append(tf.Layer(layer, common_layer_settings))
     else:
         layers.append(tf.Layer(settings.view_layer_selection, common_layer_settings))

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/sanity_checks.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/sanity_checks.py
@@ -36,7 +36,7 @@ def run_sanity_checks(settings):
         )
 
     renderable_cameras = blender_utils.get_renderable_cameras(settings.scene_name)
-    renderable_layers = blender_utils.get_view_layers(settings.scene_name)
+    renderable_layers = blender_utils.get_renderable_view_layers(settings.scene_name)
 
     # Ensure there is at least one renderable camera.
     if len(renderable_cameras) == 0:

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/scene_settings_widget.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/scene_settings_widget.py
@@ -175,7 +175,7 @@ class SceneSettingsWidget(QWidget):
             self.layers_box.addItem(
                 COMBO_DEFAULT_ALL_RENDERABLE_LAYERS, COMBO_DEFAULT_ALL_RENDERABLE_LAYERS
             )
-            for layer in blender_utils.get_view_layers(scene):
+            for layer in blender_utils.get_renderable_view_layers(scene):
                 self.layers_box.addItem(layer, layer)
 
             # Re-select the layer if possible


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
If the `Use for Rendering` checkbox was not selected on a View Layer it was still being included in the submitter dropdown and generated job template when selected or using `All Renderable Layers`
### What was the solution? (How)
Added a check to only include a layer if its `use` property is true
### What is the impact of this change?
We don't include view layers that we shouldn't anymore
### How was this change tested?
Created a sample scene with two layers and marked one to not `Use for Rendering`
  - Before these changes both layers were included in the submitter dropdown and generated job template when using `All Renderable Layers`
  - After these changes the layer marked to not use for rendering was no longer included in the UI or generated job template when using `All Renderable Layers`
### Was this change documented?
No
### Is this a breaking change?
Technically yes as it's changing the function name `get_view_layers`->`get_renderable_view_layers`

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*