### PR TITLE
chore: Add environment enter/exit timeouts to default adaptor template

### DIFF
--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/default_blender_template.yaml
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/default_blender_template.yaml
@@ -120,6 +120,7 @@ steps:
             - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 3720
         onExit:
           command: blender-openjd
           args:
@@ -129,6 +130,7 @@ steps:
             - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 120
   script:
     embeddedFiles:
       - name: runData

--- a/test/integ/test_scripts/minimal_test/expected_job_bundle/template.yaml
+++ b/test/integ/test_scripts/minimal_test/expected_job_bundle/template.yaml
@@ -162,6 +162,7 @@ steps:
           - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 3720
         onExit:
           command: blender-openjd
           args:
@@ -171,6 +172,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 120
   script:
     embeddedFiles:
     - name: runData
@@ -233,6 +235,7 @@ steps:
           - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 3720
         onExit:
           command: blender-openjd
           args:
@@ -242,6 +245,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 120
   script:
     embeddedFiles:
     - name: runData

--- a/test/integ/test_scripts/minimal_test_host_requirements/expected_job_bundle/template.yaml
+++ b/test/integ/test_scripts/minimal_test_host_requirements/expected_job_bundle/template.yaml
@@ -161,6 +161,7 @@ steps:
           - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 3720
         onExit:
           command: blender-openjd
           args:
@@ -170,6 +171,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 120
   script:
     embeddedFiles:
     - name: runData

--- a/test/unit/deadline_submitter_for_blender/test_submitter.py
+++ b/test/unit/deadline_submitter_for_blender/test_submitter.py
@@ -235,6 +235,7 @@ def test_fill_job_template(submitter_settings, common_layer_settings):
                                         "file://{{Env.File.initData}}",
                                     ],
                                     "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
+                                    "timeout": 3720,
                                 },
                                 "onExit": {
                                     "command": "blender-openjd",
@@ -245,6 +246,7 @@ def test_fill_job_template(submitter_settings, common_layer_settings):
                                         "{{ Session.WorkingDirectory }}/connection.json",
                                     ],
                                     "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
+                                    "timeout": 120,
                                 },
                             },
                         },
@@ -308,6 +310,7 @@ def test_fill_job_template(submitter_settings, common_layer_settings):
                                         "file://{{Env.File.initData}}",
                                     ],
                                     "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
+                                    "timeout": 3720,
                                 },
                                 "onExit": {
                                     "command": "blender-openjd",
@@ -318,6 +321,7 @@ def test_fill_job_template(submitter_settings, common_layer_settings):
                                         "{{ Session.WorkingDirectory }}/connection.json",
                                     ],
                                     "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
+                                    "timeout": 120,
                                 },
                             },
                         },


### PR DESCRIPTION
Fixes #187 .

### What was the problem/requirement? (What/Why)
We are missing timeouts for entering/exiting the adaptor environment in job templates generated by the submitter.

### What was the solution? (How)
Added timeouts to the adaptor's enter/exit environment actions in the default template. These are ~1-1.5 minutes longer than the combined adaptor & Blender startup/exit timeouts.

Thank you to @karthikbekalp and @joel-wong-aws for the example PR and proposed solution :)

### What is the impact of this change?
Covers the edge case where the adaptor hangs while entering/exiting the environment and the worker agent cannot enforce the adaptor timeouts.

### How was this change tested?
Unit & integration tests

#### Please run the integration tests and paste the results below
```
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
[gw0] [ 25%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
[gw0] [ 50%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
[gw0] [ 75%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter
[gw0] [100%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter

========================================================= slowest 5 durations ==========================================================
90.52s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
37.09s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
6.32s call     test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
5.56s call     test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter
0.01s setup    test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
==================================================== 4 passed in 140.52s (0:02:20) =====================================================
```

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below
n/a

### Was this change documented?
nop

### Is this a breaking change?
nop

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*