### PR TITLE
chore: Only include the current platform in the deps bundle

### DIFF
--- a/depsBundle.sh
+++ b/depsBundle.sh
@@ -7,4 +7,4 @@
 # https://docs.python.org/3/library/subprocess.html#security-considerations
 set -xeuo pipefail
 
-python3 depsBundle.py
+python3 scripts/depsBundle.py

--- a/install_builder/deadline-cloud-for-blender.xml
+++ b/install_builder/deadline-cloud-for-blender.xml
@@ -56,42 +56,6 @@
         </if>
         <setInstallerVariable name="blender_addondir" value="${blender_installdir}/addons" />
         <setInstallerVariable name="blender_moduledir" value="${blender_installdir}/modules" />
-        <if>
-            <conditionRuleList>
-                <platformTest type="windows" />
-            </conditionRuleList>
-            <actionList>
-                <setInstallerVariable name="blender_deps_platform" value="windows" />
-            </actionList>
-        </if>
-        <if>
-            <conditionRuleList>
-                <platformTest type="linux" />
-            </conditionRuleList>
-            <actionList>
-                <setInstallerVariable name="blender_deps_platform" value="linux" />
-            </actionList>
-        </if>
-        <if>
-            <conditionRuleEvaluationLogic>and</conditionRuleEvaluationLogic>
-            <conditionRuleList>
-                <platformTest type="osx" />
-                <platformTest type="osx-intel" />
-            </conditionRuleList>
-            <actionList>
-                <setInstallerVariable name="blender_deps_platform" value="macos-intel" />
-            </actionList>
-        </if>
-        <if>
-            <conditionRuleEvaluationLogic>and</conditionRuleEvaluationLogic>
-            <conditionRuleList>
-                <platformTest type="osx" />
-                <platformTest negate="1" type="osx-intel" />
-            </conditionRuleList>
-            <actionList>
-                <setInstallerVariable name="blender_deps_platform" value="macos-arm64" />
-            </actionList>
-        </if>
     </readyToInstallActionList>
     <postInstallationActionList>
         <if>
@@ -104,7 +68,7 @@
         </if>
         <unzip>
             <destinationDirectory>${blender_moduledir}</destinationDirectory>
-            <zipFile>${installdir}/tmp/blender_deps/dependency_bundle/deadline_cloud_for_blender_submitter-deps-${blender_deps_platform}.zip</zipFile>
+            <zipFile>${installdir}/tmp/blender_deps/dependency_bundle/deadline_cloud_for_blender_submitter-deps.zip</zipFile>
         </unzip>
         <deleteFile>
             <path>${installdir}/tmp/blender_deps</path>

--- a/scripts/build_installer.py
+++ b/scripts/build_installer.py
@@ -2,7 +2,6 @@
 """Script to create platform-specific Deadline Client installers using InstallBuilder."""
 
 import os
-import platform
 import sys
 import shutil
 import tempfile
@@ -11,12 +10,8 @@ from typing import Optional
 from pathlib import Path
 
 from common import EvaluationBuildError, run
-from find_installbuilder import InstallBuilderSelection
+from find_installbuilder import InstallBuilderSelection, get_builder_exe_name
 
-# Add the top level to the path for now. We can move depsBundle.py
-# to the scripts directory when we have more confidence that
-# it isnt' needed in the root directory anymore.
-sys.path.append(str(Path(__file__).resolve().parent.parent))
 from depsBundle import build_deps_bundle
 
 # This is derived from <installerFilename> in installer/DeadlineCloudClient.xml
@@ -55,17 +50,12 @@ def setup_install_builder(
 
     install_builder_path = selection.resolve_install_builder_installation(workdir)
 
-    if platform.system() == "Windows":
-        binary_name = "builder.exe"
-    else:
-        binary_name = "builder"
-
     if (
         not install_builder_path.is_dir()
-        or not (install_builder_path / "bin" / binary_name).is_file()
+        or not (install_builder_path / "bin" / get_builder_exe_name()).is_file()
     ):
         raise FileNotFoundError(
-            f"InstallBuilder path '{install_builder_path}' must be a directory containing 'bin/{binary_name}'."
+            f"InstallBuilder path '{install_builder_path}' must be a directory containing 'bin/{get_builder_exe_name()}'."
         )
 
     if license_file_path is not None:
@@ -184,7 +174,7 @@ def main(
                 f"Found:\n\t{os.linesep.join([str(i) for i in installer_dir.iterdir()])}"
             )
 
-        output_path = installer_filename
+        output_path = Path(installer_filename)
         if output_dir:
             output_dir.mkdir(exist_ok=True)
             output_path = output_dir / output_path

--- a/scripts/depsBundle.py
+++ b/scripts/depsBundle.py
@@ -12,19 +12,7 @@ from tempfile import TemporaryDirectory
 from typing import Any
 
 SUPPORTED_PYTHON_VERSIONS = ["3.10", "3.11"]
-SUPPORTED_PLATFORMS = [
-    "win_amd64",
-    "manylinux2014_x86_64",
-    "macosx_10_9_x86_64",
-    "macosx_11_0_arm64",
-]
 NATIVE_DEPENDENCIES = ["xxhash"]
-FINAL_BUNDLE_NAMES = [
-    "deadline_cloud_for_blender_submitter-deps-windows.zip",
-    "deadline_cloud_for_blender_submitter-deps-linux.zip",
-    "deadline_cloud_for_blender_submitter-deps-macos-intel.zip",
-    "deadline_cloud_for_blender_submitter-deps-macos-arm64.zip",
-]
 
 
 def _get_project_dict() -> dict[str, Any]:
@@ -33,7 +21,7 @@ def _get_project_dict() -> dict[str, Any]:
             toml_install_pip_args = ["pip", "install", "--target", toml_env, "toml"]
             subprocess.run(toml_install_pip_args, check=True)
             sys.path.insert(0, toml_env)
-            import toml
+            import toml  # type: ignore
         mode = "r"
     else:
         import tomllib as toml
@@ -92,25 +80,20 @@ def _download_native_dependencies(working_directory: Path, base_env: Path) -> li
     ]
     native_dependency_paths = []
     for version in SUPPORTED_PYTHON_VERSIONS:
-        for platform in SUPPORTED_PLATFORMS:
-            native_dependency_path = (
-                working_directory / "native" / f"{version.replace('.', '_')}_{platform}"
-            )
-            native_dependency_paths.append(native_dependency_path)
-            native_dependency_path.mkdir(parents=True)
-            native_dependency_pip_args = [
-                "pip",
-                "install",
-                "--target",
-                str(native_dependency_path),
-                "--platform",
-                platform,
-                "--python-version",
-                version,
-                "--only-binary=:all:",
-                *versioned_native_dependencies,
-            ]
-            subprocess.run(native_dependency_pip_args, check=True)
+        native_dependency_path = working_directory / "native" / f"{version.replace('.', '_')}"
+        native_dependency_paths.append(native_dependency_path)
+        native_dependency_path.mkdir(parents=True)
+        native_dependency_pip_args = [
+            "pip",
+            "install",
+            "--target",
+            str(native_dependency_path),
+            "--python-version",
+            version,
+            "--only-binary=:all:",
+            *versioned_native_dependencies,
+        ]
+        subprocess.run(native_dependency_pip_args, check=True)
     return native_dependency_paths
 
 
@@ -151,19 +134,9 @@ def _copy_zip_to_destination(zip_path: Path) -> Path:
     return zip_destination
 
 
-def _remove_old_bundles(zip_destination: Path):
-    for file in FINAL_BUNDLE_NAMES:
-        Path(zip_destination.parent / file).unlink(missing_ok=True)
-
-
-def _rename_bundles_to_final_names(zip_destination: Path):
-    for file in FINAL_BUNDLE_NAMES:
-        shutil.copy(zip_destination, zip_destination.parent / file)
-
-
 def build_deps_bundle() -> None:
-    with TemporaryDirectory() as working_directory:
-        working_directory = Path(working_directory)
+    with TemporaryDirectory() as wd:
+        working_directory = Path(wd)
         project_dict = _get_project_dict()
         dependencies = _get_dependencies(project_dict)
         base_env = _build_base_environment(working_directory, dependencies)
@@ -172,9 +145,7 @@ def build_deps_bundle() -> None:
         zip_path = _get_zip_path(working_directory, project_dict)
         _zip_bundle(base_env, zip_path)
         print(list(working_directory.glob("*")))
-        zip_destination = _copy_zip_to_destination(zip_path)
-        _remove_old_bundles(zip_destination)
-        _rename_bundles_to_final_names(zip_destination)
+        _copy_zip_to_destination(zip_path)
 
 
 if __name__ == "__main__":

--- a/scripts/find_installbuilder.py
+++ b/scripts/find_installbuilder.py
@@ -151,6 +151,12 @@ class _InstallBuilderInstallation:
         )
 
 
+def get_builder_exe_name() -> str:
+    if platform.system() == "Windows":
+        return "builder.exe"
+    return "builder"
+
+
 def _get_default_installbuilder_location() -> Path:
     """
     Returns the default location where InstallBuilder Professional will be installed depending on the platform.
@@ -162,7 +168,7 @@ def _get_default_installbuilder_location() -> Path:
     for install_dir in config.parent_path.iterdir():
         if install_dir.is_dir():
             match = config.get_install_directory_regex().match(install_dir.name)
-            if match and (install_dir / "bin" / "builder").is_file():
+            if match and (install_dir / "bin" / get_builder_exe_name()).is_file():
                 if platform.system() == "Linux":
                     version_offset = 0
                 else:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We were including all platforms when we build the dependency bundle rather than just the current platform. Other platforms aren't necessary.

### What was the solution? (How)

Only include the current platform.

### What is the impact of this change?

Smaller and faster installers. Less code overall.

### How was this change tested?

I built the installer locally and ran it and verified I could open the Deadline Cloud dialog in Blender

#### Please run the integration tests and paste the results below

This change doesn't change any submitter code.

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

```
=================================================== test session starts ====================================================
platform win32 -- Python 3.9.13, pytest-8.3.5, pluggy-1.5.0 -- C:\Users\evans\AppData\Local\hatch\env\virtual\deadline-cloud-for-blender\8LSmqhTD\deadline-cloud-for-blender\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\evans\Development\installers-project\deadline-cloud-for-blender
configfile: pyproject.toml
plugins: cov-6.1.0, xdist-3.6.1
8 workers [13 items]    
scheduling tests via LoadScheduling

test/installer/test_installer.py::test_default_location
test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::TestWindows::test_system_permissions 
test/installer/test_installer.py::TestUserInstall::test_install 
[gw5] [  7%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions 
[gw2] [ 15%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw2] [ 23%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
test/installer/test_installer.py::TestUserInstall::test_uninstall 
[gw3] [ 30%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestVerifySigning::test_linux_signing
[gw3] [ 38%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw1] [ 46%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw1] [ 53%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw0] [ 61%] PASSED test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestSystemInstall::test_install 
[gw0] [ 69%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_install 
[gw4] [ 76%] PASSED test/installer/test_installer.py::TestWindows::test_user_permissions
test/installer/test_installer.py::TestVerifySigning::test_macos_signing
[gw4] [ 84%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing
[gw6] [ 92%] PASSED test/installer/test_installer.py::TestUserInstall::test_install
[gw7] [100%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall

=================================================== slowest 5 durations ==================================================== 
111.08s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
111.02s setup    test/installer/test_installer.py::TestUserInstall::test_install
101.11s setup    test/installer/test_installer.py::TestWindows::test_user_permissions
19.84s call     test/installer/test_installer.py::TestUserInstall::test_uninstall
5.10s call     test/installer/test_installer.py::test_default_location
========================================= 4 passed, 9 skipped in 136.49s (0:02:16) =========================================
```

### Was this change documented?
No

### Is this a breaking change?
I suppose technically you can't copy an installation to a different platform anymore any have it work.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*