### PR TITLE
fix: Enable close button  on the submitter dialog in Blender 4.2

### DIFF
--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py
@@ -80,7 +80,7 @@ class DEADLINE_CLOUD_OT_open_dialog(Operator):
         # Option 0: Default behaviour: window will always stay on top of other windows.
         # self.widget.setWindowFlags(self.widget.windowFlags() | QtCore.Qt.WindowStaysOnTopHint)
         # Option 1: go into background when focus is lost, keep a taskbar entry.
-        self.widget.setWindowFlags(self.widget.windowFlags() & ~QtCore.Qt.WindowStaysOnTopHint)  # type: ignore
+        self.widget.setWindowFlags(self.widget.windowFlags() & ~QtCore.Qt.WindowStaysOnTopHint | QtCore.Qt.WindowCloseButtonHint)  # type: ignore
         # Option 2: tool window.
         # Setting the window to be a tool window has the desired effect of making it stay on top
         # of the Blender window only. But the disadvantage that, without a presence in the menu bar,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The submitter's close button was disabled in Blender 4.2. The only way to close the dialog was to either, Submit, Export Bundle or press escape.

<img width="555" alt="Screenshot 2024-10-04 at 3 04 44 PM" src="https://github.com/user-attachments/assets/62651307-74ab-411f-a59b-d7a29858ede1">  

### What was the solution? (How)

Explicitly added the Qt `WindowCloseButtonHint` to the dialog's window flags.

Fixes https://github.com/aws-deadline/deadline-cloud-for-blender/issues/126

### What is the impact of this change?

Slightly better experience on 4.2.

### How was this change tested?

Manually added to both a 4.2 and 3.6 install. Both worked as expected.

### Was this change documented?

No. 

### Is this a breaking change?

No.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*