### PR TITLE
chore: skip installer signing tests for dev builds

### DIFF
--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -185,7 +185,7 @@ def test_default_location(installer_path: Path):
 
 
 @pytest.mark.skipif(
-    os.getenv("CODEBUILD_SRC_DIR") is None,
+    os.getenv("CODEBUILD_SRC_DIR") is None or os.getenv("IS_DEV_BUILD", "false").lower() == "true",
     reason="Only installers built with a license will not be evaluation mode",
 )
 @pytest.mark.skipif(
@@ -458,7 +458,7 @@ class TestSystemInstall:
 
 
 @pytest.mark.skipif(
-    os.getenv("CODEBUILD_SRC_DIR") is None,
+    os.getenv("CODEBUILD_SRC_DIR") is None or os.getenv("IS_DEV_BUILD", "false").lower() == "true",
     reason="Only installers built internally will be signed",
 )
 class TestVerifySigning:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Signing verification tests and the install builder evaluation check tests would run during test runs against dev deployments of the backend infrastructure and fail.

### What was the solution? (How)
Skip those tests if `IS_DEV_BUILD` is set as an environment variable or if `CODEBUILD_SRC_DIR` isn't set so.

### What is the impact of this change?
Don't have to comment out tests and push to your own fork to skip the signing and install builder evaluation check tests

### How was this change tested?
Tested against my own deployment of the infrastructure and verified the tests were skipped

### Was this change documented?
No

### Is this a breaking change?

No

### Does this change impact security?
No
----

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*