### PR TITLE
chore: add environment input to build installers workflow

### DIFF
--- a/.github/workflows/build_installers.yml
+++ b/.github/workflows/build_installers.yml
@@ -17,11 +17,15 @@ on:
         options:
         - tags
         - heads
-
       ref:
         required: true
         type: string
         default: mainline
+      environment:
+        required: true
+        type: choice
+        options:
+        - mainline
 
 jobs:
   BuildInstaller:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The build installers workflow was failing to grab credentials in my testing.
### What was the solution? (How)
Needed to add the environment input to select the mainline environment for the secret to be found. This matches what deadline-cloud uses https://github.com/aws-deadline/deadline-cloud/blob/mainline/.github/workflows/build_installer.yml#L23
### What is the impact of this change?
Installer builds work
### How was this change tested?
Tested against my own backend setup and verified the workflow could get the credentials
#### Please run the integration tests and paste the results below
No
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*