### PR TITLE
chore: shorten bundle identifier for now

### DIFF
--- a/installer/DeadlineCloudForBlenderSubmitter.xml
+++ b/installer/DeadlineCloudForBlenderSubmitter.xml
@@ -9,7 +9,7 @@
     <enableTimestamp>1</enableTimestamp>
     <allowComponentSelection>1</allowComponentSelection>
 
-    <osxApplicationBundleIdentifier>com.amazonaws.deadline.clientinstaller.blender</osxApplicationBundleIdentifier>
+    <osxApplicationBundleIdentifier>com.amazonaws.deadline.clientinstaller</osxApplicationBundleIdentifier>
 
     <!-- Images and icons -->
     <logoImage>logoImage.png</logoImage>


### PR DESCRIPTION
shorten the identifier for now to simplify notarization and signing. May change back later.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*