### PR TITLE
chore: Determine the installer version based on Git revision and tags

### DIFF
--- a/scripts/build_installer.py
+++ b/scripts/build_installer.py
@@ -5,11 +5,10 @@ import os
 import sys
 import shutil
 import tempfile
-from datetime import datetime
 from typing import Optional
 from pathlib import Path
 
-from common import EvaluationBuildError, run
+from common import EvaluationBuildError, run, get_version_string
 from find_installbuilder import InstallBuilderSelection, get_builder_exe_name
 
 from depsBundle import build_deps_bundle
@@ -70,6 +69,7 @@ def build_installer(
     install_builder_location: Path,
     installer_platform: str,
     dev: bool,
+    override_installer_version: Optional[str],
 ) -> Path:
     """
     Actually build the installer
@@ -97,9 +97,11 @@ def build_installer(
 
     install_builder_cli = install_builder_location / "bin" / "builder"
     out_dir = workdir / "out"
-    installer_version = os.getenv("INSTALLER_VERSION") if not dev else "00000000"
-    if installer_version is None:
-        raise ValueError("INSTALLER_VERSION environment variable must be set.")
+    root = Path(__file__).resolve().parent.parent
+    if override_installer_version is not None:
+        installer_version = override_installer_version
+    else:
+        installer_version = get_version_string(cwd=root)
     output = run(
         [
             install_builder_cli,
@@ -108,7 +110,7 @@ def build_installer(
             installbuilder_platform,
             "--setvars",
             f"project.outputDirectory={out_dir}",
-            f"project.version={installer_version[:8]}-{datetime.today().date()}",
+            f"project.version={installer_version}",
         ]
     )
     sys.stdout.write(
@@ -138,6 +140,7 @@ def main(
     output_dir: Optional[Path],
     installer_platform: str,
     installer_source_path: Path,
+    override_installer_version: Optional[str],
 ) -> None:
     with tempfile.TemporaryDirectory() as wd:
         workdir = Path(wd)
@@ -157,6 +160,7 @@ def main(
             install_builder_location=installbuilder_path,
             dev=dev,
             installer_platform=installer_platform,
+            override_installer_version=override_installer_version,
         )
 
         installer_filename = INSTALLER_FILENAMES[installer_platform]

--- a/scripts/build_installer_cli.py
+++ b/scripts/build_installer_cli.py
@@ -190,6 +190,7 @@ def _not_allowed_if_env_var_set(
     type=Path,
     help="The path to the installer source xml file",
 )
+@click.option("--override-installer-version", type=str, help="Use this as the installer version.")
 def cli(
     install_builder_path: Optional[Path],
     install_builder_s3_bucket: Optional[str],
@@ -200,6 +201,7 @@ def cli(
     platform: str,
     output_dir: Optional[Path],
     installer_source_path: Path,
+    override_installer_version: Optional[str],
 ) -> None:
     cli_body(
         install_builder_path,
@@ -211,6 +213,7 @@ def cli(
         platform,
         output_dir,
         installer_source_path,
+        override_installer_version,
     )
 
 
@@ -224,6 +227,7 @@ def cli_body(
     platform: str,
     output_dir: Optional[Path],
     installer_source_path: Path,
+    override_installer_version: Optional[str],
 ) -> None:
     """
     Separate from the command function so we can mock the body out
@@ -238,6 +242,7 @@ def cli_body(
         output_dir,
         platform,
         installer_source_path,
+        override_installer_version,
     )
 
 

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -2,6 +2,9 @@
 import subprocess
 import sys
 
+from os import PathLike
+from typing import Union, Dict, Optional, List
+
 
 class BadExitCodeError(Exception):
     pass
@@ -15,23 +18,55 @@ class UnsupportedOSError(Exception):
     pass
 
 
-def run(cmd, cwd=None, env=None, echo=True):
+def run(
+    cmd: Union[PathLike, str, List[Union[str, PathLike]]],
+    cwd: Optional[Union[str, PathLike]] = None,
+    env: Optional[Dict[str, str]] = None,
+    echo: bool = True,
+) -> str:
     if echo:
         sys.stdout.write(f"Running cmd: {cmd}\n")
-    kwargs = {
-        "shell": True,
-        "stdout": subprocess.PIPE,
-        "stderr": subprocess.PIPE,
-    }
-    if isinstance(cmd, list):
-        kwargs["shell"] = False
-    if cwd is not None:
-        kwargs["cwd"] = cwd
-    if env is not None:
-        kwargs["env"] = env
-    p = subprocess.Popen(cmd, **kwargs)
+    shell = not isinstance(cmd, list)
+    p = subprocess.Popen(
+        cmd, shell=shell, cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
     stdout, stderr = p.communicate()
     output = stdout.decode("utf-8") + stderr.decode("utf-8")
+
     if p.returncode != 0:
-        raise BadExitCodeError(f"Bad rc ({p.returncode}) for cmd '{cmd}': {output}")
+        raise BadExitCodeError(
+            f"Process '{str(cmd)}' failed with exit code {p.returncode} and output: {output}"
+        )
+
     return output
+
+
+def get_latest_git_tag(cwd: Optional[Union[PathLike, str]] = None) -> str:
+    result = run(["git", "describe", "--tags", "--abbrev=0"], cwd=cwd, echo=False).strip()
+    return result
+
+
+def get_latest_commit_hash(cwd: Optional[Union[PathLike, str]] = None) -> str:
+    result = run(["git", "rev-parse", "HEAD"], cwd=cwd, echo=False).strip()
+    return result
+
+
+def get_latest_git_tag_hash(cwd: Optional[Union[PathLike, str]] = None) -> str:
+    tag = get_latest_git_tag(cwd)
+    result = run(["git", "rev-list", "-n", "1", tag], cwd=cwd, echo=False).strip()
+    return result
+
+
+def get_latest_commit_short_hash(cwd: Optional[Union[PathLike, str]] = None) -> str:
+    result = run(["git", "rev-parse", "--short", "HEAD"], cwd=cwd, echo=False).strip()
+    return result
+
+
+def get_version_string(cwd: Optional[Union[PathLike, str]] = None) -> str:
+    latest_tag = get_latest_git_tag(cwd)
+    latest_commit_hash = get_latest_commit_hash(cwd)
+    latest_tag_hash = get_latest_git_tag_hash(cwd)
+    if latest_commit_hash == latest_tag_hash:
+        return latest_tag
+    latest_commit_hash_short = get_latest_commit_short_hash()
+    return f"{latest_tag}.{latest_commit_hash_short}"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

DCC Submitter installers get their version from an environment variable, or use "00000000" for dev builds, then add the current date on the end. Instead, installers should have versions based on repository tags. If the latest tag matches the current commit hash, the version should just be the latest tag. Otherwise, the version should be the latest tag plus the short commit hash of the current commit.

### What was the solution? (How)

Change the way the installer building script determines the version to match what was described above. Additionally I added a flag for overriding the version.

### What is the impact of this change?

Versions will be related to the tags.

### How was this change tested?

I build the installer, ran it, and verified that installer_version.txt contained the correct version.

#### Please run the integration tests and paste the results below

N/A

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

```
================================== test session starts ==================================
platform win32 -- Python 3.13.2, pytest-8.3.5, pluggy-1.5.0 -- C:\Users\evans\AppData\Local\hatch\env\virtual\deadline-cloud-for-blender\xII6PE8V\deadline-cloud-for-blender\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\evans\Development\installers-project\deadline-cloud-for-blender
configfile: pyproject.toml
plugins: cov-6.1.1, xdist-3.6.1
8 workers [13 items]    
scheduling tests via LoadScheduling

test/installer/test_installer.py::test_default_location
test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
test/installer/test_installer.py::TestWindows::test_user_permissions
test/installer/test_installer.py::TestUserInstall::test_install
test/installer/test_installer.py::TestWindows::test_system_permissions
[gw2] [  7%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
[gw3] [ 15%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions
[gw5] [ 23%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions
test/installer/test_installer.py::test_did_not_build_with_evaluation_mode
test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw2] [ 30%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing
test/installer/test_installer.py::TestVerifySigning::test_linux_signing
[gw3] [ 38%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing
[gw1] [ 46%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode
test/installer/test_installer.py::TestUserInstall::test_uninstall
test/installer/test_installer.py::TestSystemInstall::test_uninstall
[gw1] [ 53%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uninstall  
[gw0] [ 61%] PASSED test/installer/test_installer.py::test_default_location
test/installer/test_installer.py::TestSystemInstall::test_install
[gw0] [ 69%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_install    
[gw6] [ 76%] PASSED test/installer/test_installer.py::TestUserInstall::test_install       
[gw4] [ 84%] PASSED test/installer/test_installer.py::TestWindows::test_user_permissions  
test/installer/test_installer.py::TestVerifySigning::test_macos_signing
[gw4] [ 92%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing
[gw7] [100%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall     

================================== slowest 5 durations ================================== 
89.35s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
88.39s setup    test/installer/test_installer.py::TestUserInstall::test_install
88.30s setup    test/installer/test_installer.py::TestWindows::test_user_permissions      
19.04s call     test/installer/test_installer.py::TestUserInstall::test_uninstall
5.05s call     test/installer/test_installer.py::test_default_location
======================= 4 passed, 9 skipped in 111.84s (0:01:51) ========================
```

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*