### PR TITLE
ci: Use reusable workflows for Publish and Build Installers

### DIFF
--- a/.github/workflows/build_installers.yml
+++ b/.github/workflows/build_installers.yml
@@ -3,7 +3,7 @@ name: "Build Installers"
 on:
   workflow_dispatch:
     inputs:
-      branch:
+      tag:
         required: true
         type: string
 
@@ -11,24 +11,9 @@ jobs:
   BuildLinuxInstaller:
     if: (github.repository == 'aws-deadline/deadline-cloud-for-blender')
     name: Build Linux Installer
-    runs-on: ubuntu-latest
-    environment: ${{inputs.environment}}
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_INSTALLER_ROLE }}
-          aws-region: us-west-2
-          mask-aws-account-id: true
-          role-duration-seconds: 3600
-        
-      - name: Build Linux Installer
-        uses: aws-actions/aws-codebuild-run-build@v1
-        with:
-          project-name: deadline-cloud-for-blender-LinuxInstaller
-          source-version-override: ${{inputs.branch}}
-          hide-cloudwatch-logs: true
+    uses: aws-deadline/.github/.github/workflows/reusable_build_installers.yml@mainline
+    secrets: inherit
+    with:
+      environment: ${{inputs.environment}}
+      tag: ${{inputs.tag}}
+      oses: "['Linux']"

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: aws-deadline/.github/.github/workflows/reusable_publish.yml@mainline
+    uses: aws-deadline/.github/.github/workflows/reusable_publish_v2.yml@mainline
     secrets: inherit
   # PyPI does not support reusable workflows yet
   # # See https://github.com/pypi/warehouse/issues/11096


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We have new reusable workflows that are standard for the organization's repositories.

### What was the solution? (How)
Edit workflows to use `reusable_publish_v2.yml` and `reusable_build_installers.yml`.

### What is the impact of this change?
Synchronized process for publishing releases and building installers.

### How was this change tested?
Tested in my fork with the references to `aws-deadline` replaced with `miabatta`.

#### Please run the integration tests and paste the results below
No submitter/adaptor code changes, n/a

### Was this change documented?
n/a

### Is this a breaking change?
nop

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*