### PR TITLE
test: let windows installer tests run on containers

### DIFF
--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -305,6 +305,23 @@ class TestWindows:
         # GIVEN / WHEN / THEN
         self._verify_windows_least_privilege(system_installation)
 
+    def _running_in_container(self) -> bool:
+        """
+        Check to see if the cexecsvc service exists and is running
+        to determine if we're running on a container.
+        """
+        # assists mypy type checking to ignore this on non-Windows
+        assert sys.platform == "win32"
+        import win32service
+        import win32serviceutil
+
+        try:
+            service_status = win32serviceutil.QueryServiceStatus("cexecsvc")
+            return service_status[1] == win32service.SERVICE_RUNNING
+        except win32service.error:
+            # Service doesn't exist, not on a container
+            return False
+
     def _verify_windows_least_privilege(self, installation_path: Path):
         # assists mypy type checking to ignore this on non-Windows
         assert sys.platform == "win32"
@@ -315,7 +332,15 @@ class TestWindows:
 
         # GIVEN
         windows_user = getpass.getuser()
-        builtin_admin_group_sid, _, _ = win32security.LookupAccountName(None, "Administrators")
+
+        if self._running_in_container():
+            # The admin group is different when running
+            # in a container.
+            admin_group = "ContainerAdministrator"
+        else:
+            admin_group = "Administrators"
+
+        builtin_admin_group_sid, _, _ = win32security.LookupAccountName(None, admin_group)
         user_sid, _, _ = win32security.LookupAccountName(None, windows_user)
 
         # WHEN
@@ -331,7 +356,7 @@ class TestWindows:
             if _is_admin():
                 if builtin_admin_group_sid != owner_sid:
                     bad_perms[path].append(
-                        f"Expected to be owned by 'Administrators' but got '{win32security.LookupAccountSid(None, owner_sid)}'"
+                        f"Expected to be owned by '{admin_group}' but got '{win32security.LookupAccountSid(None, owner_sid)}'"
                     )
             elif user_sid != owner_sid:
                 bad_perms[path].append(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Installer ownership tests were failing on Windows on Containers

### What was the solution? (How)
The admin group is `ContainerAdministrator` instead of `Administrators` on Windows containers.

### What is the impact of this change?
Tests can run on Windows Containers, and therefore the pipeline.

### How was this change tested?
Ran the tests in CodeBuild. I haven't had a chance to run on a local Windows machine. Will do that will this is being reviewed.

#### Please run the integration tests and paste the results below
Doesn't touch any submitter/adaptor code

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below
N/A

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*