### PR TITLE
chore: Added github workflows to stale, unstale and notify maintainer…

### DIFF
--- a/.github/workflows/label_new_prs.yml
+++ b/.github/workflows/label_new_prs.yml
@@ -1,0 +1,18 @@
+name: Label New Pull Requests
+
+on:
+    pull_request_target:
+        types: [opened, reopened]
+
+jobs:
+    label-new-prs:
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+        steps:
+            - name: Update pr labels
+              run:  gh pr edit "$NUMBER" --add-label "waiting-on-maintainers"
+              env:
+                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                GH_REPO: ${{ github.repository }}
+                NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/responded.yml
+++ b/.github/workflows/responded.yml
@@ -1,0 +1,34 @@
+name: Contributor Responded
+on:
+    issue_comment:
+        types: [created, edited]
+    
+jobs:
+  add-reponded-to-issue:
+    # Check if an issue waiting for a contributor response has been responded to by a non-owner/non-maintainer
+    if: ${{ !github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'response-requested') && !contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association) }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add issue labels
+        run: gh issue edit "$NUMBER" --add-label "waiting-on-maintainers" --remove-label "response-requested,closing-soon"
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GH_REPO: ${{ github.repository }}
+            NUMBER: ${{ github.event.issue.number }}
+  add-reponded-to-pr:
+    # Check if a PR waiting for a contributor response has been responded to by a non-owner/non-maintainer
+    if:  ${{ github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'response-requested') && !contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association) }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Update pr labels
+        run: gh pr edit "$NUMBER" --add-label "waiting-on-maintainers" --remove-label "response-requested,no-pr-activity"
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GH_REPO: ${{ github.repository }}
+            NUMBER: ${{ github.event.issue.number }}
+
+          

--- a/.github/workflows/stale_prs_and_issues.yml
+++ b/.github/workflows/stale_prs_and_issues.yml
@@ -1,0 +1,30 @@
+name: 'Check stale issues/PRs.'
+on: 
+  schedule:
+    # Run every hour on the hour
+    - cron: '0 * * * *'
+
+jobs:
+  stale-review-stage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          debug-only: false
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          days-before-stale: 5
+          days-before-close: 10
+
+          stale-issue-message: 'Greetings! It looks like this issue hasn’t been active in more than five days. We encourage you to check if this is still an issue in the latest release. In the absence of more information, we will be closing this issue soon. If you find that this is still a problem, please feel free to provide a comment or upvote with a reaction on the initial post to prevent automatic closure. If the issue is already closed, please feel free to open a new one.'
+          stale-pr-message: 'This pull request is in the review stage. It has been 5 days with no response to feedback provided by the maintainers. Please comment with an update to indicate work you are still working on the pull request. Thanks!'
+
+          stale-issue-label: closing-soon
+          stale-pr-label: no-pr-activity
+
+          labels-to-add-when-unstale: waiting-on-maintainers
+          labels-to-remove-when-unstale: response-requested,closing-soon,no-pr-activity  
+          only-labels: response-requested
+
+          close-issue-label: closed-for-staleness
+          close-pr-label: closed-for-staleness 


### PR DESCRIPTION
…s for issues/prs.

### What was the problem/requirement? (What/Why)

We want to use labels to better engage with contributions. Right now we don't have a way of finding issues or prs that are waiting for maintainers or automatically closing issues and prs that are stale. 

### What was the solution? (How)

I've added 3 github actions.

1) Stales and Unstales issues and prs. It will post a comment after 5 days of inactivity if the "response-requested" label is applied to the issue/pr. After 10 more days of inactivity, the issue/pr will be closed. It also applies and removes labels appropriately when stale-ing or unstale-ing. This action runs once every hour.

2) An action that adds/removes labels that have discussion or feedback. When I maintainer needs more information or leaves feedback on a pr, they'll add the "response-requested" label. That label is removed when a non-maintainer comments on the issue or pr and replaced with the "waiting-on-maintainers". 

3) An action to label new or reopened PRs with the "waiting-on-maintainers" label.

### What is the impact of this change?

Issue and PR management should be easier with proper labeling and closing of stale items. 

### How was this change tested?

I deployed these changes to the mainline of my own fork (GitHub actions need to be in mainline for them to appear in the repo).

I changed the actions slightly to reduce the stale times and to manually run the actions. I made a test issue and test pr. Posted comments from accounts that were not maintainers or owners to make sure the labeling worked. I also tested to make sure that my own comments as owner and the bot stale comments wouldn't affect the labeling. 

#### Please run the integration tests and paste the results below
n/a

### Was this change documented?
No

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*