### PR TITLE
feat: output directory and output file prefix are remembered when submitting the same scene

### DIFF
--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/template_filling.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/template_filling.py
@@ -46,8 +46,8 @@ class BlenderSubmitterUISettings:
 
     # Paths and files.
     project_path: str = field(default="")
-    output_path: str = field(default="")
-    output_file_prefix: str = field(default="output_####")
+    output_path: str = field(default="", metadata={"sticky": True})
+    output_file_prefix: str = field(default="output_####", metadata={"sticky": True})
     input_filenames: list[str] = field(default_factory=list, metadata={"sticky": True})
     input_directories: list[str] = field(default_factory=list, metadata={"sticky": True})
     output_directories: list[str] = field(default_factory=list, metadata={"sticky": True})


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Issue reported that the Output Directory and Output File Prefix fields in the blender submitter has to be set every time the submitter is opened.

<img width="537" alt="outputs" src="https://github.com/user-attachments/assets/06a23bf3-9d9d-48a9-b121-e1e9945dac3d" />


### What was the solution? (How)
set `output_path` and `output_file_prefix` to sticky.

### What is the impact of this change?
After the output directory and output file prefix have been set, they will be remembered the next time the submitter is opened for that same scene

### How was this change tested?
`hatch run lint && hatch run test && hatch run integ:test`

1. Opened a new scene in the submitter, confirmed the Output Directory was set to "/tmp" and the Output File Prefix is set to `output_####`.
2. Change the the Output Directory and Output File Prefix and Submitted a Job.
3. Confirmed that when the Submitter was re-opened in the same scene the settings from Step 2 were still set.
4. Confirmed when opening a new scene that  Output Directory was set to "/tmp" and the Output File Prefix is set to `output_####`

#### Please run the integration tests and paste the results below
```
hatch run integ:test
=========================================================================================================== test session starts ===========================================================================================================
platform darwin -- Python 3.11.11, pytest-8.3.4, pluggy-1.5.0 -- /Users/moorec/Library/Application Support/hatch/env/virtual/deadline-cloud-for-blender/UAESGOCP/integ/bin/python
cachedir: .pytest_cache
rootdir: /Users/moorec/Demo/deadline-cloud-for-blender
configfile: pyproject.toml
plugins: cov-6.0.0, xdist-3.6.1
1 worker [2 items]     
scheduling tests via LoadScheduling

test/integ/test_blender.py::test_minimal_scene_submitter 
[gw0] [ 50%] PASSED test/integ/test_blender.py::test_minimal_scene_submitter 
test/integ/test_blender.py::test_minimal_scene_adaptor 
[gw0] [100%] XFAIL test/integ/test_blender.py::test_minimal_scene_adaptor 

=========================================================================================================== slowest 5 durations ===========================================================================================================
32.94s call     test/integ/test_blender.py::test_minimal_scene_adaptor
5.30s call     test/integ/test_blender.py::test_minimal_scene_submitter
0.00s setup    test/integ/test_blender.py::test_minimal_scene_submitter
0.00s setup    test/integ/test_blender.py::test_minimal_scene_adaptor
0.00s teardown test/integ/test_blender.py::test_minimal_scene_adaptor
====================================================================================================== 1 passed, 1 xfailed in 35.53s ======================================================================================================
```
### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*