### PR TITLE
fix: Use user-specified output directories when applicable

### DIFF
--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/sanity_checks.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/sanity_checks.py
@@ -4,6 +4,7 @@
 Sanity checks done on submit or export bundle
 """
 from typing import Union
+from pathlib import Path
 
 import bpy
 from qtpy import QtWidgets
@@ -64,6 +65,15 @@ def run_sanity_checks(settings):
             "Please select a different ViewLayer.".format(settings.view_layer_selection)
         )
 
+    # Ensure the specified output directory exists.
+    # If not, create it
+    output_dir_as_path = Path(settings.output_path)
+    if not (output_dir_as_path.exists()):
+        try:
+            output_dir_as_path.mkdir(parents=True)
+        except Exception as e:
+            raise RuntimeError(f"Could not create {output_dir_as_path}.\n\nError message:\n{e}")
+
 
 def _prompt_unsaved_changes():
     """
@@ -91,7 +101,7 @@ def _prompt_unsaved_changes():
     if return_value == 0:
         bpy.ops.wm.save_mainfile()
     elif return_value == QtWidgets.QMessageBox.Cancel:
-        raise RuntimeError("Submission cancelled")
+        raise RuntimeError("Submission cancelled.")
 
 
 def _validate_frame_range(frames: str):


### PR DESCRIPTION
Fixes (some of) https://github.com/aws-deadline/deadline-cloud-for-blender/issues/136.

### What was the problem/requirement? (What/Why)
Blender provides users two ways to specify output directories (In Preferences > File Paths > Render Output, or in Scene > Output). However, the submitter overwrites these options and sets the output directory to be the whichever directory the scene file is in.

### What was the solution? (How)
Check if the scene has an output path set, and use the directory if it exists. If not, look for a render output directory in preferences. Only if neither of these exist do we set the output directory in the submitter dialog to be the scene file directory. The Blender APIs in this change exist in both Blender 3.6 and 4.2.

File paths are converted to absolute paths before submission- sometimes Blender uses relative paths that don't map nicely to sessions :) (I can elaborate if necessary)

### What is the impact of this change?
Users will not have to manually override the output directory value after already setting it in Blender.

Note that custom-specified output file names are still not supported and will use a default value. This will be addressed soon in a future fix.

### How was this change tested?
Manually tested with different values in the scene output and preferences. Ran existing unit tests to confirm nothing broke.

No new unit tests have been added since they would just mock the Blender API and test if-statements.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*