### PR TITLE
chore: loosen numpy pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ AWS Deadline Cloud for Blender is a python package that allows users to create [
 This library requires:
 
 1. Blender 3.6 or greater,
-1. Python 3.10 or higher; and
+1. Python 3.9 to 3.12; and
 1. Linux, Windows, or a macOS operating system.
    * Adaptor only supports Linux and macOS
 

--- a/requirements-integ-testing.txt
+++ b/requirements-integ-testing.txt
@@ -1,3 +1,3 @@
 pillow == 11.1.*
-numpy == 2.2.*
+numpy == 2.*
 openjd-cli == 0.7.*


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Dependabot was trying to downgrade Numpy. Only reason I can think of is that we support Python 3.9 still, but Numpy 2.2.* removes 3.9 support
### What was the solution? (How)
I'm loosening the pin for Numpy to just the major version. We are only using numpy for the integ tests and just to do some simple array comparisons which seems unlikely to break between minor versions.

Also updated the README to reflect our supported versions correctly
### What is the impact of this change?
Less dependabot confusion
### How was this change tested?
Ran the integ tests locally

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*