### PR TITLE
chore: make depsBundle work on Windows

### DIFF
--- a/depsBundle.py
+++ b/depsBundle.py
@@ -19,6 +19,12 @@ SUPPORTED_PLATFORMS = [
     "macosx_11_0_arm64",
 ]
 NATIVE_DEPENDENCIES = ["xxhash"]
+FINAL_BUNDLE_NAMES = [
+    "deadline_cloud_for_blender_submitter-deps-windows.zip",
+    "deadline_cloud_for_blender_submitter-deps-linux.zip",
+    "deadline_cloud_for_blender_submitter-deps-macos-intel.zip",
+    "deadline_cloud_for_blender_submitter-deps-macos-arm64.zip",
+]
 
 
 def _get_project_dict() -> dict[str, Any]:
@@ -134,13 +140,25 @@ def _zip_bundle(base_env: Path, zip_path: Path) -> None:
     shutil.make_archive(str(zip_path.with_suffix("")), "zip", str(base_env))
 
 
-def _copy_zip_to_destination(zip_path: Path) -> None:
+def _copy_zip_to_destination(zip_path: Path) -> Path:
     dependency_bundle_dir = Path.cwd() / "dependency_bundle"
     dependency_bundle_dir.mkdir(exist_ok=True)
     zip_destination = dependency_bundle_dir / zip_path.name
     if zip_destination.exists():
         zip_destination.unlink()
     shutil.copy(str(zip_path), str(zip_destination))
+
+    return zip_destination
+
+
+def _remove_old_bundles(zip_destination: Path):
+    for file in FINAL_BUNDLE_NAMES:
+        Path(zip_destination.parent / file).unlink(missing_ok=True)
+
+
+def _rename_bundles_to_final_names(zip_destination: Path):
+    for file in FINAL_BUNDLE_NAMES:
+        shutil.copy(zip_destination, zip_destination.parent / file)
 
 
 def build_deps_bundle() -> None:
@@ -154,7 +172,9 @@ def build_deps_bundle() -> None:
         zip_path = _get_zip_path(working_directory, project_dict)
         _zip_bundle(base_env, zip_path)
         print(list(working_directory.glob("*")))
-        _copy_zip_to_destination(zip_path)
+        zip_destination = _copy_zip_to_destination(zip_path)
+        _remove_old_bundles(zip_destination)
+        _rename_bundles_to_final_names(zip_destination)
 
 
 if __name__ == "__main__":

--- a/depsBundle.sh
+++ b/depsBundle.sh
@@ -8,13 +8,3 @@
 set -xeuo pipefail
 
 python3 depsBundle.py
-
-rm -f dependency_bundle/deadline_cloud_for_blender_submitter-deps-windows.zip
-rm -f dependency_bundle/deadline_cloud_for_blender_submitter-deps-linux.zip
-rm -f dependency_bundle/deadline_cloud_for_blender_submitter-deps-macos-intel.zip
-rm -f dependency_bundle/deadline_cloud_for_blender_submitter-deps-macos-arm64.zip
-
-cp dependency_bundle/deadline_cloud_for_blender_submitter-deps.zip dependency_bundle/deadline_cloud_for_blender_submitter-deps-windows.zip
-cp dependency_bundle/deadline_cloud_for_blender_submitter-deps.zip dependency_bundle/deadline_cloud_for_blender_submitter-deps-linux.zip
-cp dependency_bundle/deadline_cloud_for_blender_submitter-deps.zip dependency_bundle/deadline_cloud_for_blender_submitter-deps-macos-intel.zip
-cp dependency_bundle/deadline_cloud_for_blender_submitter-deps.zip dependency_bundle/deadline_cloud_for_blender_submitter-deps-macos-arm64.zip

--- a/scripts/build_installer.py
+++ b/scripts/build_installer.py
@@ -3,7 +3,6 @@
 
 import os
 import platform
-import subprocess
 import sys
 import shutil
 import tempfile
@@ -13,6 +12,12 @@ from pathlib import Path
 
 from common import EvaluationBuildError, run
 from find_installbuilder import InstallBuilderSelection
+
+# Add the top level to the path for now. We can move depsBundle.py
+# to the scripts directory when we have more confidence that
+# it isnt' needed in the root directory anymore.
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from depsBundle import build_deps_bundle
 
 # This is derived from <installerFilename> in installer/DeadlineCloudClient.xml
 # See "Supported Platforms" table in https://releases.installbuilder.com/installbuilder/docs/installbuilder-userguide.html
@@ -98,20 +103,7 @@ def build_installer(
     else:
         raise ValueError(f"Unknown platform '{installer_platform}'")
 
-    try:
-        if platform.system() == "Windows":
-            # `shell=True` is necessary here to run on Windows.
-            # Please see the security considerations of this flag if editing the script or its invocation:
-            # https://docs.python.org/3/library/subprocess.html#security-considerations
-            deps_bundle_output = subprocess.run(
-                "depsBundle.sh", check=True, shell=True, capture_output=True
-            )
-        else:
-            deps_bundle_output = subprocess.run("./depsBundle.sh", check=True, capture_output=True)
-        print(deps_bundle_output.stdout.decode("utf-8"))
-    except subprocess.CalledProcessError as e:
-        print(f"Error when bundling dependencies: {e.stdout.decode('utf-8')}")
-        raise
+    build_deps_bundle()
 
     install_builder_cli = install_builder_location / "bin" / "builder"
     out_dir = workdir / "out"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
`bundleDeps.sh` doesn't work on Windows

### What was the solution? (How)
Instead of using a shell script, put all of the functionality into `bundleDeps.py` so that it can run in a cross platform way. Then we can import it in `build_installers.py` instead of running a subprocess. We're keeping `bundleDeps.py` in the top level directory for now in case it's still needed to be there. We can move it to `scripts/` and remove the path append once we verify that 

### What is the impact of this change?
Can build installers programmatically on Windows.

### How was this change tested?
Ran `hatch installer:build-installer` on my Mac and verified the installer was built as expected. I also ran it through Windows CodeBuild and verified that installers were built as expected.

#### Please run the integration tests and paste the results below
This doesn't touch any of the submitter or adaptor code.

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below
N/A

### Was this change documented?
N/A

### Is this a breaking change?
Nope

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*