### PR TITLE
fix: correct conda package name

### DIFF
--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
@@ -76,7 +76,7 @@ def create_deadline_dialog(parent=None) -> SubmitJobToDeadlineDialog:
     adaptor_version = ".".join(str(v) for v in adaptor_version_tuple[:2])
     # Need Blender and the Blender OpenJD application interface adaptor
     rez_packages = f"blender-{blender_version} deadline_cloud_for_blender"
-    conda_packages = f"blender={blender_version}.* blender-openjd={adaptor_version}.*"
+    conda_packages = f"blender={blender_version}.* deadline-cloud-for-blender={adaptor_version}.*"
 
     # Create and return the dialog widget.
     # dialog = SubmitJobToDeadlineDialog(

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/template_filling.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/template_filling.py
@@ -403,7 +403,9 @@ def get_parameter_values(
             )
         if conda_param:
             conda_param["value"] = " ".join(
-                pkg for pkg in conda_param["value"].split() if not pkg.startswith("blender-openjd")
+                pkg
+                for pkg in conda_param["value"].split()
+                if not pkg.startswith("deadline-cloud-for-blender")
             )
 
     params.extend({"name": param["name"], "value": param["value"]} for param in queue_params)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Blender cloud submitter was defaulting with a conda package name that is inconsistent with the github and pypi package name.
 
### What was the solution? (How)
Rename the package variables from "blender-openjd" to "deadline-cloud-for-blender".

### What is the impact of this change?
Changes the default value.  Can be changed via deadline Conda Queue Environment, or manually in the submitter dialog.
When overriding python wheels, it should exclude the correct package.

### How was this change tested?
In Blender, Render->Submit to AWS Deadline Cloud, Conda Packages line editor shows the package name.

### Was this change documented?
Not applicable.

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*