### PR TITLE
chore(installer): Refactor to use new build scripts

### DIFF
--- a/.github/workflows/build_installers.yml
+++ b/.github/workflows/build_installers.yml
@@ -3,17 +3,35 @@ name: "Build Installers"
 on:
   workflow_dispatch:
     inputs:
-      tag:
+      os:
+        required: true
+        default: Linux
+        type: choice
+        options:
+        - Linux
+        - Windows
+      ref_type:
+        required: true
+        default: tags
+        type: choice
+        options:
+        - tags
+        - heads
+
+      ref:
         required: true
         type: string
+        default: mainline
 
 jobs:
-  BuildLinuxInstaller:
+  BuildInstaller:
     if: (github.repository == 'aws-deadline/deadline-cloud-for-blender')
-    name: Build Linux Installer
+    name: Build Installer
     uses: aws-deadline/.github/.github/workflows/reusable_build_installers.yml@mainline
     secrets: inherit
     with:
       environment: ${{inputs.environment}}
-      tag: ${{inputs.tag}}
-      oses: "['Linux']"
+      ref_type: ${{inputs.ref_type}}
+      ref: ${{inputs.ref}}
+      oses: "['${{inputs.os}}']"
+      project_name: "deadline-cloud-for-blender"

--- a/depsBundle.sh
+++ b/depsBundle.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# This script is called in a shell subprocess.
+# If editing this script, please see the security considerations
+# of this invocation method:
+# https://docs.python.org/3/library/subprocess.html#security-considerations
 set -xeuo pipefail
 
 python3 depsBundle.py

--- a/hatch.toml
+++ b/hatch.toml
@@ -6,6 +6,7 @@ pre-install-commands = [
 [envs.default.scripts]
 sync = "pip install -r requirements-testing.txt"
 test = "pytest --cov-config pyproject.toml {args:test/unit}"
+test-installer = "pytest --no-cov {args:test/installer} -vvv"
 typing = "mypy {args:src test}"
 style = [
   "ruff check {args:.}",
@@ -19,8 +20,7 @@ lint = [
   "style",
   "typing",
 ]
-build-installer = "python {root}/scripts/build_installer.py --dcc-name blender --dcc-installer-file {root}/installer/DeadlineCloudForBlenderSubmitter.xml {args:}"
-test-installer = "pytest --no-cov {args:test/installer} -vvv"
+
 build-addon = "python scripts/build_addon.py {args}"
 
 [[envs.all.matrix]]
@@ -29,6 +29,9 @@ python = ["3.9", "3.10", "3.11", "3.12"]
 [envs.default.env-vars]
 SKIP_BOOTSTRAP_TEST_RESOURCES="True"
 DEADLINE_ENABLE_DEVELOPER_OPTIONS="True"
+
+[envs.installer.scripts]
+build-installer = "python {root}/scripts/build_installer_cli.py --installer-source-path {root}/installer/DeadlineCloudForBlenderSubmitter.xml {args:}"
 
 [envs.codebuild.scripts]
 build = "hatch build"

--- a/installer/DeadlineCloudForBlenderSubmitter.xml
+++ b/installer/DeadlineCloudForBlenderSubmitter.xml
@@ -134,7 +134,7 @@
 
     <componentList>
         <include>
-            <file>components/deadline-cloud-for-blender.xml</file>
+            <file>../install_builder/deadline-cloud-for-blender.xml</file>
         </include>
     </componentList>
 

--- a/pipeline/build_installer.ps1
+++ b/pipeline/build_installer.ps1
@@ -1,0 +1,3 @@
+$ErrorActionPreference = "Stop"
+
+hatch run installer:build-installer @args

--- a/pipeline/build_installer.sh
+++ b/pipeline/build_installer.sh
@@ -2,8 +2,4 @@
 # Set the -e option
 set -e
 
-pip install --upgrade pip
-pip install --upgrade hatch
-
-# This script is specifically for non-dev builds, so it requires the prod arguments.
-hatch run build-installer --platform $1 --install-builder-license-file $2 --install-builder-s3-bucket $3
+hatch run installer:build-installer $@

--- a/pipeline/test_installer.ps1
+++ b/pipeline/test_installer.ps1
@@ -1,0 +1,3 @@
+$ErrorActionPreference = "Stop"
+
+hatch run test-installer

--- a/pipeline/test_installer.sh
+++ b/pipeline/test_installer.sh
@@ -2,6 +2,4 @@
 # Set the -e option
 set -e
 
-pip install --upgrade pip
-pip install --upgrade hatch
 hatch run test-installer

--- a/scripts/build_installer.py
+++ b/scripts/build_installer.py
@@ -1,341 +1,199 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-"""Script to create platform-specific Deadline submission installers"""
-import argparse
+"""Script to create platform-specific Deadline Client installers using InstallBuilder."""
+
 import os
 import platform
-import shutil
-import stat
 import subprocess
+import sys
+import shutil
 import tempfile
 from datetime import datetime
+from typing import Optional
 from pathlib import Path
-from typing import List, NamedTuple, Optional
 
-# If the InstallBuilder version is being changed, please ensure the archives are in a "flattened" structure.
-#
-# The InstallBuilder archives listed below must be in a "flattened" file structure, where the
-# actual install files are at the root of the archive. The structure of the root of the archive
-# should contain the following: (relevant output from `ls -l`)
-# drwxr-xr-x autoupdate
-# drwxr-xr-x bin
-# drwxr-xr-x demo
-# drwxr-xr-x docs
-# drwxr-xr-x output
-# drwxr-xr-x paks
-# drwxr-xr-x projects
-# drwxr-xr-x tools
-# -rwx------ uninstall (.app folder on Mac, .exe on Windows)
-#
-# Since the BitRock license ("license.xml" file) needs to be put at the root of the InstallBuilder
-# installation folder, having a flattened structure makes this location consistent across platforms.
-# See https://installbuilder.com/docs/installbuilder-userguide/_installation_and_getting_started.html
-#
-# For example, the InstallBuilder 19.8.0 archives originally had the installation files one folder deeper
-# from the root of the archive for Windows and Linux:
-# - Windows: <archive-root>/BitRock InstallBuilder Professional 19.8.0/<files>
-# - Linux: <archive-root>/installbuilder-19.8.0/<files>
-# - Mac: <archive-root>/<files>
-# In this case, the Windows and Linux archives were changed to be "flattened" like the Mac one above.
-INSTALL_BUILDER = {
-    "archive": "install_builder/VMware-InstallBuilder-Professional-linux.tar.gz",
-    "command": Path("bin") / "builder",
-}
+from common import EvaluationBuildError, run
+from find_installbuilder import InstallBuilderSelection
 
-# This is derived from <installerFilename> in DeadlineCloudForBlenderSubmitter.xml
+# This is derived from <installerFilename> in installer/DeadlineCloudClient.xml
 # See "Supported Platforms" table in https://releases.installbuilder.com/installbuilder/docs/installbuilder-userguide.html
-INSTALLER_FILENAME_TEMPLATE = "DeadlineCloudForBlenderSubmitter-{platform}-installer.{ext}"
-
-# This is the directory containing the InstallBuilder root .xml component.
-# All file paths in the InstallBuilder component files are relative to this directory
-INSTALL_BUILDER_PROJECT_ROOT = Path(__file__).absolute().parent.parent / "install_builder"
-INSTALLER_ROOT = Path(__file__).absolute().parent.parent / "installer"
-INSTALLER_TEMPLATE = "DeadlineCloudForBlenderSubmitter.xml"
+INSTALLER_FILENAMES = {
+    "Windows": "DeadlineCloudForBlenderSubmitter-windows-x64-installer.exe",
+    "Linux": "DeadlineCloudForBlenderSubmitter-linux-x64-installer.run",
+    "MacOS": "DeadlineCloudForBlenderSubmitter-osx-installer.app",
+}
 EVALUATION_VERSION_STRING = "Built with an evaluation version of InstallBuilder"
 
 
-class DccSubmitter(NamedTuple):
+def setup_install_builder(
+    workdir: Path,
+    install_builder_location: Optional[Path],
+    license_file_path: Optional[Path],
+    install_builder_s3_bucket: Optional[str] = None,
+    install_builder_s3_key: Optional[str] = None,
+) -> Path:
     """
-    A structure representing the parameters for integrating a DCC submitter into the InstallBuilder
-    project.
+    Ensure installbuilder is installed in some way and return the path
+    to the installation directory.
+    The method of installing/finding installbuilder is based on the inputs:
+        - If `install_builder_location` is provided, look for an installbuilder installation at that path
+        - Else if `install_builder_s3_bucket` is provided, attempt to download and unpack install builder from that bucket
+        - Else search for it at the default installation path (handy for dev mode)
     """
-
-    name: str
-    """
-    The name of the DCC application this submitter is for.
-    """
-
-    @property
-    def componentName(self) -> str:
-        """
-        The component name that corresponds to a subdirectory of 'components' subdir
-        of the InstallBuilder project file's directory. By convention, this should
-        match the submitter's repository name.
-        """
-        return f"deadline-cloud-for-{self.name}"
-
-
-class EvaluationBuildError(Exception):
-    """
-    Raised when an evaluation build of InstallBuilder is detected where it should not be used.
-    """
-
-    pass
-
-
-def download_from_s3(bucket_name: str, key: str, output_folder: str) -> Path:
-    dest_path = Path(output_folder) / Path(key).name
-    print(f"Downloading {key} from s3:\\\\{bucket_name}")
-    import boto3
-
-    s3 = boto3.client("s3")
-    s3.download_file(bucket_name, key, dest_path)
-    return dest_path
-
-
-def _add_write_perms(func, path, exc_info) -> None:
-    """
-    Used as an error callback in `shutil.rmtree` to address an AccessDenied error that occurs on Windows.
-    If a directory fails to delete, attempt to add write permissions to it and try again.
-    Re-raise the error if it persists.
-    """
-
-    if not os.access(path, os.W_OK):
-        os.chmod(path, stat.S_IWUSR)
-        func(path)
+    if install_builder_location is not None:
+        selection = InstallBuilderSelection.from_path(install_builder_location)
+    elif install_builder_s3_bucket is not None:
+        selection = InstallBuilderSelection.from_s3(
+            install_builder_s3_bucket, workdir, install_builder_s3_key
+        )
     else:
-        raise
+        selection = InstallBuilderSelection.from_search()
+
+    install_builder_path = selection.resolve_install_builder_installation(workdir)
+
+    if platform.system() == "Windows":
+        binary_name = "builder.exe"
+    else:
+        binary_name = "builder"
+
+    if (
+        not install_builder_path.is_dir()
+        or not (install_builder_path / "bin" / binary_name).is_file()
+    ):
+        raise FileNotFoundError(
+            f"InstallBuilder path '{install_builder_path}' must be a directory containing 'bin/{binary_name}'."
+        )
+
+    if license_file_path is not None:
+        shutil.copy(license_file_path, install_builder_path / "license.xml")
+
+    return install_builder_path
 
 
 def build_installer(
     workdir: Path,
-    license_file: str,
+    component_file_path: Path,
     install_builder_location: Path,
-    platform: str,
-    local_dev_build: bool,
-    s3bucket: Optional[str],
+    installer_platform: str,
+    dev: bool,
 ) -> Path:
-    install_builder_config = INSTALL_BUILDER
-    if not local_dev_build:
-        install_builder_archive = download_from_s3(
-            s3bucket, install_builder_config["archive"], workdir
-        )
-        shutil.unpack_archive(install_builder_archive, workdir)
-        install_builder_path = workdir
-    else:
-        install_builder_path = install_builder_location
-
-    if not Path(install_builder_path).is_dir():
+    """
+    Actually build the installer
+    """
+    if install_builder_location is None:
         raise FileNotFoundError(
-            f"InstallBuilder path '{str(install_builder_path)}' must be a directory containing 'bin/builder'."
+            "Could not find a default InstallBuilder path. Please specify one with '--install-builder-location'."
         )
 
-    if license_file and not local_dev_build:
-        shutil.copy(license_file, Path(workdir) / "license.xml")
+    if not install_builder_location.is_dir():
+        raise FileNotFoundError(
+            f"InstallBuilder path '{install_builder_location}' must be a directory containing 'bin/builder'."
+        )
 
-    install_builder = install_builder_path / install_builder_config["command"]
-    out_dir = Path(workdir) / "out"
-    installer_version = os.getenv("INSTALLER_VERSION") if not local_dev_build else "00000000"
-    date = datetime.today().date()
+    if installer_platform == "Linux":
+        installbuilder_platform = "linux-x64"
+    elif installer_platform == "MacOS":
+        installbuilder_platform = "osx"
+    elif installer_platform == "Windows":
+        installbuilder_platform = "windows-x64"
+    else:
+        raise ValueError(f"Unknown platform '{installer_platform}'")
 
-    print("Running Install Builder...")
     try:
-        output = subprocess.run(
-            [
-                install_builder,
-                "build",
-                INSTALLER_ROOT / INSTALLER_TEMPLATE,
-                platform,
-                "--setvars",
-                f"project.outputDirectory={out_dir}",
-                f"project.version={installer_version[:8]}-{date}",
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
+        if platform.system() == "Windows":
+            # `shell=True` is necessary here to run on Windows.
+            # Please see the security considerations of this flag if editing the script or its invocation:
+            # https://docs.python.org/3/library/subprocess.html#security-considerations
+            deps_bundle_output = subprocess.run(
+                "depsBundle.sh", check=True, shell=True, capture_output=True
+            )
+        else:
+            deps_bundle_output = subprocess.run("./depsBundle.sh", check=True, capture_output=True)
+        print(deps_bundle_output.stdout.decode("utf-8"))
     except subprocess.CalledProcessError as e:
-        print(f"Encountered an error when running: {e.output}")
+        print(f"Error when bundling dependencies: {e.stdout.decode('utf-8')}")
         raise
-    print(
-        f"{'-'*30}\nBegin Install Builder Output\n{'-'*30}\n"
-        f"{output.stdout}"
-        f"{'-'*30}\nEnd Install Builder Output\n{'-'*30}\n"
+
+    install_builder_cli = install_builder_location / "bin" / "builder"
+    out_dir = workdir / "out"
+    installer_version = os.getenv("INSTALLER_VERSION") if not dev else "00000000"
+    if installer_version is None:
+        raise ValueError("INSTALLER_VERSION environment variable must be set.")
+    output = run(
+        [
+            install_builder_cli,
+            "build",
+            str(component_file_path),
+            installbuilder_platform,
+            "--setvars",
+            f"project.outputDirectory={out_dir}",
+            f"project.version={installer_version[:8]}-{datetime.today().date()}",
+        ]
+    )
+    sys.stdout.write(
+        f"{'-' * 30}\nBegin Install Builder Output\n{'-' * 30}\n"
+        f"{output}\n"
+        f"{'-' * 30}\nEnd Install Builder Output\n{'-' * 30}\n"
     )
 
-    if (
-        EVALUATION_VERSION_STRING in output.stdout
-        and not local_dev_build
-        and license_file is not None
-    ):
+    if EVALUATION_VERSION_STRING in output and not dev:
+        raise EvaluationBuildError("InstallBuilder was detected using an evaluation version.")
+    elif dev and EVALUATION_VERSION_STRING not in output:
         raise EvaluationBuildError(
-            "InstallBuilder was detected using an evaluation version, which is only permitted in local dev builds."
-        )
-    elif local_dev_build and EVALUATION_VERSION_STRING not in output.stdout:
-        print(
-            "WARNING: InstallBuilder was not detected using an evaluation version when running a dev build. "
+            "InstallBuilder was not detected using an evaluation version when running a dev build. "
             "This could indicate that the error messaging when using an evaluation version has changed.\n"
             "Please check the InstallBuilder logs to confirm if the error messaging has changed from "
-            f"'{EVALUATION_VERSION_STRING}' and update the install_builder.py script accordingly."
+            f"'{EVALUATION_VERSION_STRING}' and update the build_installer.py script accordingly."
         )
     return out_dir
 
 
-class RequiredArg(NamedTuple):
-    """
-    Structure to represent a required CLI argument. Used to provide better error messaging.
-    """
+def main(
+    dev: bool,
+    install_builder_location: Optional[Path],
+    install_builder_license_path: Optional[Path],
+    install_builder_s3_bucket: Optional[str],
+    install_builder_s3_key: Optional[str],
+    output_dir: Optional[Path],
+    installer_platform: str,
+    installer_source_path: Path,
+) -> None:
+    with tempfile.TemporaryDirectory() as wd:
+        workdir = Path(wd)
+        print(f"cwd: {os.getcwd()}")
+        print(f"working directory: {str(workdir)}")
 
-    argument: str
-    attr: str
-
-
-def main(args: argparse.Namespace) -> None:
-
-    if not args.local_dev_build:
-        missing_args = []
-        for required_arg in prod_required_args:
-            if getattr(args, required_arg.attr) is None:
-                missing_args.append(required_arg.argument)
-        if missing_args:
-            parser.error(
-                "the following arguments are required for non-dev builds: "
-                f"{', '.join(missing_args)}\n"
-            )
-    else:
-        if os.environ.get("CODEBUILD_BUILD_ID") is not None:
-            parser.error("--local-dev-build cannot be used when running in CodeBuild.")
-    with tempfile.TemporaryDirectory() as workdir:
-        print(f"cwd: {Path.cwd()}")
-        print(f"working directory: {workdir})")
-        components_dir = INSTALLER_ROOT / "components"
-        components_dir.mkdir(exist_ok=True)
-
-        if components_dir.exists():
-            shutil.rmtree(components_dir, onerror=_add_write_perms)
-        shutil.copytree(INSTALL_BUILDER_PROJECT_ROOT, components_dir)
-
-        bundle_file = Path(shutil.copy("depsBundle.sh", f"{components_dir}/depsBundle.sh"))
-        shutil.copy("depsBundle.py", f"{components_dir}/depsBundle.py")
-        bundle_file.chmod(bundle_file.stat().st_mode | stat.S_IEXEC)
-        try:
-            subprocess.run(["bash", bundle_file], check=True)
-        except subprocess.CalledProcessError as e:
-            print(f"Encountered the following error when bundling dependencies: {e.output}")
-            raise
-
-        try:
-            installer_dir = build_installer(
-                workdir=workdir,
-                license_file=(
-                    args.install_builder_license_file
-                    if args.install_builder_license_file != "NO_LICENSE"
-                    else None
-                ),
-                install_builder_location=(
-                    args.install_builder_location
-                    if args.install_builder_location
-                    else INSTALL_BUILDER["archive"]
-                ),
-                platform=args.platform,
-                local_dev_build=args.local_dev_build,
-                s3bucket=args.install_builder_s3_bucket,
-            )
-        except Exception as e:
-            if args.cleanup:
-                shutil.rmtree(components_dir, onerror=_add_write_perms)
-            raise e
-
-        # There are three possible extensions for built installers, depending on the platform.
-        # See `platform_exec_suffix` in https://releases.installbuilder.com/installbuilder/docs/installbuilder-userguide.html#built_in_variables
-        if args.platform == "osx":
-            installer_extension = "app"
-        elif args.platform.startswith("windows"):
-            installer_extension = "exe"
-        else:
-            installer_extension = "run"
-        installer_filename = INSTALLER_FILENAME_TEMPLATE.format(
-            platform=args.platform, ext=installer_extension
+        installbuilder_path = setup_install_builder(
+            workdir=workdir,
+            install_builder_location=install_builder_location,
+            license_file_path=install_builder_license_path,
+            install_builder_s3_bucket=install_builder_s3_bucket,
+            install_builder_s3_key=install_builder_s3_key,
         )
-        installer_path = Path(installer_dir) / installer_filename
+        installer_dir = build_installer(
+            workdir=workdir,
+            component_file_path=installer_source_path,
+            install_builder_location=installbuilder_path,
+            dev=dev,
+            installer_platform=installer_platform,
+        )
+
+        installer_filename = INSTALLER_FILENAMES[installer_platform]
+        installer_path = installer_dir / installer_filename
 
         # The macOS .app installer will always be a directory, not a file.
         # Other OS installers will be files.
-        if not installer_path.is_dir() if args.platform == "osx" else not installer_path.is_file():
+        if (
+            not installer_path.is_dir()
+            if installer_platform == "MacOS"
+            else not installer_path.is_file()
+        ):
             raise FileNotFoundError(
                 f"Expected installer file {installer_filename} not found in {installer_dir}.\n"
-                f"Found:\n\t{os.linesep.join(installer_dir.iterdir())}"
+                f"Found:\n\t{os.linesep.join([str(i) for i in installer_dir.iterdir()])}"
             )
 
         output_path = installer_filename
-        if args.output_dir:
-            args.output_dir.mkdir(exist_ok=True)
-            output_path = args.output_dir / output_path
-        if platform.system() == "Darwin" and Path(output_path).exists():
-            shutil.rmtree(output_path, onerror=prod_required_args)
+        if output_dir:
+            output_dir.mkdir(exist_ok=True)
+            output_path = output_dir / output_path
         shutil.move(installer_path, output_path)
-
-        if args.cleanup:
-            shutil.rmtree(components_dir, onerror=_add_write_perms)
-            print(f"Deleted build directory: {components_dir}")
-
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description=__doc__)
-    prod_required_args: List[RequiredArg] = []
-
-    parser.add_argument(
-        "--dcc-name", required=True, help="The name of the DCC application this submitter is for."
-    )
-    parser.add_argument(
-        "--dcc-installer-file", required=True, help="The main installer file for the DCC"
-    )
-
-    parser.add_argument(
-        "--local-dev-build",
-        action=argparse.BooleanOptionalAction,
-        help=(
-            "Add this argument when running a development build. This will use an evaluation copy of InstallBuilder and not require a license."
-        ),
-    )
-    parser.add_argument(
-        "--install-builder-s3-bucket",
-        help="The name of S3 Bucket that contains Install Builder. Required for non-local builds.",
-    )  # Required for non-local builds
-    prod_required_args.append(
-        RequiredArg("--install-builder-s3-bucket", "install_builder_s3_bucket")
-    )
-
-    parser.add_argument(
-        "--install-builder-location",
-        help="The InstallBuilder location, containing 'bin/builder'. Required for local dev builds.",
-        type=Path,
-    )
-
-    parser.add_argument(
-        "--install-builder-license-file",
-        help="The path to the file containing the InstallBuilder license. This can be set to NO_LICENSE to skip downloading the license.",
-    )  # Required for non-local builds
-    prod_required_args.append(
-        RequiredArg("--install-builder-license-file", "install_builder_license_file")
-    )
-
-    parser.add_argument(
-        "--no-cleanup",
-        dest="cleanup",
-        action="store_false",
-        help="Do not delete the build components folder after completion.",
-    )
-    parser.add_argument(
-        "--platform",
-        required=True,
-        help="The platform to build an installer for. See the InstallBuilder documentation for a full list of allowed platforms.",
-    )
-    parser.add_argument(
-        "--output-dir",
-        required=False,
-        default=None,
-        type=Path,
-        help="The directory to create the installer in. Default is the current directory.",
-    )
-    args = parser.parse_args()
-    main(args)

--- a/scripts/build_installer_cli.py
+++ b/scripts/build_installer_cli.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+import os
+import platform
+
+import click
+
+from pathlib import Path
+from typing import Any, Callable, Iterable, Optional
+from build_installer import main
+
+
+def _snake_to_kebab(name: str) -> str:
+    return name.replace("_", "-")
+
+
+def _combine_callbacks(
+    *callbacks: Callable[[click.Context, click.Option, Any], Any],
+) -> Callable[[click.Context, click.Option, Any], Any]:
+    """
+    Combine multiple click callbacks which will then subsequently be called in order
+    """
+
+    def _combined_callback(ctx: click.Context, param: click.Option, value: Any):
+        for callback in callbacks:
+            value = callback(ctx, param, value)
+        return value
+
+    return _combined_callback
+
+
+def _mutually_exclude(others: Iterable[str]) -> Callable[[click.Context, click.Option, Any], Any]:
+    """
+    Creates a callback wich raises an error if this argument is specified and any of other specified arguments are also specified
+    """
+
+    def _callback(ctx: click.Context, param: click.Option, value: Any) -> Any:
+        if value:
+            for other in others:
+                if ctx.params.get(other):
+                    raise click.BadParameter(
+                        f"Cannot specify both --{param.name} and --{_snake_to_kebab(other)}"
+                    )
+        return value
+
+    return _callback
+
+
+def _dependency(dependency: str) -> Callable[[click.Context, click.Option, Any], Any]:
+    """
+    Creates a callback that raises an error if this argument is specified but an given argument it depends on is not
+    """
+
+    def _callback(ctx: click.Context, param: click.Option, value: Any) -> Any:
+        if value:
+            if not ctx.params.get(dependency):
+                raise click.BadParameter(
+                    f"Must specify --{_snake_to_kebab(dependency)} when specifying --{param.name}"
+                )
+        return value
+
+    return _callback
+
+
+def _require_if_false_or_unspecified(
+    other: str,
+) -> Callable[[click.Context, click.Option, Any], Any]:
+    """
+    Creates a callback that raises an error if this argument is not specified and a given argument is either False or unspecified
+    """
+
+    def _callback(ctx: click.Context, param: click.Option, value: Any) -> Any:
+        if not ctx.params.get(other):
+            if not value:
+                raise click.BadParameter(
+                    f"Must specify --{param.name} when --{_snake_to_kebab(other)} is not specified"
+                )
+        return value
+
+    return _callback
+
+
+def _require_if_all_false_or_unspecified(
+    others: Iterable[str],
+) -> Callable[[click.Context, click.Option, Any], Any]:
+    """
+    Creates a callback that raises an error if this argument is not specified and all of the given arguments are either False or unspecified
+    """
+
+    def _callback(ctx: click.Context, param: click.Option, value: Any) -> Any:
+        if value is not None:
+            return value
+        for other in others:
+            if ctx.params.get(other):
+                return value
+        all_params = [f"--{_snake_to_kebab(other)}" for other in others]
+        name = _snake_to_kebab(param.name if param.name else "")
+        raise click.BadParameter(
+            f"Must specify --{name} when none of {', '.join(all_params)} are specified"
+        )
+
+    return _callback
+
+
+def _current_platform_as_default(
+    _ctx: click.Context, _param: click.Option, value: Optional[str]
+) -> str:
+    """
+    A callback that dynamically sets the default to the current platform
+    """
+    if value is None:
+        value = platform.system()
+        if value == "Darwin":
+            return "MacOS"
+    return value
+
+
+def _not_allowed_if_env_var_set(
+    env_var_name: str,
+) -> Callable[[click.Context, click.Option, Any], Any]:
+    """
+    Creates a callback that raises an error if the argument was specified and a given environment variable is set
+    """
+
+    def _callback(_ctx: click.Context, param: click.Option, value: Any) -> Any:
+        if value and os.environ.get(env_var_name) is not None:
+            raise click.BadParameter(f"--{param.name} cannot be used when {env_var_name} is set.")
+        return value
+
+    return _callback
+
+
+@click.command()
+@click.option(
+    "--install-builder-path",
+    type=Path,
+    callback=_mutually_exclude(["install_builder_s3_bucket"]),
+    help="The path to the InstallBuilder builder executable",
+)
+@click.option(
+    "--install-builder-s3-bucket",
+    type=str,
+    callback=_combine_callbacks(
+        _require_if_false_or_unspecified("local_dev"), _mutually_exclude(["install_builder_path"])
+    ),
+    help="The name of S3 Bucket that contains an archive of an install of InstallBuilder",
+)
+@click.option(
+    "--install-builder-s3-key",
+    type=str,
+    callback=_dependency("install_builder_s3_bucket"),
+    help="The key of the archive of an install of InstallBuilder",
+)
+@click.option(
+    "--install-builder-license-path",
+    type=Path,
+    callback=_require_if_all_false_or_unspecified(["dev", "local_dev"]),
+    help="The path to the InstallBuilder license file",
+)
+@click.option(
+    "--dev",
+    is_flag=True,
+    callback=_mutually_exclude(["local_dev"]),
+    help="If specified, build in dev mode",
+)
+@click.option(
+    "--local-dev",
+    is_flag=True,
+    callback=_combine_callbacks(
+        _not_allowed_if_env_var_set("CODEBUILD_BUILD_ID"), _mutually_exclude(["dev"])
+    ),
+    help="If specified, build in local dev mode",
+)
+@click.option(
+    "--platform",
+    type=click.Choice(["Windows", "MacOS", "Linux"], case_sensitive=False),
+    callback=_combine_callbacks(
+        _require_if_false_or_unspecified("local_dev"), _current_platform_as_default
+    ),
+    help="The platform to build the installer for. Default is the current platform",
+)
+@click.option(
+    "--output-dir",
+    type=Path,
+    callback=_require_if_false_or_unspecified("local_dev"),
+    help="The directory to output the installer to",
+)
+@click.option(
+    "--installer-source-path",
+    type=Path,
+    help="The path to the installer source xml file",
+)
+def cli(
+    install_builder_path: Optional[Path],
+    install_builder_s3_bucket: Optional[str],
+    install_builder_s3_key: Optional[str],
+    install_builder_license_path: Optional[Path],
+    dev: bool,
+    local_dev: bool,
+    platform: str,
+    output_dir: Optional[Path],
+    installer_source_path: Path,
+) -> None:
+    cli_body(
+        install_builder_path,
+        install_builder_s3_bucket,
+        install_builder_s3_key,
+        install_builder_license_path,
+        dev,
+        local_dev,
+        platform,
+        output_dir,
+        installer_source_path,
+    )
+
+
+def cli_body(
+    install_builder_path: Optional[Path],
+    install_builder_s3_bucket: Optional[str],
+    install_builder_s3_key: Optional[str],
+    install_builder_license_path: Optional[Path],
+    dev: bool,
+    local_dev: bool,
+    platform: str,
+    output_dir: Optional[Path],
+    installer_source_path: Path,
+) -> None:
+    """
+    Separate from the command function so we can mock the body out
+    when testing the cli arguments
+    """
+    main(
+        dev or local_dev,
+        install_builder_path,
+        install_builder_license_path,
+        install_builder_s3_bucket,
+        install_builder_s3_key,
+        output_dir,
+        platform,
+        installer_source_path,
+    )
+
+
+if __name__ == "__main__":
+    cli()

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+import subprocess
+import sys
+
+
+class BadExitCodeError(Exception):
+    pass
+
+
+class EvaluationBuildError(Exception):
+    pass
+
+
+class UnsupportedOSError(Exception):
+    pass
+
+
+def run(cmd, cwd=None, env=None, echo=True):
+    if echo:
+        sys.stdout.write(f"Running cmd: {cmd}\n")
+    kwargs = {
+        "shell": True,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+    }
+    if isinstance(cmd, list):
+        kwargs["shell"] = False
+    if cwd is not None:
+        kwargs["cwd"] = cwd
+    if env is not None:
+        kwargs["env"] = env
+    p = subprocess.Popen(cmd, **kwargs)
+    stdout, stderr = p.communicate()
+    output = stdout.decode("utf-8") + stderr.decode("utf-8")
+    if p.returncode != 0:
+        raise BadExitCodeError(f"Bad rc ({p.returncode}) for cmd '{cmd}': {output}")
+    return output

--- a/scripts/find_installbuilder.py
+++ b/scripts/find_installbuilder.py
@@ -1,0 +1,184 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+import platform
+import re
+import shutil
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Optional, Union
+
+import boto3
+
+from common import UnsupportedOSError
+
+
+_INSTALL_BUILDER_ARCHIVE_FILENAME = {
+    "Windows": "VMware-InstallBuilder-Professional-windows.tar.gz",
+    "Linux": "VMware-InstallBuilder-Professional-linux.tar.gz",
+}
+
+
+@dataclass
+class _InstallBuilderPathSelection:
+    path: Path
+
+
+@dataclass
+class _InstallBuilderS3Selection:
+    bucket: str
+    key: str
+    dest_path: Path
+
+
+@dataclass
+class InstallBuilderSelection:
+    selection: Optional[Union[_InstallBuilderPathSelection, _InstallBuilderS3Selection]]
+
+    def resolve_install_builder_installation(self, workdir: Path) -> Path:
+        if self.selection is None:
+            return _get_default_installbuilder_location()
+        elif isinstance(self.selection, _InstallBuilderPathSelection):
+            return self.selection.path
+        elif isinstance(self.selection, _InstallBuilderS3Selection):
+            filename = self.selection.key.split("/")[-1]
+            s3 = boto3.client("s3")
+            dest = self.selection.dest_path / filename
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            s3.download_file(self.selection.bucket, self.selection.key, str(dest))
+            unpack_dest = workdir / filename.split(".tar.gz")[0]
+            shutil.unpack_archive(dest, unpack_dest)
+            dest.unlink()
+            return unpack_dest
+        else:
+            raise ValueError(f"Unknown selection type: {type(self.selection)}")
+
+    @staticmethod
+    def from_s3(bucket_name: str, dest_path: Path, key: Optional[str] = None):
+        if key is None:
+            if platform.system() in _INSTALL_BUILDER_ARCHIVE_FILENAME:
+                resolved_key = (
+                    f"install_builder/{_INSTALL_BUILDER_ARCHIVE_FILENAME[platform.system()]}"
+                )
+            else:
+                raise UnsupportedOSError(f"Unsupported OS: {platform.system()}")
+        else:
+            resolved_key = key
+        return InstallBuilderSelection(
+            _InstallBuilderS3Selection(bucket_name, resolved_key, dest_path)
+        )
+
+    @staticmethod
+    def from_path(path: Path):
+        return InstallBuilderSelection(_InstallBuilderPathSelection(path))
+
+    @staticmethod
+    def from_search():
+        return InstallBuilderSelection(None)
+
+
+@dataclass
+class _InstallBuilderSearchConfig:
+    parent_path: Path
+    install_directory_name_regex: str
+
+    def get_install_directory_regex(self) -> re.Pattern:
+        return re.compile(self.install_directory_name_regex)
+
+
+_INSTALL_BUILDER_SEARCH_CONFIGS = {
+    "Linux": _InstallBuilderSearchConfig(Path("/opt"), r"^installbuilder-(\d+)\.(\d+)\.(\d+)$"),
+    "Darwin": _InstallBuilderSearchConfig(
+        Path("/Applications"),
+        r"^InstallBuilder (Professional|Enterprise|For (?:Windows|OS X)) (\d+)\.(\d+)\.(\d+)$",
+    ),
+    "Windows": _InstallBuilderSearchConfig(
+        Path("C:\\Program Files"),
+        r"^InstallBuilder (Professional|Enterprise|For (?:Windows|OS X)) (\d+)\.(\d+)\.(\d+)$",
+    ),
+}
+
+
+class _InstallBuilderEdition(Enum):
+    PROFESSIONAL = "Professional"
+    ENTERPRISE = "Enterprise"
+    WINDOWS = "For Windows"
+    OSX = "For OS X"
+    LINUX = ""
+
+    @staticmethod
+    def from_str(edition: str):
+        if edition == "Professional":
+            return _InstallBuilderEdition.PROFESSIONAL
+        elif edition == "Enterprise":
+            return _InstallBuilderEdition.ENTERPRISE
+        elif edition == "For Windows":
+            return _InstallBuilderEdition.WINDOWS
+        elif edition == "For OS X":
+            return _InstallBuilderEdition.OSX
+        elif edition == "":
+            return _InstallBuilderEdition.LINUX
+        else:
+            raise ValueError(f"Unknown edition: {edition}")
+
+
+@dataclass
+class _Semver:
+    major: int
+    minor: int
+    patch: int
+
+
+@dataclass
+class _InstallBuilderInstallation:
+    path: Path
+    version: _Semver
+    edition: _InstallBuilderEdition
+
+    @staticmethod
+    def _sort_key(install: "_InstallBuilderInstallation") -> tuple[int, int, int, int]:
+        # Prioritize Enterprise, then Professional, then any other edition
+        edition_priority = {
+            _InstallBuilderEdition.ENTERPRISE: 0,
+            _InstallBuilderEdition.PROFESSIONAL: 1,
+        }
+        edition_value = edition_priority.get(install.edition, 2)
+        return (
+            -install.version.major,
+            -install.version.minor,
+            -install.version.patch,
+            edition_value,
+        )
+
+
+def _get_default_installbuilder_location() -> Path:
+    """
+    Returns the default location where InstallBuilder Professional will be installed depending on the platform.
+    """
+    if platform.system() not in _INSTALL_BUILDER_SEARCH_CONFIGS:
+        raise UnsupportedOSError(f"Unsupported OS for building installer: {platform.system()}")
+    config = _INSTALL_BUILDER_SEARCH_CONFIGS[platform.system()]
+    candidates = []
+    for install_dir in config.parent_path.iterdir():
+        if install_dir.is_dir():
+            match = config.get_install_directory_regex().match(install_dir.name)
+            if match and (install_dir / "bin" / "builder").is_file():
+                if platform.system() == "Linux":
+                    version_offset = 0
+                else:
+                    version_offset = 1
+                installation = _InstallBuilderInstallation(
+                    install_dir,
+                    _Semver(
+                        int(match.group(1 + version_offset)),
+                        int(match.group(2 + version_offset)),
+                        int(match.group(3 + version_offset)),
+                    ),
+                    _InstallBuilderEdition.from_str(
+                        match.group(1) if platform.system() != "Linux" else ""
+                    ),
+                )
+                candidates.append(installation)
+    candidates.sort(key=_InstallBuilderInstallation._sort_key)
+    if not candidates:
+        raise FileNotFoundError("Could not find a default InstallBuilder path.")
+    return candidates[0].path


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We have newer, more robust build scripts for building installers!

### What was the solution? (How)
Adapt and add the new scripts to Blender.

### What is the impact of this change?
Installer building is cleaner and can be easily generalized to other repositories.

### How was this change tested?
Ran the existing installer unit tests with the new build scripts to check for regressions on Windows and Linux.

#### Please run the integration tests and paste the results below
N/A

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below
```
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.11.9, pytest-8.3.5, pluggy-1.5.0 -- /local/home/miabatta/.local/share/hatch/env/virtual/deadline-cloud-for-blender/YGJunDkE/installer/bin/python
cachedir: .pytest_cache
rootdir: /local/home/miabatta/bea/bealine-client-forks/deadline-cloud-for-blender
configfile: pyproject.toml
plugins: xdist-3.6.1, cov-6.0.0
1 worker [13 items]    
scheduling tests via LoadScheduling

test/installer/test_installer.py::test_default_location 
[gw0] [  7%] PASSED test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
[gw0] [ 15%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
[gw0] [ 23%] PASSED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
[gw0] [ 30%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestWindows::test_user_permissions 
[gw0] [ 38%] SKIPPED test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::TestWindows::test_system_permissions 
[gw0] [ 46%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions 
test/installer/test_installer.py::TestUserInstall::test_install 
[gw0] [ 53%] PASSED test/installer/test_installer.py::TestUserInstall::test_install 
test/installer/test_installer.py::TestUserInstall::test_uninstall 
[gw0] [ 61%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall 
test/installer/test_installer.py::TestSystemInstall::test_install 
[gw0] [ 69%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_install 
test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw0] [ 76%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uninstall 
test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw0] [ 84%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw0] [ 92%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw0] [100%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing 

============================================================================================== slowest 5 durations ==============================================================================================
6.36s setup    test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
6.24s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
0.78s call     test/installer/test_installer.py::TestUserInstall::test_uninstall
0.58s call     test/installer/test_installer.py::test_default_location
0.13s call     test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
========================================================================================= 4 passed, 9 skipped in 14.38s =========================================================================================
```
```

```

### Was this change documented?
n/a

### Is this a breaking change?
nop

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*