### PR TITLE
test: add installer permission tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,8 @@
 
 #### Please run the integration tests and paste the results below
 
+#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below
+
 ### Was this change documented?
 
 ### Is this a breaking change?

--- a/hatch.toml
+++ b/hatch.toml
@@ -20,7 +20,7 @@ lint = [
   "typing",
 ]
 build-installer = "python {root}/scripts/build_installer.py --dcc-name blender --dcc-installer-file {root}/installer/DeadlineCloudForBlenderSubmitter.xml {args:}"
-test-installer = "pytest --no-cov {args:test/installer} -vvv --numprocesses=1"
+test-installer = "pytest --no-cov {args:test/installer} -vvv"
 build-addon = "python scripts/build_addon.py {args}"
 
 [[envs.all.matrix]]

--- a/scripts/build_installer.py
+++ b/scripts/build_installer.py
@@ -218,7 +218,7 @@ def main(args: argparse.Namespace) -> None:
         shutil.copy("depsBundle.py", f"{components_dir}/depsBundle.py")
         bundle_file.chmod(bundle_file.stat().st_mode | stat.S_IEXEC)
         try:
-            subprocess.run(str(bundle_file), check=True)
+            subprocess.run(["bash", bundle_file], check=True)
         except subprocess.CalledProcessError as e:
             print(f"Encountered the following error when bundling dependencies: {e.output}")
             raise

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 import getpass
 import os
 from pathlib import Path
+import re
 import stat
 import subprocess
 import platform
@@ -179,6 +180,55 @@ def uninstaller_path():
         uninstaller_path = uninstaller_path.with_suffix("exe")
 
     yield uninstaller_path
+
+
+def test_default_location(installer_path: Path):
+    """Ensures that the default output location reported by the installer is accurate.
+       The help text will only show it for the default scope (user). Example help output:
+
+    --prefix <prefix>                           Installation Directory
+                                                Default: /home/<user>/DeadlineCloudForBlenderSubmitter
+    """
+    # GIVEN
+    default_install_location = Path("~/DeadlineCloudForBlenderSubmitter").expanduser()
+    default_pattern = r"Default: (.*)"
+    location = ""
+
+    # WHEN
+    help_result = subprocess.run(
+        [installer_path, "--mode", "text", "--help"], check=True, capture_output=True
+    )
+
+    # THEN
+    assert help_result.returncode == 0
+
+    help_output = iter(help_result.stdout.decode("utf-8").splitlines())
+    while (line := next(help_output, None)) is not None:
+        if line.strip().startswith("--prefix"):
+            location = re.match(default_pattern, next(help_output, "").strip(), flags=re.IGNORECASE)
+            break
+
+    assert (
+        location
+    ), f"Could not find default install location in help output:\n{help_result.stdout.decode('utf-8')}"
+    if platform.system() != "Windows":
+        assert location.group(1) == default_install_location.as_posix()
+    else:
+        assert location.group(1) == str(default_install_location())
+
+
+def test_does_not_use_evaluation_mode(installer_path: Path, tmp_path: Path):
+    """Ensure the installer is not built with the evaluation mode of the installer software"""
+    # GIVEN
+    eval_text = r"Created with an evaluation version of InstallBuilder"
+
+    # WHEN
+    result = subprocess.run(
+        [installer_path, "--mode", "text", "--prefix", tmp_path], check=True, capture_output=True
+    )
+
+    # THEN
+    assert eval_text not in result.stdout.decode("utf-8")
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only run on macOS")

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -1,18 +1,25 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-from collections import defaultdict
 import getpass
+import glob
 import os
-from pathlib import Path
+import platform
 import re
+import shutil
 import stat
 import subprocess
-import platform
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
 
 import pytest
 
 
 def _is_admin() -> bool:
-    if platform.system() != "Windows":
+    """Platform independent utility to determine if the tests are running with
+    elevated privileges"""
+    # sys.platform helps mypy type checking ignore other platforms
+    if sys.platform != "win32":
         return os.getuid() == 0
 
     import ctypes
@@ -37,7 +44,7 @@ def installer_path():
     elif platform.system() == "Windows":
         path = path.format(platform="windows-x64", ext="exe")
     elif platform.system() == "Linux":
-        path = path.format(platform="linux", ext="run")
+        path = path.format(platform="linux-x64", ext="run")
 
     if not os.path.isfile(path):
         raise FileNotFoundError(f"Installer not found at '{path}'")
@@ -49,6 +56,8 @@ def installer_path():
 
 
 def _run_installer(installer_path, install_scope, installation_path) -> Path:
+    # use a path that does not exist
+    installation_path = installation_path / "dne"
     args = [
         installer_path,
         "--mode",
@@ -60,8 +69,7 @@ def _run_installer(installer_path, install_scope, installation_path) -> Path:
         "--enable-components",
         "deadline_cloud_for_blender",
     ]
-    result = subprocess.run(args, check=True)
-    assert result.returncode == 0
+    subprocess.run(args, check=True)
 
     return Path(installation_path)
 
@@ -92,57 +100,6 @@ def _validate_files(installation_path: Path) -> None:
         f.name for f in (python_dir / "addons" / "deadline_cloud_blender_submitter").iterdir()
     ]
     assert "_version.py" in addon_dir
-
-
-def _has_group_other_write(mode: int) -> bool:
-    return bool(mode & (stat.S_IWGRP | stat.S_IWOTH))
-
-
-def _has_user_read_write(mode: int) -> bool:
-    return bool(mode & (stat.S_IRUSR | stat.S_IWUSR))
-
-
-def _has_user_group_other_execute(mode: int) -> bool:
-    return bool(mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
-
-
-def _validate_posix_permissions(installation_path: Path):
-    # GIVEN
-    current_user = getpass.getuser()
-
-    # WHEN
-    bad_perms: defaultdict[Path, list[str]] = defaultdict(list)
-    for entry in [installation_path, *installation_path.rglob("*")]:
-        mode = stat.S_IMODE(entry.stat().st_mode)
-        if _has_group_other_write(mode):
-            bad_perms[entry].append("should not have group/other write permissions")
-        if not _has_user_read_write(mode):
-            bad_perms[entry].append("should have user read/write permissions")
-        if entry.is_dir() and not _has_user_group_other_execute(mode):
-            bad_perms[entry].append("is a directory and should have execute permissions")
-        if entry.owner() != current_user:
-            bad_perms[entry].append(f"is not owned by the '{current_user}'")
-
-    error_message = [f"Found {len(bad_perms)} instance(s) of incorrect permissions"]
-    for i, entry in enumerate(bad_perms):
-        fmted_reasons = "\n  - ".join(reason for reason in bad_perms[entry])
-        error_message.append(
-            f"{i+1}. ({stat.S_IMODE(entry.stat().st_mode):o}) '{str(Path(*entry.parts[len(user_installation.parts):])):>3}'\n"
-            f"  - {fmted_reasons}"
-        )
-
-    # THEN
-    assert len(bad_perms) == 0, "\n".join(error_message)
-
-
-def _validate_windows_permissions(installation_path: Path):
-    # GIVEN
-    current_user = getpass.getuser()
-
-    # WHEN
-
-    # THEN
-    assert False
 
 
 @pytest.fixture(scope="session")
@@ -177,7 +134,7 @@ def uninstaller_path():
     if platform.system() == "Darwin":
         uninstaller_path = Path("uninstall.app", "Contents", "MacOS", "installbuilder.sh")
     elif platform.system() == "Windows":
-        uninstaller_path = uninstaller_path.with_suffix("exe")
+        uninstaller_path = uninstaller_path.with_suffix(".exe")
 
     yield uninstaller_path
 
@@ -192,35 +149,51 @@ def test_default_location(installer_path: Path):
     # GIVEN
     default_install_location = Path("~/DeadlineCloudForBlenderSubmitter").expanduser()
     default_pattern = r"Default: (.*)"
-    location = ""
+    location = None
 
     # WHEN
-    help_result = subprocess.run(
-        [installer_path, "--mode", "text", "--help"], check=True, capture_output=True
-    )
+    text_mode = [] if sys.platform == "win32" else ["--mode", "text"]
+    # Since windows doesn't have text mode, it'll pop-up a gui. We use the timeout to ensure it stops
+    try:
+        help_result = subprocess.run(
+            [installer_path, *text_mode, "--help"], capture_output=True, text=True, timeout=5
+        )
+        assert (
+            help_result.returncode == 0
+        ), f"Installer exited with non-zero code: {help_result.returncode}"
+        assert help_result.stdout is not None, "No stdout from --help"
+        help_output = iter(help_result.stdout.splitlines())
+    except subprocess.TimeoutExpired as e:
+        assert e.stdout is not None, "No stdout from --help"
+        # mypy/docs say this should be bytes, but was str?
+        assert isinstance(e.stdout, str)
+        help_output = iter(e.stdout.splitlines())
 
     # THEN
-    assert help_result.returncode == 0
-
-    help_output = iter(help_result.stdout.decode("utf-8").splitlines())
     while (line := next(help_output, None)) is not None:
         if line.strip().startswith("--prefix"):
             location = re.match(default_pattern, next(help_output, "").strip(), flags=re.IGNORECASE)
             break
 
     assert (
-        location
-    ), f"Could not find default install location in help output:\n{help_result.stdout.decode('utf-8')}"
+        location is not None
+    ), f"Could not find default install location in help output:\n{help_result.stdout}"
     if platform.system() != "Windows":
         assert location.group(1) == default_install_location.as_posix()
     else:
-        assert location.group(1) == str(default_install_location())
+        assert str(Path(location.group(1))) == str(default_install_location)
 
 
+@pytest.mark.skipif(
+    os.getenv("CODEBUILD_SRC_DIR") is None,
+    reason="Only installers built with a license will not be evaluation mode",
+)
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="CLI usage for Windows does not make the eval text available"
+)
 def test_did_not_build_with_evaluation_mode(installer_path: Path, tmp_path: Path):
     """Tests to see if there's an evaluation version header from installbuilder.
-    Should never occur in a production build but is fine when building your own for testing.
-    
+
     This is done by launching the installer, exiting before it completes, and checking the output
     does NOT contain a specific line entry. Unfortunately this is makes the test pretty fragile, but
     the behaviour has existed for years. If it exists it's expected to be the second line, but we check
@@ -234,70 +207,178 @@ def test_did_not_build_with_evaluation_mode(installer_path: Path, tmp_path: Path
 
     # WHEN
     proc = subprocess.Popen(
-        [installer_path, "--mode", "text", "--prefix", tmp_path], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+        [installer_path, "--mode", "text", "--prefix", tmp_path],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
     )
-    
+
     try:
         # We want to fail the installer fast so that it doesn't proceed to install with the defaults
         proc.wait(0.5)
-    except subprocess.TimeoutExpired as e:
-        # Example header from installbuilder
-        """----------------------------------------------------------------------------
-Created with an evaluation version of InstallBuilder
-
-Welcome to the AWS Deadline Cloud for ... Submitter Setup Wizard.
-
-----------------------------------------------------------------------------
-"""
-        output = [ proc.stdout.readline().strip() for _ in range(6) ]
+    except subprocess.TimeoutExpired:
+        # expected behaviour due to the above wait happening before the installer finishes
+        pass
     finally:
         proc.terminate()
         proc.kill()
-        
+
     # THEN
+    assert proc.stdout is not None
+    # Example header from installbuilder
+    """----------------------------------------------------------------------------
+    Created with an evaluation version of InstallBuilder
+
+    Welcome to the AWS Deadline Cloud for ... Submitter Setup Wizard.
+
+    ----------------------------------------------------------------------------
+    """
+    output = [proc.stdout.readline().strip() for _ in range(6)]
+    assert output
+
     for line in output:
-        assert eval_text not in line, "Installer was detected to have been built with Evaluation mode"
+        assert (
+            eval_text not in line
+        ), "Installer was detected to have been built with Evaluation mode"
 
 
-@pytest.mark.skipif(platform.system() != "Darwin", reason="Only run on macOS")
-class TestMacOS:
-
+@pytest.mark.skipif(platform.system() == "Windows", reason="Only run on Linux and MacOS")
+class TestLinuxAndMacOS:
     def test_user_permissions(self, user_installation: Path):
         # GIVEN / WHEN / THEN
-        _validate_posix_permissions(user_installation)
+        self._validate_posix_permissions(user_installation)
 
     @pytest.mark.skipif(not _is_admin(), reason="Tests requires admin privileges")
     def test_system_permissions(self, system_installation):
         # GIVEN / WHEN / THEN
-        _validate_posix_permissions(system_installation)
+        self._validate_posix_permissions(system_installation)
 
+    def _has_group_other_write(self, mode: int) -> bool:
+        return bool(mode & (stat.S_IWGRP | stat.S_IWOTH))
 
-@pytest.mark.skipif(platform.system() != "Linux", reason="Only run on Linux")
-class TestLinux:
-    def test_user_permissions(self, user_installation):
-        # GIVEN / WHEN / THEN
-        _validate_posix_permissions(user_installation)
+    def _has_user_read_write(self, mode: int) -> bool:
+        return bool(mode & (stat.S_IRUSR | stat.S_IWUSR))
 
-    @pytest.mark.skipif(not _is_admin(), reason="Tests requires admin privileges")
-    def test_system_permissions(self, system_installation):
-        # GIVEN / WHEN / THEN
-        _validate_posix_permissions(system_installation)
+    def _has_user_group_other_execute(self, mode: int) -> bool:
+        return bool(mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+
+    def _validate_posix_permissions(self, installation_path: Path):
+        # assists mypy type checking to ignore this on Windows
+        assert sys.platform != "win32"
+        # GIVEN
+        current_user = getpass.getuser()
+
+        # WHEN
+        bad_perms: defaultdict[Path, list[str]] = defaultdict(list)
+        for entry in [installation_path, *installation_path.rglob("*")]:
+            mode = stat.S_IMODE(entry.stat().st_mode)
+            if self._has_group_other_write(mode):
+                bad_perms[entry].append("should not have group/other write permissions")
+            if not self._has_user_read_write(mode):
+                bad_perms[entry].append("should have user read/write permissions")
+            if entry.is_dir() and not self._has_user_group_other_execute(mode):
+                bad_perms[entry].append("is a directory and should have execute permissions")
+            if entry.owner() != current_user:  # type: ignore
+                bad_perms[entry].append(f"is not owned by the '{current_user}'")
+
+        error_message = [f"Found {len(bad_perms)} instance(s) of incorrect permissions"]
+        for i, entry in enumerate(bad_perms):
+            fmted_reasons = "\n  - ".join(reason for reason in bad_perms[entry])
+            error_message.append(
+                f"{i+1}. ({stat.S_IMODE(entry.stat().st_mode):o}) '{Path(*entry.parts[len(installation_path.parts):])!s:>3}'\n"
+                f"  - {fmted_reasons}"
+            )
+
+        # THEN
+        assert len(bad_perms) == 0, "\n".join(error_message)
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only run on Windows")
 class TestWindows:
     def test_user_permissions(self, user_installation):
         # GIVEN / WHEN / THEN
-        _validate_windows_permissions(user_installation)
+        self._verify_windows_least_privilege(user_installation)
 
     @pytest.mark.skipif(not _is_admin(), reason="Tests requires admin privileges")
     def test_system_permissions(self, system_installation):
         # GIVEN / WHEN / THEN
-        _validate_windows_permissions(system_installation)
+        self._verify_windows_least_privilege(system_installation)
+
+    def _verify_windows_least_privilege(self, installation_path: Path):
+        # assists mypy type checking to ignore this on non-Windows
+        assert sys.platform == "win32"
+        import ntsecuritycon
+        import win32con
+        import win32file
+        import win32security
+
+        # GIVEN
+        windows_user = getpass.getuser()
+        builtin_admin_group_sid, _, _ = win32security.LookupAccountName(None, "Administrators")
+        user_sid, _, _ = win32security.LookupAccountName(None, windows_user)
+
+        # WHEN
+        bad_perms: defaultdict[Path, list[str]] = defaultdict(list)
+        for path in [installation_path, *installation_path.rglob("*")]:
+            sd = win32security.GetFileSecurity(
+                str(path),
+                win32con.DACL_SECURITY_INFORMATION | win32con.OWNER_SECURITY_INFORMATION,
+            )
+
+            # Verify ownership
+            owner_sid = sd.GetSecurityDescriptorOwner()
+            if _is_admin():
+                if builtin_admin_group_sid != owner_sid:
+                    bad_perms[path].append(
+                        f"Expected to be owned by 'Administrators' but got '{win32security.LookupAccountSid(None, owner_sid)}'"
+                    )
+            elif user_sid != owner_sid:
+                bad_perms[path].append(
+                    f"Expected to be owned by '{win32security.LookupAccountSid(None, user_sid)}' but got '{win32security.LookupAccountSid(None, owner_sid)}'"
+                )
+
+            # Verify all ACEs
+            dacl = sd.GetSecurityDescriptorDacl()
+            if dacl.GetAceCount() != 3:
+                bad_perms[path].append(f"Expected 3 ACEs, but was {dacl.GetAceCount()}")
+
+            for ace in [dacl.GetAce(i) for i in range(dacl.GetAceCount())]:
+                _ace_info, mask, sid = ace
+                ace_type, ace_flags = _ace_info
+
+                if sid not in [builtin_admin_group_sid, user_sid]:
+                    continue
+                if ace_type != ntsecuritycon.ACCESS_ALLOWED_ACE_TYPE:
+                    bad_perms[path].append(
+                        f"Expected ACE type {ntsecuritycon.ACCESS_ALLOWED_ACE_TYPE} but got {ace_type}"
+                    )
+                if (
+                    path.is_dir()
+                    and ace_flags
+                    != ntsecuritycon.OBJECT_INHERIT_ACE | ntsecuritycon.CONTAINER_INHERIT_ACE
+                ):
+                    bad_perms[path].append(
+                        f"Expected inheritance in ACE to be {ntsecuritycon.OBJECT_INHERIT_ACE | ntsecuritycon.CONTAINER_INHERIT_ACE} but got {ace_flags}"
+                    )
+                if mask != win32file.FILE_ALL_ACCESS:
+                    bad_perms[path].append(
+                        f"Expected only FILE_ALL_ACCESS ({win32file.FILE_ALL_ACCESS}) ACEs but got {mask}"
+                    )
+
+        error_message = [f"Found {len(bad_perms)} instance(s) of incorrect permissions"]
+        for i, path in enumerate(bad_perms):
+            fmted_reasons = "\n  - ".join(reason for reason in bad_perms[path])
+            error_message.append(
+                f"{i+1}. '{Path(*path.parts[len(installation_path.parts):])!s:>3}'\n"
+                f"  - {fmted_reasons}"
+            )
+
+        # THEN
+        assert len(bad_perms) == 0, "\n".join(error_message)
 
 
 class TestUserInstall:
-
     def test_install(self, user_installation: Path):
         # GIVEN / WHEN / THEN
         _validate_files(user_installation)
@@ -305,24 +386,24 @@ class TestUserInstall:
     def test_uninstall(self, per_test_user_installation: Path, uninstaller_path: Path):
         # GIVEN / WHEN
         result = subprocess.run(
-            [per_test_user_installation / uninstaller_path, "--mode", "unattended"], check=True
+            [per_test_user_installation / uninstaller_path, "--mode", "unattended"]
         )
 
         # THEN
         assert result.returncode == 0
-        assert not per_test_user_installation.exists()
 
-        # The uninstall process will return before the uninstallation is complete.
-        # If necessary, wait for up to one minute before timing out.
-        # for _ in range(6):
-        #     if not per_test_user_installation.exists():
-        #         break
-        #     time.sleep(10)
+        # On Windows, the uninstall process will return before the uninstallation is complete.
+        # If necessary, wait for up to 1 minute 40 seconds before timing out.
+        if platform.system() == "Windows":
+            for _ in range(10):
+                if not per_test_user_installation.exists():
+                    break
+                time.sleep(10)
+        assert not per_test_user_installation.exists()
 
 
 @pytest.mark.skipif(not _is_admin(), reason="Tests requires admin privileges")
 class TestSystemInstall:
-
     def test_install(self, system_installation: Path):
         # GIVEN / WHEN / THEN
         _validate_files(system_installation)
@@ -332,16 +413,119 @@ class TestSystemInstall:
         result = subprocess.run(
             [per_test_system_installation / uninstaller_path, "--mode", "unattended"],
             capture_output=True,
-            check=True,
+            text=True,
         )
 
         # THEN
         assert result.returncode == 0
 
-        # The uninstall process will return before the uninstallation is complete.
-        # If necessary, wait for up to one minute before timing out.
-        # for _ in range(6):
-        #     if not per_test_system_installation.exists():
-        #         break
-        #     time.sleep(10)
+        # On Windows, the uninstall process will return before the uninstallation is complete.
+        # If necessary, wait for up to 1 minute 40 seconds before timing out.
+        if platform.system() == "Windows":
+            for _ in range(10):
+                if not per_test_system_installation.exists():
+                    break
+                time.sleep(10)
         assert not per_test_system_installation.exists()
+
+
+@pytest.mark.skipif(
+    os.getenv("CODEBUILD_SRC_DIR") is None,
+    reason="Only installers built internally will be signed",
+)
+class TestVerifySigning:
+    @pytest.mark.skipif(platform.system() != "Windows", reason="Only run on Windows")
+    def test_windows_signing(self, installer_path):
+        """Assumes that the Windows SDK is installed so we can find signtool:
+            C:/Program Files*/Windows Kits/*/bin/*/x64/signtool.exe
+        Example success:
+
+            Index  Algorithm  Timestamp
+            ========================================
+            0      sha256     Authenticode
+
+            Successfully verified: C:\*.exe
+
+        Example failure:
+
+            Index  Algorithm  Timestamp
+            ========================================
+            SignTool Error: No signature found.
+
+            Number of errors: 1
+        """
+        # GIVEN
+        signtool = next(glob.iglob("C:/Program Files*/Windows Kits/*/bin/*/x64/signtool.exe"), None)
+        assert signtool, "signtool not found in expected location"
+
+        # WHEN
+        result = subprocess.run(
+            [signtool, "verify", "/pa", installer_path], capture_output=True, text=True
+        )
+
+        # THEN
+        assert "SignTool Error:" not in result.stderr, "signtool did not succeed"
+        assert result.returncode == 0
+        assert "Successfully verified:" in result.stdout
+
+    @pytest.mark.skipif(platform.system() != "Linux", reason="Only run on Linux")
+    def test_linux_signing(self, installer_path):
+        """Assumes that gpg is on the PATH, and that the public key has already been imported"""
+        # GIVEN
+        gpg = shutil.which("gpg")
+        assert gpg, "gpg not found in PATH"
+
+        # WHEN
+        result = subprocess.run(
+            [gpg, "--verify", f"{installer_path}.sig", installer_path],
+            capture_output=True,
+            text=True,
+        )
+
+        # THEN
+        assert (
+            "Can't check signature: No public key" not in result.stderr
+        ), "Missing Public Key in keyring"
+        assert result.returncode == 0, "Code signing validation failed"
+        # gpg shoves the success message into stderr for some reason
+        # This matches what customers are told to do via the public docs:
+        #   https://docs.aws.amazon.com/deadline-cloud/latest/userguide/submitter.html#verify-installer
+        assert (
+            'Good signature from "AWS Deadline Cloud <aws-deadline@amazon.com>"' in result.stderr
+        ), "Signing succeeded, but did not match docs instructions"
+
+    @pytest.mark.skipif(platform.system() != "Darwin", reason="Only run on MacOS")
+    def test_macos_signing(self, installer_path):
+        """Tests that the relevant files are signed on MacOS. Assumes codesign and spectl are on the PATH
+
+        Leverages codesign to check signing, and spctl to verify that MacOS does not complain about running it
+        """
+        # GIVEN
+        codesign = shutil.which("codesign")
+        spctl = shutil.which("spctl")
+        assert codesign, "codesign not found in PATH"
+        assert spctl, "spctl not found in PATH"
+
+        # WHEN / THEN
+        codesign_result = subprocess.run(
+            [codesign, "--verify", "--deep", "--verbose", installer_path],
+            capture_output=True,
+            text=True,
+        )
+        assert (
+            "code object is not signed at all" not in codesign_result.stdout
+        ), "The file is not signed"
+        assert codesign_result.returncode == 0
+
+        # WHEN / THEN
+        spctl_result = subprocess.run(
+            [spctl, "--verbose", "--assess", "--type", "execute", installer_path],
+            capture_output=True,
+            text=True,
+        )
+        assert (
+            "rejected" not in spctl_result.stderr
+        ), "MacOS will not allow this file to be executed"
+        assert spctl_result.returncode == 0
+        # success message is sent to stderr
+        assert "accepted" in spctl_result.stderr, "File was not accepted by MacOS"

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -217,18 +217,46 @@ def test_default_location(installer_path: Path):
         assert location.group(1) == str(default_install_location())
 
 
-def test_does_not_use_evaluation_mode(installer_path: Path, tmp_path: Path):
-    """Ensure the installer is not built with the evaluation mode of the installer software"""
+def test_did_not_build_with_evaluation_mode(installer_path: Path, tmp_path: Path):
+    """Tests to see if there's an evaluation version header from installbuilder.
+    Should never occur in a production build but is fine when building your own for testing.
+    
+    This is done by launching the installer, exiting before it completes, and checking the output
+    does NOT contain a specific line entry. Unfortunately this is makes the test pretty fragile, but
+    the behaviour has existed for years. If it exists it's expected to be the second line, but we check
+    the top few lines that we're guaranteed to have in case it shifts a tiny bit.
+
+    note: tmp_path is leveraged to ensure that the user's install is not messed with if the test does not
+    behave correctly."""
     # GIVEN
     eval_text = r"Created with an evaluation version of InstallBuilder"
+    output = []
 
     # WHEN
-    result = subprocess.run(
-        [installer_path, "--mode", "text", "--prefix", tmp_path], check=True, capture_output=True
+    proc = subprocess.Popen(
+        [installer_path, "--mode", "text", "--prefix", tmp_path], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
     )
+    
+    try:
+        # We want to fail the installer fast so that it doesn't proceed to install with the defaults
+        proc.wait(0.5)
+    except subprocess.TimeoutExpired as e:
+        # Example header from installbuilder
+        """----------------------------------------------------------------------------
+Created with an evaluation version of InstallBuilder
 
+Welcome to the AWS Deadline Cloud for ... Submitter Setup Wizard.
+
+----------------------------------------------------------------------------
+"""
+        output = [ proc.stdout.readline().strip() for _ in range(6) ]
+    finally:
+        proc.terminate()
+        proc.kill()
+        
     # THEN
-    assert eval_text not in result.stdout.decode("utf-8")
+    for line in output:
+        assert eval_text not in line, "Installer was detected to have been built with Evaluation mode"
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only run on macOS")

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -1,11 +1,25 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from collections import defaultdict
+import getpass
 import os
-import subprocess
-import time
 from pathlib import Path
+import stat
+import subprocess
 import platform
 
 import pytest
+
+
+def _is_admin() -> bool:
+    if platform.system() != "Windows":
+        return os.getuid() == 0
+
+    import ctypes
+
+    try:
+        return ctypes.windll.shell32.IsUserAnAdmin() == 1
+    except Exception:
+        return False
 
 
 @pytest.fixture(scope="session")
@@ -22,7 +36,7 @@ def installer_path():
     elif platform.system() == "Windows":
         path = path.format(platform="windows-x64", ext="exe")
     elif platform.system() == "Linux":
-        path = path.format(platform="linux-x64", ext="run")
+        path = path.format(platform="linux", ext="run")
 
     if not os.path.isfile(path):
         raise FileNotFoundError(f"Installer not found at '{path}'")
@@ -33,38 +47,36 @@ def installer_path():
     yield Path(path).absolute()
 
 
-@pytest.fixture(scope="function")
-def installed(installer_path, tmp_path):
+def _run_installer(installer_path, install_scope, installation_path) -> Path:
     args = [
         installer_path,
         "--mode",
         "unattended",
         "--installscope",
-        "user",
+        install_scope,
         "--prefix",
-        tmp_path,
+        installation_path,
         "--enable-components",
         "deadline_cloud_for_blender",
     ]
     result = subprocess.run(args, check=True)
     assert result.returncode == 0
 
-    yield Path(tmp_path)
+    return Path(installation_path)
 
 
-def test_install(installed: Path):
-    # GIVEN / WHEN
+def _validate_files(installation_path: Path) -> None:
     if platform.system() == "Darwin":
         uninstaller = "uninstall.app"
     elif platform.system() == "Windows":
         uninstaller = "uninstall.exe"
     else:
         uninstaller = "uninstall"
-    python_dir = installed / "python"
+    python_dir = installation_path / "python"
 
     # THEN
-    top_level_dir = [f.name for f in installed.iterdir()]
-    assert python_dir.name in top_level_dir
+    top_level_dir = [f.name for f in installation_path.iterdir()]
+    assert "python" in top_level_dir
     assert "installer_version.txt" in top_level_dir
     assert uninstaller in top_level_dir
 
@@ -72,6 +84,7 @@ def test_install(installed: Path):
     module_dir = [f.name for f in (python_dir / "modules").iterdir()]
     assert "deadline" in module_dir
     assert "qtpy" in module_dir
+    assert "xxhash" in module_dir
 
     # Check the blender module is here and there's a version file
     addon_dir = [
@@ -80,27 +93,177 @@ def test_install(installed: Path):
     assert "_version.py" in addon_dir
 
 
-def test_uninstall(installed: Path):
+def _has_group_other_write(mode: int) -> bool:
+    return bool(mode & (stat.S_IWGRP | stat.S_IWOTH))
+
+
+def _has_user_read_write(mode: int) -> bool:
+    return bool(mode & (stat.S_IRUSR | stat.S_IWUSR))
+
+
+def _has_user_group_other_execute(mode: int) -> bool:
+    return bool(mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+
+
+def _validate_posix_permissions(installation_path: Path):
     # GIVEN
-    if platform.system() == "Darwin":
-        uninstaller_path = os.path.join(
-            installed, "uninstall.app", "Contents", "MacOS", "installbuilder.sh"
-        )
-    elif platform.system() == "Windows":
-        uninstaller_path = os.path.join(installed, "uninstall.exe")
-    else:
-        uninstaller_path = os.path.join(installed, "uninstall")
+    current_user = getpass.getuser()
 
     # WHEN
-    result = subprocess.run([uninstaller_path, "--mode", "unattended"], check=True)
+    bad_perms: defaultdict[Path, list[str]] = defaultdict(list)
+    for entry in [installation_path, *installation_path.rglob("*")]:
+        mode = stat.S_IMODE(entry.stat().st_mode)
+        if _has_group_other_write(mode):
+            bad_perms[entry].append("should not have group/other write permissions")
+        if not _has_user_read_write(mode):
+            bad_perms[entry].append("should have user read/write permissions")
+        if entry.is_dir() and not _has_user_group_other_execute(mode):
+            bad_perms[entry].append("is a directory and should have execute permissions")
+        if entry.owner() != current_user:
+            bad_perms[entry].append(f"is not owned by the '{current_user}'")
+
+    error_message = [f"Found {len(bad_perms)} instance(s) of incorrect permissions"]
+    for i, entry in enumerate(bad_perms):
+        fmted_reasons = "\n  - ".join(reason for reason in bad_perms[entry])
+        error_message.append(
+            f"{i+1}. ({stat.S_IMODE(entry.stat().st_mode):o}) '{str(Path(*entry.parts[len(user_installation.parts):])):>3}'\n"
+            f"  - {fmted_reasons}"
+        )
 
     # THEN
-    assert result.returncode == 0
+    assert len(bad_perms) == 0, "\n".join(error_message)
 
-    # The uninstall process will return before the uninstallation is complete.
-    # If necessary, wait for up to one minute before timing out.
-    for _ in range(6):
-        if not installed.exists():
-            break
-        time.sleep(10)
-    assert not installed.exists()
+
+def _validate_windows_permissions(installation_path: Path):
+    # GIVEN
+    current_user = getpass.getuser()
+
+    # WHEN
+
+    # THEN
+    assert False
+
+
+@pytest.fixture(scope="session")
+def user_installation(installer_path, tmp_path_factory):
+    """Used for tests that just want to assert some facts around the install but do not modify"""
+    tmp_path = tmp_path_factory.mktemp("install")
+    yield _run_installer(installer_path, "user", tmp_path)
+
+
+@pytest.fixture(scope="session")
+def system_installation(installer_path, tmp_path_factory):
+    """Used for tests that just want to assert some facts around the install but do not modify"""
+    tmp_path = tmp_path_factory.mktemp("install")
+    yield _run_installer(installer_path, "system", tmp_path)
+
+
+@pytest.fixture(scope="function")
+def per_test_user_installation(installer_path, tmp_path):
+    """Used for tests that modify the installation"""
+    yield _run_installer(installer_path, "user", tmp_path)
+
+
+@pytest.fixture(scope="function")
+def per_test_system_installation(installer_path, tmp_path):
+    """Used for tests that modify the installation"""
+    yield _run_installer(installer_path, "system", tmp_path)
+
+
+@pytest.fixture(scope="function")
+def uninstaller_path():
+    uninstaller_path = Path("uninstall")
+    if platform.system() == "Darwin":
+        uninstaller_path = Path("uninstall.app", "Contents", "MacOS", "installbuilder.sh")
+    elif platform.system() == "Windows":
+        uninstaller_path = uninstaller_path.with_suffix("exe")
+
+    yield uninstaller_path
+
+
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Only run on macOS")
+class TestMacOS:
+
+    def test_user_permissions(self, user_installation: Path):
+        # GIVEN / WHEN / THEN
+        _validate_posix_permissions(user_installation)
+
+    @pytest.mark.skipif(not _is_admin(), reason="Tests requires admin privileges")
+    def test_system_permissions(self, system_installation):
+        # GIVEN / WHEN / THEN
+        _validate_posix_permissions(system_installation)
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason="Only run on Linux")
+class TestLinux:
+    def test_user_permissions(self, user_installation):
+        # GIVEN / WHEN / THEN
+        _validate_posix_permissions(user_installation)
+
+    @pytest.mark.skipif(not _is_admin(), reason="Tests requires admin privileges")
+    def test_system_permissions(self, system_installation):
+        # GIVEN / WHEN / THEN
+        _validate_posix_permissions(system_installation)
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Only run on Windows")
+class TestWindows:
+    def test_user_permissions(self, user_installation):
+        # GIVEN / WHEN / THEN
+        _validate_windows_permissions(user_installation)
+
+    @pytest.mark.skipif(not _is_admin(), reason="Tests requires admin privileges")
+    def test_system_permissions(self, system_installation):
+        # GIVEN / WHEN / THEN
+        _validate_windows_permissions(system_installation)
+
+
+class TestUserInstall:
+
+    def test_install(self, user_installation: Path):
+        # GIVEN / WHEN / THEN
+        _validate_files(user_installation)
+
+    def test_uninstall(self, per_test_user_installation: Path, uninstaller_path: Path):
+        # GIVEN / WHEN
+        result = subprocess.run(
+            [per_test_user_installation / uninstaller_path, "--mode", "unattended"], check=True
+        )
+
+        # THEN
+        assert result.returncode == 0
+        assert not per_test_user_installation.exists()
+
+        # The uninstall process will return before the uninstallation is complete.
+        # If necessary, wait for up to one minute before timing out.
+        # for _ in range(6):
+        #     if not per_test_user_installation.exists():
+        #         break
+        #     time.sleep(10)
+
+
+@pytest.mark.skipif(not _is_admin(), reason="Tests requires admin privileges")
+class TestSystemInstall:
+
+    def test_install(self, system_installation: Path):
+        # GIVEN / WHEN / THEN
+        _validate_files(system_installation)
+
+    def test_uninstall(self, per_test_system_installation: Path, uninstaller_path: Path):
+        # GIVEN / WHEN
+        result = subprocess.run(
+            [per_test_system_installation / uninstaller_path, "--mode", "unattended"],
+            capture_output=True,
+            check=True,
+        )
+
+        # THEN
+        assert result.returncode == 0
+
+        # The uninstall process will return before the uninstallation is complete.
+        # If necessary, wait for up to one minute before timing out.
+        # for _ in range(6):
+        #     if not per_test_system_installation.exists():
+        #         break
+        #     time.sleep(10)
+        assert not per_test_system_installation.exists()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We need automated tests that validate the installer behaves as expected. Default values, file permissions, evaluation mode, signing, etc.

### What was the solution? (How)

Add them!

### What is the impact of this change?

We've got automated tests that help ensure we're not breaking anything!

### How was this change tested?

These tests are not currently run automatically in GitHub, so I performed this iteration cycle across the different operating systems
```
hatch run build-installer --platform <osx|...> --local-dev-build --install-builder-location <...>
hatch run test-installer
```

I've ran through these tests a few times on each operating system.

#### Please run the integration tests and paste the results below

N/A

### Was this change documented?

N/A

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*