### PR TITLE
chore: Remove LFS for .blend files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
 * text=auto
 *.sh text eol=lf
 *.py text eol=lf
-*.blend filter=lfs diff=lfs merge=lfs -text

--- a/test/integ/test_blender.py
+++ b/test/integ/test_blender.py
@@ -51,6 +51,7 @@ def test_minimal_scene_submitter(
             {"name": "OutputDir", "value": str(output_path)},
             {"name": "RenderScene", "value": "Scene"},
             {"name": "RenderEngine", "value": "cycles"},
+            {"name": "GPUDevice", "value": "NONE"},
             {"name": "Frames", "value": "1-2"},
             {"name": "ResolutionX", "value": 640},
             {"name": "ResolutionY", "value": 480},

--- a/test/integ/test_scripts/minimal_test/expected_job_bundle/template.yaml
+++ b/test/integ/test_scripts/minimal_test/expected_job_bundle/template.yaml
@@ -16,7 +16,7 @@ parameterDefinitions:
     - label: All Files
       patterns:
       - '*'
-  description: Choose the Blender scene file you want to render.
+  description: The Blender scene file you want to render.
 - name: RenderEngine
   type: STRING
   default: cycles
@@ -37,7 +37,7 @@ parameterDefinitions:
   userInterface:
     control: LINE_EDIT
     label: view_layer
-  description: Choose the layer to render.
+  description: The layer to render.
   default: ViewLayer
 - name: Frames
   type: STRING
@@ -54,20 +54,20 @@ parameterDefinitions:
   userInterface:
     control: CHOOSE_DIRECTORY
     label: Output Directory
-  description: Choose the render output directory.
+  description: The render output directory.
 - name: OutputFileName
   type: STRING
   userInterface:
     control: LINE_EDIT
     label: Output File Name
   default: output_####
-  description: Enter the output filename (without extension).
+  description: The output filename (without extension).
 - name: OutputFormat
   type: STRING
   userInterface:
     control: DROPDOWN_LIST
     label: Output File Format
-  description: Choose the file format to render as.
+  description: The file format to render as.
   default: PNG
   allowedValues:
   - TARGA
@@ -83,6 +83,13 @@ parameterDefinitions:
   - DPX
   - JPEG2000
   - WEBP
+- name: GPUDevice
+  type: STRING
+  userInterface:
+    label: GPU Device
+    control: LINE_EDIT
+  description: The GPU device type to render with when using the cycles engine.
+  default: NONE
 - name: StrictErrorChecking
   type: STRING
   userInterface:
@@ -133,6 +140,7 @@ steps:
         data: |-
           scene_file: {{Param.BlenderFile}}
           render_engine: {{Param.RenderEngine}}
+          gpu_device: {{Param.GPUDevice}}
           render_scene: {{Param.RenderScene}}
           view_layer: ViewLayer
           output_dir: {{Param.OutputDir}}
@@ -203,6 +211,7 @@ steps:
         data: |-
           scene_file: {{Param.BlenderFile}}
           render_engine: {{Param.RenderEngine}}
+          gpu_device: {{Param.GPUDevice}}
           render_scene: {{Param.RenderScene}}
           view_layer: ViewLayer_001
           output_dir: {{Param.OutputDir}}


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The test scene blend file is not big enough to need LFS.

### What was the solution? (How)
Remove LFS filter on .blend files in .gitattributes.
Also had to edit integration tests to accommodate the breaking GPU change.

### What is the impact of this change?
CI should pass 🎉 

### How was this change tested?
Unit & integration tests

#### Please run the integration tests and paste the results below
```
test/integ/test_blender.py::test_minimal_scene_submitter
[gw0] [ 50%] PASSED test/integ/test_blender.py::test_minimal_scene_submitter 
test/integ/test_blender.py::test_minimal_scene_adaptor
[gw0] [100%] XFAIL test/integ/test_blender.py::test_minimal_scene_adaptor 

============================================================================================= slowest 5 durations ============================================================================================== 
8.59s call     test/integ/test_blender.py::test_minimal_scene_adaptor
7.29s call     test/integ/test_blender.py::test_minimal_scene_submitter
0.01s setup    test/integ/test_blender.py::test_minimal_scene_adaptor
0.00s setup    test/integ/test_blender.py::test_minimal_scene_submitter
0.00s teardown test/integ/test_blender.py::test_minimal_scene_adaptor
======================================================================================== 1 passed, 1 xfailed in 17.02s ========================================================================================= 
```

### Was this change documented?
Nop

### Is this a breaking change?
Nop

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*