### PR TITLE
chore: add installer operating systems and publish tag

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -18,6 +18,8 @@ jobs:
       id-token: write
       contents: write
     uses: aws-deadline/.github/.github/workflows/reusable_publish_v2.yml@mainline
+    with:
+      installer_oses: "['Linux', 'Windows', 'MacOS']"
     secrets: inherit
   # PyPI does not support reusable workflows yet
   # # See https://github.com/pypi/warehouse/issues/11096
@@ -31,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: release
+          ref: ${{ needs.Publish.outputs.tag }}
           fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

1. Release workflow wasn't building installers
2. PyPI publish was using the release branch

### What was the solution? (How)

1. Add the installer operating systems to the workflow call
2. Expose the created tag as a workflow output: https://github.com/aws-deadline/.github/pull/34
3. consume the workflow output tag to checkout instead of the release branch

### What is the impact of this change?

Built artifacts!

### How was this change tested?

Playing a little fast/loose here, so it hasn't.

#### Please run the integration tests and paste the results below

N/A

### Was this change documented?

N/A

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*