### PR TITLE
chore: Upgrade deadline-cloud to 0.49.*.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 # Blender 4.1+ uses Python version 3.11
 
 dependencies = [
-    "deadline == 0.48.*", 
+    "deadline == 0.49.*", 
     "openjd-adaptor-runtime >= 0.7,< 0.9",
 ]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

New release of deadline-cloud.

### What was the solution? (How)

Upgraded the deadline-cloud dependency to 0.49.0

### What is the impact of this change?

Consume all the new changes and stay up to date.

### How was this change tested?

Built the package and ran integ tests with:
`hatch run test`

### Was this change documented?

No

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*