### PR TITLE
fix: Add OCIO configuration support in SMF

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ explicit_package_bases = true
 mypy_path = "src"
 
 [[tool.mypy.overrides]]
-module = ["bpy.*", "qtpy.*"]
+module = ["bpy.*", "qtpy.*", "PyOpenColorIO.*"]
 
 # --- RUFF / BLACK ---
 

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/ocio_utils.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/ocio_utils.py
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import os
+from pathlib import Path
+
+import PyOpenColorIO as ocio
+
+
+def get_ocio_path() -> str:
+    return os.environ["OCIO"] if "OCIO" in os.environ else ""
+
+
+def get_ocio_config(filename: str) -> ocio.Config:
+    return ocio.Config.CreateFromFile(filename)
+
+
+def get_ocio_referenced_dirs(config: ocio.Config) -> list[str]:
+    """
+    Given an OCIO Config object, parse its `search_path` attribute and
+    return a list of referenced directories.
+    """
+
+    path_list = []
+    if config.getSearchPath():
+        for path in config.getSearchPaths():
+            # Paths may be absolute or relative to the config file.
+            if not Path(path).is_absolute():
+                path = Path.joinpath(Path(os.path.dirname(get_ocio_path())), path)
+
+            path_list.append(path)
+
+    return path_list

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
@@ -16,6 +16,7 @@ from . import blender_utils as bu
 from . import sanity_checks as sc
 from . import scene_settings_widget as ssw
 from . import template_filling as tf
+from . import ocio_utils as ocio
 from ._version import version
 from ._version import version_tuple as adaptor_version_tuple
 
@@ -71,6 +72,12 @@ def create_deadline_dialog(parent=None) -> SubmitJobToDeadlineDialog:
 
     # Set auto-detected attachments.
     auto_detected_attachments = _get_auto_detected_assets(settings.project_path)
+
+    # If the user has an OCIO config file set, we will have to upload any directories referenced by that file as job attachments.
+    if ocio.get_ocio_path():
+        ocio_config = ocio.get_ocio_config(ocio.get_ocio_path())
+        for path in ocio.get_ocio_referenced_dirs(ocio_config):
+            auto_detected_attachments.input_directories.add(str(path))
 
     # Set regular attachments.
     attachments = AssetReferences(

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/scene_settings_widget.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/scene_settings_widget.py
@@ -10,6 +10,7 @@ import os
 from deadline.client.ui import block_signals
 from . import blender_utils
 from .template_filling import BlenderSubmitterUISettings
+from . import ocio_utils as ocio
 from qtpy.QtCore import QRegularExpression, QSize, Qt  # type: ignore
 from qtpy.QtGui import QRegularExpressionValidator  # type: ignore
 from qtpy.QtWidgets import (  # type: ignore
@@ -224,6 +225,7 @@ class SceneSettingsWidget(QWidget):
         settings.output_file_prefix = self.op_file_txt.text()
         settings.scene_name = self.scenes_box.currentData()
         settings.renderer_name = self.render_engine_box.currentData()
+        settings.ocio_config_path = ocio.get_ocio_path()
         settings.view_layer_selection = self.layers_box.currentData()
         settings.camera_selection = self.cameras_box.currentData()
         settings.override_frame_range = self.frame_override_check.isChecked()

--- a/test/unit/deadline_submitter_for_blender/__init__.py
+++ b/test/unit/deadline_submitter_for_blender/__init__.py
@@ -9,6 +9,7 @@ mock_modules = [
     "PySide2.QtCore",
     "PySide2.QtGui",
     "PySide2.QtWidgets",
+    "PyOpenColorIO",
     "qtpy",
     "qtpy.QtCore",
     "qtpy.QtWidgets",


### PR DESCRIPTION
Fixes #143.

### What was the problem/requirement? (What/Why)
Users can specify colour management information with the `OCIO` environment variable. However, the contents of this variable are not automatically set on SMF, so a user may unintentionally render something that doesn't use their proper colour management information.

### What was the solution? (How)
Add functions to upload the OCIO config file, along with any directories referenced in this file, as job attachments so they can be accessed by SMF workers.

The `OCIO` environment variable is set on the worker by adding it in a job environment to the default template. Any additional directories that are added are shown in the submitter dialog as auto-detected assets.

### What is the impact of this change?
Users can use OCIO in their Blender renders without special set-up.

### How was this change tested?
- Added a unit test that an extra job environment & parameter value are added when OCIO is set in the submitter settings.
- Tested rendering with:
  - No OCIO environment variable
  - `OCIO` set to the default Blender colour management data, which references two other directories
  - `OCIO` set to an [example configuration from the Academy Software Foundation](https://github.com/AcademySoftwareFoundation/OpenColorIO-Config-ACES/releases) (`cg-config-v2.1.0_aces-v1.3_ocio-v2.2.ocio`)

Note that, when testing, Blender 3.6 only supports OCIO versions <= 2.2.

The manual test results are attached! `no_setting` and `default` are expected to look the same because they both use the default Blender config. We can confirm that the right file was uploaded by looking at the task logs.

No OCIO set:
![RenderLayer_Camera_test_ocio_no_config0001](https://github.com/user-attachments/assets/2032a066-7022-49ca-8492-5b876bb281d2)

Default OCIO uploaded:
![RenderLayer_Camera_test_ocio_default_config0001](https://github.com/user-attachments/assets/2929515d-c1c4-4ae8-8d1c-99a58dab0512)

With this line from the task logs:
`2024/12/10 16:33:33-06:00 ADAPTOR_OUTPUT: STDOUT: Color management: Using /sessions/[session ID]/[asset root]/Program Files/Blender Foundation/Blender 3.6/3.6/datafiles/colormanagement/config.ocio as a configuration file`

ACES configuration uploaded:
![RenderLayer_Camera_ocio_file_example0001](https://github.com/user-attachments/assets/7376d617-e676-4e9d-9646-41ee19f617e4)


### Was this change documented?
No
### Is this a breaking change?
No


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*