### PR TITLE
chore(installer): update installer descriptions to include 4.2

### DIFF
--- a/install_builder/deadline-cloud-for-blender.xml
+++ b/install_builder/deadline-cloud-for-blender.xml
@@ -1,14 +1,14 @@
 <component>
-    <name>blender_integrated_submitter</name>
-    <description>Deadline Cloud for Blender 3.6</description>
-	<detailedDescription>Blender plugin for submitting jobs to AWS Deadline Cloud</detailedDescription>
+    <name>deadline_cloud_for_blender</name>
+    <description>Deadline Cloud for Blender 3.6-4.2</description>
+    <detailedDescription>Blender plugin for submitting jobs to AWS Deadline Cloud</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
     <show>1</show>
     <parameterList>
-        <stringParameter name="blender_integrated_submitter_summary" ask="0" cliOptionShow="0">
-            <value>Deadline Cloud for Blender 3.6
-- Compatible with Blender 3.6
+        <stringParameter name="deadline_cloud_for_blender_summary" ask="0" cliOptionShow="0">
+            <value>Deadline Cloud for Blender 3.6-4.2
+- Compatible with Blender 3.6 to 4.2
 - Install the integrated Blender submitter files to the installation directory</value>
         </stringParameter>
     </parameterList>
@@ -38,46 +38,46 @@
         </folder>
     </folderList>
     <initializationActionList>
-        <setInstallerVariable name="all_components" value="${all_components} blender_integrated_submitter"/>
+        <setInstallerVariable name="all_components" value="${all_components} deadline_cloud_for_blender" />
     </initializationActionList>
     <readyToInstallActionList>
-        <setInstallerVariable name="blender_installdir" value="${installdir}/Submitters/Blender/python"/>
-        <setInstallerVariable name="blender_addondir" value="${blender_installdir}/addons"/>
-        <setInstallerVariable name="blender_moduledir" value="${blender_installdir}/modules"/>
+        <setInstallerVariable name="blender_installdir" value="${installdir}/Submitters/Blender/python" />
+        <setInstallerVariable name="blender_addondir" value="${blender_installdir}/addons" />
+        <setInstallerVariable name="blender_moduledir" value="${blender_installdir}/modules" />
         <if>
             <conditionRuleList>
-                <platformTest type="windows"/>
+                <platformTest type="windows" />
             </conditionRuleList>
             <actionList>
-                <setInstallerVariable name="blender_deps_platform" value="windows"/>
+                <setInstallerVariable name="blender_deps_platform" value="windows" />
             </actionList>
         </if>
         <if>
             <conditionRuleList>
-                <platformTest type="linux"/>
+                <platformTest type="linux" />
             </conditionRuleList>
             <actionList>
-                <setInstallerVariable name="blender_deps_platform" value="linux"/>
-            </actionList>
-        </if>
-        <if>
-            <conditionRuleEvaluationLogic>and</conditionRuleEvaluationLogic>
-            <conditionRuleList>
-                <platformTest type="osx"/>
-                <platformTest type="osx-intel"/>
-            </conditionRuleList>
-            <actionList>
-                <setInstallerVariable name="blender_deps_platform" value="macos-intel"/>
+                <setInstallerVariable name="blender_deps_platform" value="linux" />
             </actionList>
         </if>
         <if>
             <conditionRuleEvaluationLogic>and</conditionRuleEvaluationLogic>
             <conditionRuleList>
-                <platformTest type="osx"/>
-                <platformTest negate="1" type="osx-intel"/>
+                <platformTest type="osx" />
+                <platformTest type="osx-intel" />
             </conditionRuleList>
             <actionList>
-                <setInstallerVariable name="blender_deps_platform" value="macos-arm64"/>
+                <setInstallerVariable name="blender_deps_platform" value="macos-intel" />
+            </actionList>
+        </if>
+        <if>
+            <conditionRuleEvaluationLogic>and</conditionRuleEvaluationLogic>
+            <conditionRuleList>
+                <platformTest type="osx" />
+                <platformTest negate="1" type="osx-intel" />
+            </conditionRuleList>
+            <actionList>
+                <setInstallerVariable name="blender_deps_platform" value="macos-arm64" />
             </actionList>
         </if>
     </readyToInstallActionList>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The submitter works with 4.2 and we have a Conda package for 4.2, but the installer still only lists 3.6 as supported.
### What was the solution? (How)
- Updated the descriptions in the installer to say that it will work with 3.6-4.2
  - Given how the submitter gets installed there should be no limitation on it working with other versions between 3.6 and 4.2, but I **haven't** tested on every version between
- Renamed the component to follow the same naming convention as every other submitter to `deadline_cloud_for_blender` which will make the CLI arg to enable the component match what all the others use.
### What is the impact of this change?
Users will know that the installer can work with versions of Blender between 3.6 and 4.2
### How was this change tested?
Ran the installer on Windows and Linux and verified that I could launch the submitter and submit jobs in Blender 3.6 and 4.2 after following the additional manual installation instructions needed after running the installer.
### Was this change documented?
It's mostly a docs change in the installer
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*