### PR TITLE
feat!: Enable GPU rendering from the submitter

### DIFF
--- a/devfiles/adaptor_test_template/template.yaml
+++ b/devfiles/adaptor_test_template/template.yaml
@@ -75,6 +75,13 @@ parameterDefinitions:
 - name: Description
   type: STRING
   default: "This is a description"
+- name: GPUDevice
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: GPU Device
+  description: Choose the GPU device type to render with when using the cycles engine.
+  default: CUDA
 
 - name: StrictErrorChecking
   type: STRING

--- a/src/deadline/blender_adaptor/BlenderAdaptor/adaptor.py
+++ b/src/deadline/blender_adaptor/BlenderAdaptor/adaptor.py
@@ -31,7 +31,7 @@ class BlenderNotRunningError(Exception):
 
 
 # Actions which must be queued before any others.
-_FIRST_BLENDER_ACTIONS = ["scene_file"]
+_FIRST_BLENDER_ACTIONS = ["scene_file", "gpu_device"]
 
 # Order of execution is important.
 _BLENDER_INIT_KEYS = [

--- a/src/deadline/blender_adaptor/BlenderAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/blender_adaptor/BlenderAdaptor/schemas/init_data.schema.json
@@ -12,6 +12,9 @@
                 "cycles"
             ]
         },
+        "gpu_device": {
+            "type": "string"
+        },
         "render_scene": {
             "type": "string"
         },

--- a/src/deadline/blender_adaptor/BlenderClient/render_handlers/cycles_blender_handler.py
+++ b/src/deadline/blender_adaptor/BlenderClient/render_handlers/cycles_blender_handler.py
@@ -1,7 +1,56 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+import bpy
+import logging
+
 from .default_blender_handler import DefaultBlenderHandler
+
+_logger = logging.getLogger(__name__)
 
 
 class CyclesHandler(DefaultBlenderHandler):
     RENDER_ENGINE_NAME = "CYCLES"
+
+    def set_gpu_device(self, data: dict) -> None:
+        """
+        Enables GPU rendering on the worker if specified in the user's configuration.
+
+        Args:
+            data (dict): The data given from the Adaptor. Keys expected: ['gpu_device']
+
+        Raises:
+            RuntimeError: If no devices of the specified type are available
+        """
+
+        gpu_device = data.get("gpu_device", "NONE")
+        if gpu_device == "NONE":
+            bpy.context.scene.cycles.device = "CPU"
+            return
+
+        # Supported GPU devices for Blender 3.6 and 4.2:
+        # https://docs.blender.org/manual/en/3.6/render/cycles/gpu_rendering.html
+        # https://docs.blender.org/manual/en/4.2/render/cycles/gpu_rendering.html
+        GPU_DEVICE_TYPES_ITER = iter(["OPTIX", "CUDA", "HIP", "ONEAPI", "METAL"])
+
+        cycles_preferences = bpy.context.preferences.addons["cycles"].preferences
+        cycles_preferences.refresh_devices()
+
+        # Attempt to set the user's chosen render device.
+        # If it isn't available, loop through device types to find another GPU to use.
+        devices = self._list_compatible_render_devices(cycles_preferences, gpu_device)
+        while not devices and gpu_device != "NONE":
+            _logger.warning(f'Device type "{gpu_device}" is not available on this worker.')
+            gpu_device = next(GPU_DEVICE_TYPES_ITER, "NONE")
+            _logger.warning(f'Attempting to use "{gpu_device}" instead.')
+            devices = self._list_compatible_render_devices(cycles_preferences, gpu_device)
+
+        bpy.context.scene.cycles.device = "GPU" if gpu_device != "NONE" else "CPU"
+        cycles_preferences.compute_device_type = gpu_device
+        _logger.debug(f"Set render device to {gpu_device}.")
+
+    def _list_compatible_render_devices(self, preferences, gpu_device: str) -> list[str]:
+        try:
+            return preferences.get_devices_for_type(gpu_device)
+        except ValueError as ve:
+            _logger.warning(str(ve))
+            return []

--- a/src/deadline/blender_adaptor/BlenderClient/render_handlers/default_blender_handler.py
+++ b/src/deadline/blender_adaptor/BlenderClient/render_handlers/default_blender_handler.py
@@ -21,6 +21,7 @@ class DefaultBlenderHandler:
         # These cross-reference the Action instances created and queued in the Blender adaptor.
         self.action_dict = {
             "scene_file": self.set_scene_file,
+            "gpu_device": self.set_gpu_device,
             "render_scene": self.set_render_scene,
             "view_layer": self.set_view_layer,
             "camera": self.set_camera,
@@ -218,3 +219,10 @@ class DefaultBlenderHandler:
         if not os.path.isfile(file_path):
             raise FileNotFoundError(f"The scene file '{file_path}' does not exist")
         bpy.ops.wm.open_mainfile(filepath=file_path)
+
+    def set_gpu_device(self, data: dict) -> None:
+        """
+        Only implemented in the Cycles handler.
+        """
+
+        pass

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/default_blender_template.yaml
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/default_blender_template.yaml
@@ -14,7 +14,7 @@ parameterDefinitions:
       patterns: ["*.blend"]
     - label: All Files
       patterns: ["*"]
-  description: Choose the Blender scene file you want to render.
+  description: The Blender scene file you want to render.
 - name: RenderEngine
   type: STRING
   default: cycles
@@ -32,7 +32,7 @@ parameterDefinitions:
   userInterface:
     control: LINE_EDIT
     label: view_layer
-  description: Choose the layer to render.
+  description: The layer to render.
   default: ViewLayer
 - name: Frames
   type: STRING
@@ -49,22 +49,29 @@ parameterDefinitions:
   userInterface:
     control: CHOOSE_DIRECTORY
     label: Output Directory
-  description: Choose the render output directory.
+  description: The render output directory.
 - name: OutputFileName
   type: STRING
   userInterface:
     control: LINE_EDIT
     label: Output File Name
   default: "output_####"
-  description: Enter the output filename (without extension).
+  description: The output filename (without extension).
 - name: OutputFormat
   type: STRING
   userInterface:
     control: DROPDOWN_LIST
     label: Output File Format
-  description: Choose the file format to render as.
+  description: The file format to render as.
   default: PNG
   allowedValues: [TARGA, TARGA_RAW, JPEG, IRIS, PNG, HDR, TIFF, OPEN_EXR, OPEN_EXR_MULTILAYER, CINEON, DPX, JPEG2000, WEBP]
+- name: GPUDevice
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: GPU Device
+  description: The GPU device type to render with when using the cycles engine.
+  default: NONE
 
 - name: StrictErrorChecking
   type: STRING
@@ -95,6 +102,7 @@ steps:
           data: |
             scene_file: {{Param.BlenderFile}}
             render_engine: {{Param.RenderEngine}}
+            gpu_device: {{Param.GPUDevice}}
             render_scene: {{Param.RenderScene}}
             view_layer: {{Param.ViewLayer}}
             output_dir: {{Param.OutputDir}}

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
@@ -64,6 +64,14 @@ def create_deadline_dialog(parent=None) -> SubmitJobToDeadlineDialog:
     if bpy.path.basename(bpy.context.scene.render.filepath):
         settings.output_file_prefix = bpy.path.basename(bpy.context.scene.render.filepath)
 
+    # Read the user's preferences to set GPU settings.
+    settings.enable_gpu = bpy.context.scene.cycles.device == "GPU"
+
+    if bpy.context.preferences.addons["cycles"].preferences.compute_device_type != "NONE":
+        settings.gpu_device = bpy.context.preferences.addons[
+            "cycles"
+        ].preferences.compute_device_type
+
     # Load and set sticky settings, if any.
     settings.load_sticky_settings(settings.project_path)
 

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/template_filling.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/template_filling.py
@@ -1,11 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-"""Functions to fill Blender job templates.
-
-This file should not have a dependency on `bpy`, so it can be unit-tested.
-This implies that it should not import modules under `deadline_cloud_blender_submitter`,
-since that module imports `bpy` in `__init__.py`.
-"""
+"""Functions to fill Blender job templates."""
 
 from __future__ import annotations
 
@@ -38,6 +33,8 @@ class BlenderSubmitterUISettings:
     submitter_name: str = field(default="Blender")
     renderer_name: str = field(default="cycles", metadata={"sticky": True})
     scene_name: str = field(default="Scene", metadata={"sticky": True})
+    enable_gpu: bool = field(default=False, metadata={"sticky": True})
+    gpu_device: str = field(default="None", metadata={"sticky": True})
 
     ui_group_label: str = field(default="Blender Settings")
 
@@ -389,6 +386,7 @@ def get_parameter_values(
         "OutputDir": layer_settings.output_directories,
         "RenderScene": layer_settings.scene_name,
         "RenderEngine": layer_settings.renderer_name,
+        "GPUDevice": settings.gpu_device,
     }
 
     if layer_settings.frames_parameter_name:

--- a/test/unit/deadline_submitter_for_blender/test_submitter.py
+++ b/test/unit/deadline_submitter_for_blender/test_submitter.py
@@ -87,7 +87,7 @@ def test_fill_job_template(submitter_settings, layers):
                         {"label": "All Files", "patterns": ["*"]},
                     ],
                 },
-                "description": "Choose the Blender scene file you want to render.",
+                "description": "The Blender scene file you want to render.",
             },
             {
                 "name": "RenderEngine",
@@ -110,7 +110,7 @@ def test_fill_job_template(submitter_settings, layers):
                 "name": "ViewLayer",
                 "type": "STRING",
                 "userInterface": {"control": "LINE_EDIT", "label": "view_layer"},
-                "description": "Choose the layer to render.",
+                "description": "The layer to render.",
                 "default": "ViewLayer",
             },
             {
@@ -130,20 +130,20 @@ def test_fill_job_template(submitter_settings, layers):
                 "objectType": "DIRECTORY",
                 "dataFlow": "OUT",
                 "userInterface": {"control": "CHOOSE_DIRECTORY", "label": "Output Directory"},
-                "description": "Choose the render output directory.",
+                "description": "The render output directory.",
             },
             {
                 "name": "OutputFileName",
                 "type": "STRING",
                 "userInterface": {"control": "LINE_EDIT", "label": "Output File Name"},
                 "default": "output_####",
-                "description": "Enter the output filename (without extension).",
+                "description": "The output filename (without extension).",
             },
             {
                 "name": "OutputFormat",
                 "type": "STRING",
                 "userInterface": {"control": "DROPDOWN_LIST", "label": "Output File Format"},
-                "description": "Choose the file format to render as.",
+                "description": "The file format to render as.",
                 "default": "PNG",
                 "allowedValues": [
                     "TARGA",
@@ -160,6 +160,16 @@ def test_fill_job_template(submitter_settings, layers):
                     "JPEG2000",
                     "WEBP",
                 ],
+            },
+            {
+                "name": "GPUDevice",
+                "type": "STRING",
+                "userInterface": {
+                    "control": "LINE_EDIT",
+                    "label": "GPU Device",
+                },
+                "description": "The GPU device type to render with when using the cycles engine.",
+                "default": "NONE",
             },
             {
                 "name": "StrictErrorChecking",
@@ -215,7 +225,7 @@ def test_fill_job_template(submitter_settings, layers):
                                     "name": "initData",
                                     "filename": "init-data.yaml",
                                     "type": "TEXT",
-                                    "data": "scene_file: {{Param.BlenderFile}}\nrender_engine: {{Param.RenderEngine}}\nrender_scene: {{Param.RenderScene}}\nview_layer: layer_1\noutput_dir: {{Param.OutputDir}}\noutput_file_name: {{Param.OutputFileName}}\noutput_format: {{Param.OutputFormat}}\nrenderer: dummy_renderer\noutput_file_prefix: {{Param.OutputFilePrefix}}\nimage_width: {{Param.ImageWidth}}\nimage_height: {{Param.ImageHeight}}",
+                                    "data": "scene_file: {{Param.BlenderFile}}\nrender_engine: {{Param.RenderEngine}}\ngpu_device: {{Param.GPUDevice}}\nrender_scene: {{Param.RenderScene}}\nview_layer: layer_1\noutput_dir: {{Param.OutputDir}}\noutput_file_name: {{Param.OutputFileName}}\noutput_format: {{Param.OutputFormat}}\nrenderer: dummy_renderer\noutput_file_prefix: {{Param.OutputFilePrefix}}\nimage_width: {{Param.ImageWidth}}\nimage_height: {{Param.ImageHeight}}",
                                 }
                             ],
                             "actions": {
@@ -288,7 +298,7 @@ def test_fill_job_template(submitter_settings, layers):
                                     "name": "initData",
                                     "filename": "init-data.yaml",
                                     "type": "TEXT",
-                                    "data": "scene_file: {{Param.BlenderFile}}\nrender_engine: {{Param.RenderEngine}}\nrender_scene: {{Param.RenderScene}}\nview_layer: layer_2\noutput_dir: {{Param.OutputDir}}\noutput_file_name: {{Param.OutputFileName}}\noutput_format: {{Param.OutputFormat}}\nrenderer: dummy_renderer\noutput_file_prefix: {{Param.OutputFilePrefix}}\nimage_width: {{Param.ImageWidth}}\nimage_height: {{Param.ImageHeight}}",
+                                    "data": "scene_file: {{Param.BlenderFile}}\nrender_engine: {{Param.RenderEngine}}\ngpu_device: {{Param.GPUDevice}}\nrender_scene: {{Param.RenderScene}}\nview_layer: layer_2\noutput_dir: {{Param.OutputDir}}\noutput_file_name: {{Param.OutputFileName}}\noutput_format: {{Param.OutputFormat}}\nrenderer: dummy_renderer\noutput_file_prefix: {{Param.OutputFilePrefix}}\nimage_width: {{Param.ImageWidth}}\nimage_height: {{Param.ImageHeight}}",
                                 }
                             ],
                             "actions": {
@@ -345,6 +355,8 @@ def test_fill_job_template(submitter_settings, layers):
             },
         ],
     }
+
+    # Mock the Blender API call to retrieve the user's render device
     filled = template_filling.fill_job_template(submitter_settings, layers, host_requirements=None)
     assert filled == expected
 
@@ -365,23 +377,30 @@ def test_get_param_values(submitter_settings, common_layer_settings):
         "OutputDir": common_layer_settings.output_directories,
         "RenderScene": common_layer_settings.scene_name,
         "RenderEngine": common_layer_settings.renderer_name,
+        "GPUDevice": submitter_settings.gpu_device,
     }
     expected = [{"name": k, "value": v} for k, v in expected_settings.items()]
 
-    filled = template_filling.get_parameter_values(
-        submitter_settings, common_layer_settings, queue_params=[]
-    )
-    assert filled == expected
+    # Patching this scene setting causes GPUDevice to use the default value
+    with patch("bpy.context.scene.cycles.device", "CPU"):
+        filled = template_filling.get_parameter_values(
+            submitter_settings, common_layer_settings, queue_params=[]
+        )
+        assert filled == expected
 
+
+def test_conflicting_queue_params_error(submitter_settings, common_layer_settings):
     # If queue params are passed, their keys should not conflict with existing keys. Expect an error if they do.
     queue_params = [
         {"name": "RenderScene", "value": common_layer_settings.scene_name + "_some_value"}
     ]
     with pytest.raises(DeadlineOperationError):
-        filled = template_filling.get_parameter_values(
+        template_filling.get_parameter_values(
             submitter_settings, common_layer_settings, queue_params=queue_params
         )
 
+
+def test_get_queue_params(submitter_settings, common_layer_settings):
     # If queue params are passed, and they don't conflict with existing keys, they should be added.
     queue_params = [{"name": "SomeParam", "value": "some_value"}]
     filled = template_filling.get_parameter_values(
@@ -389,27 +408,36 @@ def test_get_param_values(submitter_settings, common_layer_settings):
     )
     assert filled[-1] == queue_params[0]
 
-    # Test RezPackages resolution.
-    # WHEN queue params include "deadline_cloud_for_blender"
+
+@pytest.mark.parametrize(
+    "queue_param_name,package_name",
+    [
+        pytest.param("RezPackages", "deadline_cloud_for_blender"),
+        pytest.param("CondaPackages", "blender-openjd"),
+    ],
+)
+def test_use_adaptor_wheels(
+    submitter_settings, common_layer_settings, queue_param_name, package_name
+):
+    """
+    Tests that default packages are excluded from CondaPackages and RezPackages if `include_adaptor_wheels` is true.
+    """
+
+    # GIVEN
     queue_params = [
         {
-            "name": "RezPackages",
-            "value": "some_other_package deadline_cloud_for_blender another_package",
+            "name": queue_param_name,
+            "value": f"some_other_package {package_name} another_package",
         }
     ]
 
-    # IF `settings.include_adaptor_wheels` is False > keep "deadline_cloud_for_blender" in the final template
-    submitter_settings.include_adaptor_wheels = False
-    filled = template_filling.get_parameter_values(
-        submitter_settings, common_layer_settings, queue_params=queue_params
-    )
-    assert filled[-1]["value"] == "some_other_package deadline_cloud_for_blender another_package"
-
-    # IF `settings.include_adaptor_wheels` is True > remove "deadline_cloud_for_blender"
+    # WHEN
     submitter_settings.include_adaptor_wheels = True
     filled = template_filling.get_parameter_values(
         submitter_settings, common_layer_settings, queue_params=queue_params
     )
+
+    # THEN
     assert filled[-1]["value"] == "some_other_package another_package"
 
 


### PR DESCRIPTION
Fixes #148. 

### Edits 02/01/25:
- Changed the new parameter's name to `gpu_device`.
- Exposed GPU rendering & device selection in the submitter UI (auto-populated based on the user & scene settings).

![image](https://github.com/user-attachments/assets/04fa8362-dd79-4418-8b0e-250deb9bcc65)

- Adaptor now iterates through Blender's devices if the supplied GPU device isn't available.

![image](https://github.com/user-attachments/assets/98c1b9dc-1028-44ba-accd-1085744d7582)

- Other misc. code refactoring as suggested!

### What was the problem/requirement? (What/Why)
Nothing in the submitter/adaptor enables GPU rendering based on the user's preferences or scene settings, meaning scenes with GPU rendering enabled will still render using the CPU on SMF.

### What was the solution? (How)
- Add the parameter `GPUDevice` to the default job template. This has a default value of `NONE` (i.e., use the CPU) and accepts any value.
- Edited the adaptor schema to have a `gpu_device` attribute.
- Added a new action type, `set_gpu_device`, to the adaptor.
- Allow users to choose from Blender's natively-supported GPU device types, or manually enter their own. If they have enabled GPU rendering but their chosen device isn't available on the worker, the worker will iterate through Blender's supported device types until it finds one with compatible devices. Fall back to CPU rendering IFF no supported GPU devices are available.

### What is the impact of this change?
GPU rendering is available through the Blender submitter without extra setup!

### How was this change tested?
- Added/updated submitter unit tests to account for the new parameter.
- Manually tested GPU renders with all four device types on both 3.6 and 4.2. Compare the times to render 3 frames:

![image](https://github.com/user-attachments/assets/f1fbd7c7-e914-44b8-a495-e586ce6950eb)
![image](https://github.com/user-attachments/assets/4958e03d-bc6d-4b1f-b061-b4d56a45334a)

### Was this change documented?
Relevant docstrings were updated.

### Is this a breaking change?
**Yes**, this adds a new attribute to the adaptor schema.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*