### PR TITLE
fix: correct adaptor override developer option

### DIFF
--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/template_filling.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/template_filling.py
@@ -242,18 +242,12 @@ def fill_job_template(
                 + f"Actual: {wheels_path_package_names}"
             )
 
-        override_adaptor_wheels_param = [
-            param
-            for param in override_environment["parameterDefinitions"]
-            if param["name"] == "OverrideAdaptorWheels"
-        ][0]
-        override_adaptor_wheels_param["default"] = str(wheels_path)
         override_adaptor_name_param = [
             param
             for param in override_environment["parameterDefinitions"]
             if param["name"] == "OverrideAdaptorName"
         ][0]
-        override_adaptor_name_param["default"] = "openjd-blender"
+        override_adaptor_name_param["default"] = "blender-openjd"
 
         # There are no parameter conflicts between these two templates, so this works
         job_template["parameterDefinitions"].extend(override_environment["parameterDefinitions"])
@@ -389,6 +383,8 @@ def get_parameter_values(
 
     # If we're overriding the adaptor with wheels, remove the adaptor from the Packages
     if settings.include_adaptor_wheels:
+        wheels_path = str(Path(__file__).parent.parent.parent.parent / "wheels")
+        params.append({"name": "OverrideAdaptorWheels", "value": wheels_path})
         rez_param = {}
         conda_param = {}
         # Find the Packages parameter definition in the queue params.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Developer op to use local adaptor does not work

### What was the solution? (How)
fix template to correctly attach and load adaptor wheel

### What is the impact of this change?
feature works, so adaptor debugging can be done more easily

### How was this change tested?
submit got using override to SMF fleet

### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*