### PR TITLE
fix: Handle '//' in output directories

### DIFF
--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
@@ -52,7 +52,7 @@ def create_deadline_dialog(parent=None) -> SubmitJobToDeadlineDialog:
 
     # For the output path, first check for a value in the Scene settings
     if os.path.dirname(bpy.context.scene.render.filepath):
-        settings.output_path = os.path.dirname(bpy.context.scene.render.filepath)
+        settings.output_path = os.path.dirname(bpy.path.abspath(bpy.context.scene.render.filepath))
     # If none, use the one in Preferences
     elif bpy.context.preferences.filepaths.render_output_directory:
         settings.output_path = bpy.context.preferences.filepaths.render_output_directory


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The `//` prefix used by Blender was not tested or accounted for in https://github.com/aws-deadline/deadline-cloud-for-blender/pull/144.

### What was the solution? (How)
Added a `bpy.path.abspath` call to evaluate the `//` in scene settings.

### What is the impact of this change?
Submitter is more robust to different output paths.

### How was this change tested?
Manual testing using a customer test case. All existing unit tests passed.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*