### PR TITLE
maintenance: Use new reusable workflows for issue/pr management.

### DIFF
--- a/.github/workflows/label_new_prs.yml
+++ b/.github/workflows/label_new_prs.yml
@@ -1,0 +1,10 @@
+name: Label New Pull Requests
+
+on:
+    pull_request:
+        types: [opened, reopened]
+
+jobs:
+    label-new-prs:
+        uses: aws-deadline/.github/.github/workflows/reusable_label_new_prs.yml@mainline
+        secrets: inherit

--- a/.github/workflows/responded.yml
+++ b/.github/workflows/responded.yml
@@ -1,0 +1,9 @@
+name: Contributor Responded
+on:
+    issue_comment:
+        types: [created, edited]
+
+jobs:
+    label-new-prs:
+        uses: aws-deadline/.github/.github/workflows/reusable_responded.yml@mainline
+        secrets: inherit

--- a/.github/workflows/stale_prs_and_issues.yml
+++ b/.github/workflows/stale_prs_and_issues.yml
@@ -1,0 +1,10 @@
+name: 'Check stale issues/PRs.'
+on: 
+  schedule:
+    # Run every hour on the hour
+    - cron: '0 * * * *'
+
+jobs:
+    label-new-prs:
+        uses: aws-deadline/.github/.github/workflows/reusable_stale_prs_and_issues.yml@mainline
+        secrets: inherit


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to use some reusable workflows for issue management.

### What was the solution? (How)
The reusable workflows all live in aws-deadline/.github. In order to use them, we create new workflows in each repo that reference them. 

### What is the impact of this change?
Issues and PRs will be labeled automatically when created or commented on. They will also be staled if they're waiting for contributors to respond for too long.

### How was this change tested?
I deployed these changes to my fork's mainline. (Workflows only work when they're in mainline)  https://github.com/erico-aws/deadline-cloud-for-blender

I created a new PR and checked that it was labeled as expected. Stale workflow is running hourly too with expected logs.  Bot adds/removes labels when contributor comments on the PR.

### Was this change documented?
No

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*