### PR TITLE
fix(adaptor): eevee render engine rename to BLENDER_EEVEE_NEXT for 4.2

### DIFF
--- a/src/deadline/blender_adaptor/BlenderClient/render_handlers/default_blender_handler.py
+++ b/src/deadline/blender_adaptor/BlenderClient/render_handlers/default_blender_handler.py
@@ -12,7 +12,7 @@ _logger = logging.getLogger(__name__)
 
 
 class DefaultBlenderHandler:
-    RENDER_ENGINE_NAME = "BLENDER_EEVEE"
+    RENDER_ENGINE_NAME = "BLENDER_EEVEE_NEXT" if bpy.app.version >= (4, 2, 0) else "BLENDER_EEVEE"
 
     def __init__(self):
         """Initialize this handler."""
@@ -146,6 +146,7 @@ class DefaultBlenderHandler:
         """
         self.scene_name = data.get("render_scene")
         bpy.context.window.scene = bpy.data.scenes[self.scene_name]
+        _logger.debug(f"Set render engine: {self.RENDER_ENGINE_NAME}")
         bpy.context.scene.render.engine = self.RENDER_ENGINE_NAME
 
     def set_output_dir(self, data: dict) -> None:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The adaptor was failing for EEVEE jobs with 4.2 because of a rename to the render engine name. When trying to start an EEVEE render with 4.2 you would get an error like:
```
TypeError: bpy_struct: item.attr = val: enum "BLENDER_EEVEE" not found in ('BLENDER_EEVEE_NEXT', 'BLENDER_WORKBENCH', 'CYCLES')
```
This rename was a [breaking change in Blender 4.2](https://developer.blender.org/docs/release_notes/4.2/python_api/#render-settings)
### What was the solution? (How)
Use BLENDER_EEVEE_NEXT for Blender versions >= 4.2.0 instead of BLENDER_EEVEE which is kept for compatibility with older versions.
### What is the impact of this change?
Blender adaptor works for EEVEE on 4.2
### How was this change tested?
Using the adaptor override I ran submissions with 3.6 and 4.2 for eevee jobs and ensured both versions now worked and also did smoke tests with cycles for each version.
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*