### PR TITLE
docs: link submitter installer instructions to public docs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -39,27 +39,7 @@ hatch run fmt
 hatch run all:test
 ```
 
-### Installation
-
-##### Submitter Installer
-
-1. Run the submitter installer and ensure you select Blender
-
-2. Add a script directory in Blender by "Edit" > "Preferences" > "File Paths" > "Script Directories"
-  * Windows: `%USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python`
-  * Linux: `~/DeadlineCloudSubmitter/Submitters/Blender/python`
-
-  Or run this script from Blender
-
-  ```
-  import bpy
-  import os
-  bpy.ops.preferences.script_directory_add(directory=os.path.expanduser(os.path.normpath('~/DeadlineCloudSubmitter/Submitters/Blender/python')))
-  ```
-
-3. Restart Blender - changes to the script directory won't take effect until Blender has been restarted.
-
-##### Manual Installation
+### Manual Installation
 
 These instructions make the following assumptions:
   * You have a [git clone of this repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository#cloning-a-repository)
@@ -98,7 +78,7 @@ You can enable this in "Edit" menu > "Preferences" menu item > "addons" tab.
 
 ## Deadline Cloud for Blender Adaptor
 
-The deadline-cloud-for-blender Adaptor supports Linux and macOS.
+The deadline-cloud-for-blender Adaptor supports Linux, macOS and Windows.
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This package provides a Blender plugin that creates jobs for AWS Deadline Cloud 
 
 ### Getting Started
 
-If you have installed the submitter using the Deadline Cloud submitter installer you can follow the instructions in the [DEVELOPMENT](https://github.com/aws-deadline/deadline-cloud-for-blender/blob/mainline/DEVELOPMENT.md#submitter-installer) file for the manual steps needed after running the installer.
+If you have installed the submitter using the Deadline Cloud submitter installer you can follow the guide to [Setup Deadline Cloud submitters](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/submitter.html#load-dca-plugin) for the manual steps needed after installation.
 
 If you are setting up the submitter for a developer workflow or manual installation you can follow the instructions in the [DEVELOPMENT](https://github.com/aws-deadline/deadline-cloud-for-blender/blob/mainline/DEVELOPMENT.md#manual-installation) file.
 ## Adaptor


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Installation instructions were unclear when using the submitter installer vs a manual installation (#104)
### What was the solution? (How)
A previous change(#119) updated the README to contain submitter installation instructions. This follow-up redirects the instructions for any manual steps when using the submitter installer to the public docs, and leaves only the manual installation instructions in the repository.

### What is the impact of this change?
Clearer instructions for installation
### How was this change tested?
N/A
### Was this change documented?
Is a docs change
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*