### PR TITLE
test: get correct user for unix installer tests

### DIFF
--- a/.github/workflows/build_installers.yml
+++ b/.github/workflows/build_installers.yml
@@ -10,6 +10,7 @@ on:
         options:
         - Linux
         - Windows
+        - MacOS
       ref_type:
         required: true
         default: tags

--- a/scripts/find_installbuilder.py
+++ b/scripts/find_installbuilder.py
@@ -15,6 +15,7 @@ from common import UnsupportedOSError
 _INSTALL_BUILDER_ARCHIVE_FILENAME = {
     "Windows": "VMware-InstallBuilder-Professional-windows.tar.gz",
     "Linux": "VMware-InstallBuilder-Professional-linux.tar.gz",
+    "Darwin": "VMware-InstallBuilder-Professional-macos.tar.gz",
 }
 
 

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -266,8 +266,11 @@ class TestLinuxAndMacOS:
     def _validate_posix_permissions(self, installation_path: Path):
         # assists mypy type checking to ignore this on Windows
         assert sys.platform != "win32"
+        # pwd is not available on Windows
+        import pwd
+
         # GIVEN
-        current_user = getpass.getuser()
+        current_user = pwd.getpwuid(os.getuid())[0]  # type: ignore
 
         # WHEN
         bad_perms: defaultdict[Path, list[str]] = defaultdict(list)


### PR DESCRIPTION
Related to https://github.com/aws-deadline/deadline-cloud/pull/640

### What was the problem/requirement? (What/Why)
Handful of issues here.
1. The installer test on Unix wasn't getting the user correctly.
2. CodeBuild tests couldn't find InstallBuilder on MacOS
3. The BuildInstaller workflow was missing MacOS

### What was the solution? (How)
1. Instead of using getpass, we're now using pwd and os. Same as the aforementioned deadline-cloud PR
2. Add a MacOS entry to the InstallBuilder selector.
3. Add MacOS to the BuildInstaller workflow.

### What is the impact of this change?
Tests pass correctly. I also checked the workflows to make sure MacOS showed up as an option, I made sure to match it to what the CodeBuild project expects it to be.

### How was this change tested?
Ran the MacOS test locally and the Linux, MacOs, and Windows tests in CodeBuild

#### Please run the integration tests and paste the results below
This doesn't touch anything that integ tests would cover

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below
N/A

### Was this change documented?
N/A

### Is this a breaking change?
N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*