### PR TITLE
fix: Classify auto-detected assets correctly

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     uses: aws-deadline/.github/.github/workflows/reusable_python_build.yml@mainline
     with:
       os: ${{ matrix.os }}

--- a/hatch.toml
+++ b/hatch.toml
@@ -21,7 +21,7 @@ lint = [
 ]
 
 [[envs.all.matrix]]
-python = ["3.10", "3.11", "3.12"]
+python = ["3.9", "3.10", "3.11", "3.12"]
 
 [envs.default.env-vars]
 SKIP_BOOTSTRAP_TEST_RESOURCES="True"

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py
@@ -11,7 +11,7 @@ import sys
 import bpy  # noqa
 from bpy.types import Operator
 
-from deadline_cloud_blender_submitter import logutil
+from . import logutil
 
 # NOTE: Variables are NOT allowed to be in bl_info since
 #       blender parses this __init__.py source for this variable

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/logutil.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/logutil.py
@@ -3,6 +3,7 @@
 import logging
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
+from typing import Optional
 
 try:
     from deadline.client import config
@@ -15,7 +16,7 @@ _DEFAULT_FORMATTER = logging.Formatter(
 
 
 def add_file_handler(
-    file: Path | None = None,
+    file: Optional[Path] = None,
     logger: logging.Logger = logging.getLogger(),
     fmt: logging.Formatter = _DEFAULT_FORMATTER,
     level=logging.DEBUG,

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/sanity_checks.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/sanity_checks.py
@@ -8,8 +8,8 @@ from typing import Union
 import bpy
 from qtpy import QtWidgets
 
-from deadline_cloud_blender_submitter import blender_utils
-from deadline_cloud_blender_submitter import scene_settings_widget as ssw
+from . import blender_utils
+from . import scene_settings_widget as ssw
 
 
 def run_sanity_checks(settings):

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/scene_settings_widget.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/scene_settings_widget.py
@@ -8,8 +8,8 @@ import logging
 import os
 
 from deadline.client.ui import block_signals
-from deadline_cloud_blender_submitter import blender_utils
-from deadline_cloud_blender_submitter.template_filling import BlenderSubmitterUISettings
+from . import blender_utils
+from .template_filling import BlenderSubmitterUISettings
 from qtpy.QtCore import QRegularExpression, QSize, Qt  # type: ignore
 from qtpy.QtGui import QRegularExpressionValidator  # type: ignore
 from qtpy.QtWidgets import (  # type: ignore

--- a/test/unit/deadline_submitter_for_blender/__init__.py
+++ b/test/unit/deadline_submitter_for_blender/__init__.py
@@ -1,1 +1,22 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import sys
+from unittest.mock import MagicMock
+
+# Mock out UI code to test functions that use the submitter dialog.
+mock_modules = [
+    "PySide2",
+    "PySide2.QtCore",
+    "PySide2.QtGui",
+    "PySide2.QtWidgets",
+    "qtpy",
+    "qtpy.QtCore",
+    "qtpy.QtWidgets",
+    "qtpy.QtGui",
+    "deadline.client.ui.dialogs.submit_job_to_deadline_dialog",
+    "bpy",
+    "bpy.types",
+]
+
+for module in mock_modules:
+    sys.modules[module] = MagicMock()


### PR DESCRIPTION
# What was the problem/requirement? (What/Why)
A utility function classified all auto-detected assets as files even when some were directories, causing jobs to not submit. Also see issue #105

### What was the solution? (How)
Created a new function to sort each returned path into the proper set (filenames or directories).

While testing, there were some linting-related issues- we determined that Blender 3.6 uses Python 3.10, so we don't need to test on Python 3.9. Instead the testing matrix should use 3.10, 3.11, and 3.12.

![image](https://github.com/user-attachments/assets/551e6f06-7690-4c75-b076-4455f46d7bb4)

### What is the impact of this change?
Users won't have to manually remove auto-detected assets and can submit jobs as expected.

### How was this change tested?
Manual testing both on my local machine and in a sample customer workspace; job submission succeeds in both cases.

I wrote a simple regression test to make sure files and directories are sorted correctly.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*