### PR TITLE
Separate publish workflow

### DIFF
--- a/.github/workflows/create_new_tag.yml
+++ b/.github/workflows/create_new_tag.yml
@@ -1,0 +1,13 @@
+name: "Create new Tag"
+
+on:
+  push:
+    branches:
+      - mainline
+    paths:
+      - CHANGELOG.md
+
+jobs:
+    create-new-tag:
+        uses: aws-deadline/.github/.github/workflows/reusable_create_new_tag.yml@mainline
+        secrets: inherit

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -1,39 +1,77 @@
 name: "Release: Publish"
-run-name: "Release: ${{ github.event.head_commit.message }}"
+run-name: "Release: ${{ inputs.tag }}"
 
 on:
-  push:
-    branches:
-      - mainline
-    paths:
-      - CHANGELOG.md
-
-concurrency:
-  group: release
+  workflow_dispatch:
+      inputs:
+          tag:
+              required: true
+              type: string
 
 jobs:
-  Publish:
-    name: Publish Release
-    permissions:
-      id-token: write
-      contents: write
-    uses: aws-deadline/.github/.github/workflows/reusable_publish_v2.yml@mainline
-    with:
-      installer_oses: "['Linux', 'Windows', 'MacOS']"
-    secrets: inherit
-  # PyPI does not support reusable workflows yet
-  # # See https://github.com/pypi/warehouse/issues/11096
-  PublishToPyPI:
-    needs: Publish
+  CheckForRelease:
     runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      id-token: write
+    name: CheckForRelease
+    outputs:
+      isReleased: ${{steps.checkrelease.outputs.isReleased}}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with: 
+          ref: ${{inputs.tag}}
+          fetch-depth: 0
+      - id: checkrelease
+        shell: bash
+        run: |
+          if gh release view "${{inputs.tag}}" &> /dev/null; then
+            echo "isReleased=true" >> $GITHUB_OUTPUT
+          else
+            echo "isReleased=false" >> $GITHUB_OUTPUT
+          fi
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  prerelease:
+      needs: CheckForRelease
+      if: needs.CheckForRelease.outputs.isReleased == 'false'
+      uses: aws-deadline/.github/.github/workflows/reusable_prerelease.yml@mainline
+      secrets: inherit
+      with:
+          installer_oses: "['Linux', 'Windows', 'MacOS']"
+          tag: ${{inputs.tag}}
+  release:
+      needs: prerelease
+      uses: aws-deadline/.github/.github/workflows/reusable_release.yml@mainline
+      secrets: inherit
+      with:
+          tag: ${{inputs.tag}}
+  IsCondaReady:
+    needs: release
+    runs-on: ubuntu-latest
+    environment: release
+    name: “Is the Conda Package available in all ProdWaves and have you ran any required manual tests?”
+    steps:
+      - run: |
+         :
+  publish:
+      needs: IsCondaReady
+      uses: aws-deadline/.github/.github/workflows/reusable_publish_python.yml@mainline
+      secrets: inherit
+      with:
+          tag: ${{inputs.tag}}
+  # PyPI does not support reusable workflows yet
+  # # See https://github.com/pypi/warehouse/issues/11096
+  PublishToPyPI:
+      needs: publish
+      runs-on: ubuntu-latest
+      environment: release
+      permissions:
+        id-token: write
+      steps:
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          ref: ${{ needs.Publish.outputs.tag }}
+          ref: ${{ inputs.tag }}
           fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -47,3 +85,4 @@ jobs:
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We want to be able to re-run the release workflow if something fails. 

### What was the solution? (How)

The release workflow is now manually run against a tag. It runs the reusable prerelease, release and  python publish workflows from this PR: https://github.com/aws-deadline/.github/pull/38

With this change, we won't be running the release workflow when the changelog is updated, it will be manual instead. As a result, we need a way to create the bump tag. I've made a new workflow that does run on changelog update to create and push the tag. Release can then use that tag to build later on.

I also added a check to prevent the workflow from running if the github release already exists. The idea being that we want to prevent someone from re-releasing an existing version. 

### What is the impact of this change?

Release becomes re-runnable.

### How was this change tested?

I pointed these changes to my own fork with the new reusable workflows. Ran the bump workflow and merged to PR to make sure the new tagging workflow ran automatically. 

Manually ran the new release: publish workflow.

### Was this change documented?

No

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*