### PR TITLE
fix(installer): Adapt installer script for prod builds

### DIFF
--- a/install_builder/deadline-cloud-for-blender.xml
+++ b/install_builder/deadline-cloud-for-blender.xml
@@ -20,7 +20,7 @@
             <platforms>all</platforms>
             <distributionFileList>
                 <distributionDirectory allowWildcards="1">
-                    <origin>components/deadline-cloud-for-blender/src/deadline/blender_submitter/addons/*</origin>
+                    <origin>../src/deadline/blender_submitter/addons/*</origin>
                     <excludeFiles>*/install_builder</excludeFiles>
                 </distributionDirectory>
             </distributionFileList>
@@ -32,7 +32,7 @@
             <platforms>all</platforms>
             <distributionFileList>
                 <distributionDirectory allowWildcards="1">
-                    <origin>components/deadline-cloud-for-blender/dependency_bundle</origin>
+                    <origin>../dependency_bundle</origin>
                 </distributionDirectory>
             </distributionFileList>
         </folder>

--- a/installer/DeadlineCloudForBlenderSubmitter.xml
+++ b/installer/DeadlineCloudForBlenderSubmitter.xml
@@ -134,7 +134,7 @@
 
     <componentList>
         <include>
-            <file>components/deadline-cloud-for-blender/install_builder/deadline-cloud-for-blender.xml</file>
+            <file>components/deadline-cloud-for-blender.xml</file>
         </include>
     </componentList>
 

--- a/pipeline/build_installer.sh
+++ b/pipeline/build_installer.sh
@@ -5,4 +5,5 @@ set -e
 pip install --upgrade pip
 pip install --upgrade hatch
 
-hatch run build-installer
+# This script is specifically for non-dev builds, so it requires the prod arguments.
+hatch run build-installer --platform $1 --install-builder-license-file $2 --install-builder-s3-bucket $3

--- a/scripts/build_installer.py
+++ b/scripts/build_installer.py
@@ -82,8 +82,8 @@ class EvaluationBuildError(Exception):
     pass
 
 
-def download_from_s3(bucket_name: str, key: Path, output_folder: Path) -> Path:
-    dest_path = output_folder / key.name
+def download_from_s3(bucket_name: str, key: str, output_folder: str) -> Path:
+    dest_path = Path(output_folder) / Path(key).name
     print(f"Downloading {key} from s3:\\\\{bucket_name}")
     import boto3
 
@@ -124,7 +124,7 @@ def build_installer(
     else:
         install_builder_path = install_builder_location
 
-    if not install_builder_path.is_dir():
+    if not Path(install_builder_path).is_dir():
         raise FileNotFoundError(
             f"InstallBuilder path '{str(install_builder_path)}' must be a directory containing 'bin/builder'."
         )
@@ -138,27 +138,35 @@ def build_installer(
     date = datetime.today().date()
 
     print("Running Install Builder...")
-    output = subprocess.run(
-        [
-            install_builder,
-            "build",
-            INSTALLER_ROOT / INSTALLER_TEMPLATE,
-            platform,
-            "--setvars",
-            f"project.outputDirectory={out_dir}",
-            f"project.version={installer_version[:8]}-{date}",
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        output = subprocess.run(
+            [
+                install_builder,
+                "build",
+                INSTALLER_ROOT / INSTALLER_TEMPLATE,
+                platform,
+                "--setvars",
+                f"project.outputDirectory={out_dir}",
+                f"project.version={installer_version[:8]}-{date}",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Encountered an error when running: {e.output}")
+        raise
     print(
         f"{'-'*30}\nBegin Install Builder Output\n{'-'*30}\n"
         f"{output.stdout}"
         f"{'-'*30}\nEnd Install Builder Output\n{'-'*30}\n"
     )
 
-    if EVALUATION_VERSION_STRING in output.stdout and not local_dev_build:
+    if (
+        EVALUATION_VERSION_STRING in output.stdout
+        and not local_dev_build
+        and license_file is not None
+    ):
         raise EvaluationBuildError(
             "InstallBuilder was detected using an evaluation version, which is only permitted in local dev builds."
         )
@@ -204,8 +212,7 @@ def main(args: argparse.Namespace) -> None:
 
         if components_dir.exists():
             shutil.rmtree(components_dir, onerror=_add_write_perms)
-        src_component_path = Path("./install_builder")
-        shutil.copytree(src_component_path, components_dir)
+        shutil.copytree(INSTALL_BUILDER_PROJECT_ROOT, components_dir)
 
         bundle_file = Path(shutil.copy("depsBundle.sh", f"{components_dir}/depsBundle.sh"))
         shutil.copy("depsBundle.py", f"{components_dir}/depsBundle.py")
@@ -224,7 +231,11 @@ def main(args: argparse.Namespace) -> None:
                     if args.install_builder_license_file != "NO_LICENSE"
                     else None
                 ),
-                install_builder_location=args.install_builder_location,
+                install_builder_location=(
+                    args.install_builder_location
+                    if args.install_builder_location
+                    else INSTALL_BUILDER["archive"]
+                ),
                 platform=args.platform,
                 local_dev_build=args.local_dev_build,
                 s3bucket=args.install_builder_s3_bucket,
@@ -296,8 +307,7 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "--install-builder-location",
-        help="The InstallBuilder location, containing 'bin/builder'.",
-        required=True,
+        help="The InstallBuilder location, containing 'bin/builder'. Required for local dev builds.",
         type=Path,
     )
 

--- a/scripts/build_installer.py
+++ b/scripts/build_installer.py
@@ -172,21 +172,6 @@ def build_installer(
     return out_dir
 
 
-def dev_create_dcc_component(
-    workdir: tempfile.TemporaryDirectory, dcc_component: DccSubmitter
-) -> None:
-    """
-    Creates artifacts locally
-    """
-    # Clone dcc component by copying it into the working directory & allowing the dependency bundle script to be executed
-    repo_dir = f"{workdir}/{dcc_component.componentName}"
-    source_folder = Path(__file__).absolute().parent.parent
-    shutil.copytree(source_folder, repo_dir, dirs_exist_ok=True)
-    bundle_file = Path(repo_dir) / "depsBundle.sh"
-    bundle_file.chmod(bundle_file.stat().st_mode | stat.S_IEXEC)
-    subprocess.run(str(bundle_file), check=True)
-
-
 class RequiredArg(NamedTuple):
     """
     Structure to represent a required CLI argument. Used to provide better error messaging.
@@ -198,7 +183,6 @@ class RequiredArg(NamedTuple):
 
 def main(args: argparse.Namespace) -> None:
 
-    dcc_submitter = DccSubmitter(name=args.dcc_name)
     if not args.local_dev_build:
         missing_args = []
         for required_arg in prod_required_args:
@@ -217,14 +201,20 @@ def main(args: argparse.Namespace) -> None:
         print(f"working directory: {workdir})")
         components_dir = INSTALLER_ROOT / "components"
         components_dir.mkdir(exist_ok=True)
-        if args.local_dev_build:
-            dev_create_dcc_component(workdir, dcc_submitter)
 
-        src_component_path = f"{workdir}/{dcc_submitter.componentName}"
-        dst_component_path = Path(components_dir) / dcc_submitter.componentName
-        if Path(dst_component_path).exists():
-            shutil.rmtree(dst_component_path, onerror=_add_write_perms)
-        shutil.copytree(src_component_path, dst_component_path)
+        if components_dir.exists():
+            shutil.rmtree(components_dir, onerror=_add_write_perms)
+        src_component_path = Path("./install_builder")
+        shutil.copytree(src_component_path, components_dir)
+
+        bundle_file = Path(shutil.copy("depsBundle.sh", f"{components_dir}/depsBundle.sh"))
+        shutil.copy("depsBundle.py", f"{components_dir}/depsBundle.py")
+        bundle_file.chmod(bundle_file.stat().st_mode | stat.S_IEXEC)
+        try:
+            subprocess.run(str(bundle_file), check=True)
+        except subprocess.CalledProcessError as e:
+            print(f"Encountered the following error when bundling dependencies: {e.output}")
+            raise
 
         try:
             installer_dir = build_installer(

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -60,11 +60,11 @@ def test_install(installed: Path):
         uninstaller = "uninstall.exe"
     else:
         uninstaller = "uninstall"
-    python_dir = installed / "Submitters" / "Blender" / "python"
+    python_dir = installed / "python"
 
     # THEN
     top_level_dir = [f.name for f in installed.iterdir()]
-    assert "Submitters" in top_level_dir
+    assert python_dir.name in top_level_dir
     assert "installer_version.txt" in top_level_dir
     assert uninstaller in top_level_dir
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The existing script to build the Blender installer needs some revisions to work correctly for production builds.

### What was the solution? (How)
- Removed `install_builder_location` as a universally required argument; instead it is recommended for local builds only
- Replaced the `dev_create_dcc_component` function with copying over required files to `install_builder/components` as necessary
- Edited the pipeline `build_installer` script to take & supply required arguments to `hatch build-installer`
- Other error handling/typing refactors as necessary

### What is the impact of this change?
We can use this script for production builds!

### How was this change tested?
- Ran the new script for both local builds & in a mock prod environment.
- Confirmed the unit tests still pass.

#### Please run the integration tests and paste the results below
No change to submitter/adaptor, skipped

### Was this change documented?
Updated docstrings and CLI help, instructions in `DEVELOPMENT.md` have not changed

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*