### PR TITLE
ci:package and publish Blender plugin to the GitHub release

### DIFF
--- a/.github/actions/bump_precommit_hook/action.yml
+++ b/.github/actions/bump_precommit_hook/action.yml
@@ -1,0 +1,16 @@
+inputs:
+  semver:
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+  - name: Update plugin Version
+    shell: bash
+    run: |
+      major=$(printf ${{inputs.semver}} | cut -d '.' -f1)
+      minor=$(printf ${{inputs.semver}} | cut -d '.' -f2)
+      patch=$(printf ${{inputs.semver}} | cut -d '.' -f3)
+      sed -i "s/\"version\": ([0-9]*, [0-9]*, [0-9]*)/\"version\": ($major, $minor, $patch)/" ./src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py
+      git add ./src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py

--- a/.github/actions/prepush_release_hook/action.yml
+++ b/.github/actions/prepush_release_hook/action.yml
@@ -1,0 +1,18 @@
+inputs:
+  semver:
+    required: true
+    type: string
+  tag:
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+  - name: Zip submitter plugin
+    shell: bash
+    run: |
+      mkdir dist_extras
+      cd src/deadline/blender_submitter/addons
+      zip -r  ../../../../dist_extras/blender_submitter_plugin_${{inputs.semver}}.zip .
+      cd ../../../../


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
1. [__init__.py](https://github.com/aws-deadline/deadline-cloud-for-blender/blob/mainline/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py#L24) contains the version of the latest release. Currently this has to be updated manually.
2. Users are required to git clone the release branch to use the latest submitter.

### What was the solution? (How)
1. Updated __init__.py with the release version when the bump workflow is run.
2. Zip the contenets of `addons` into the dist_extras directory during the release process.

### What is the impact of this change?
1. Proper versions updated in plugin file when we do a release
2. Users can access the plugin from the release page.

### How was this change tested?
Tested in a development environment using the [reusable_bump](https://github.com/aws-deadline/.github/blob/mainline/.github/workflows/reusable_bump.yml) and [reusable publish](https://github.com/aws-deadline/.github/blob/mainline/.github/workflows/reusable_publish.yml) workflows.

* Confirmed that the versions are updated properly in the ChangeLog PR.
* Confirmed that the zip exist on the release page with the expected contents.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*