### PR TITLE
docs: update installation instructions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -74,7 +74,7 @@ These instructions make the following assumptions:
     - For Blender 3.6-4.0 (uses python 3.10):
         - Windows: `pip install --python-version 3.10 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t %USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python\modules`
         - Linux/macOS: `pip install --python-version 3.10 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t ~/DeadlineCloudSubmitter/Submitters/Blender/python/modules`
-    - For Blender 4.1 (uses python 3.11):
+    - For Blender 4.1-4.2 (uses python 3.11):
         - Windows: `pip install --python-version 3.11 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t %USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python\modules`
         - Linux/macOS: `pip install --python-version 3.11 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t ~/DeadlineCloudSubmitter/Submitters/Blender/python/modules`
 1. Add a script directory in Blender by "Edit" > "Preferences" > "File Paths" > "Script Directories"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ This library requires:
 
 This package provides a Blender plugin that creates jobs for AWS Deadline Cloud using the [AWS Deadline Cloud client library][deadline-cloud-client]. Based on the loaded scene it determines the files required, allows the user to specify render options, and builds an [OpenJD template][openjd] that defines the workflow.
 
+### Getting Started
+
+If you have installed the submitter using the Deadline Cloud submitter installer you can follow the instructions in the [DEVELOPMENT](https://github.com/aws-deadline/deadline-cloud-for-blender/blob/mainline/DEVELOPMENT.md#submitter-installer) file for the manual steps needed after running the installer.
+
+If you are setting up the submitter for a developer workflow or manual installation you can follow the instructions in the [DEVELOPMENT](https://github.com/aws-deadline/deadline-cloud-for-blender/blob/mainline/DEVELOPMENT.md#manual-installation) file.
 ## Adaptor
 
 The Blender Adaptor implements the [OpenJD][openjd-adaptor-runtime] interface that allows render workloads to launch Blender and feed it commands. This gives the following benefits:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The GitHub installation docs for the submitter were not clear if the submitter installer was being used vs a manual installation.
#104 
### What was the solution? (How)
- Created a new section in the README for getting started with the submitter
- Linked from the README to the DEVELOPMENT file for manual instructions needed after running the submitter installer. In a future PR I'll likely remove the instructions entirely from the DEVELOPMENT.md file and have the ones for the submitter installer manual steps point to the AWS docs
- Linked from the README to the DEVELOPMENT file if doing a manual installation
### What is the impact of this change?
Clearer instructions for installation from either using the submitter installer or a manual installation
### How was this change tested?
N/A
### Was this change documented?
It is a docs change
### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*