### PR TITLE
fix: Asset References on Shared Drives Resolve to UNC Paths

### DIFF
--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/blender_utils.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/blender_utils.py
@@ -91,7 +91,7 @@ def find_files(project_path, skip_temp=True, skip_nonexistent=True) -> list[Path
     if skip_nonexistent:
         files = (f for f in files if f.exists())
 
-    return [f.resolve() for f in files]
+    return [Path(os.path.abspath(f)) for f in files]
 
 
 def _get_blender_temp_dirs() -> list[Path]:
@@ -105,19 +105,19 @@ def _get_blender_temp_dirs() -> list[Path]:
     dirs = []
 
     # `bpy.app.tempdir` seems to resolve to a project-specific directory, e.g. `'C:\\Users\\user\\AppData\\Local\\Temp\\blender_a07504\\'`. We want the parent directory, e.g. `'Temp\\'`.
-    dirs.append(Path(bpy.app.tempdir).parent.resolve())
+    dirs.append(Path(os.path.abspath(bpy.app.tempdir)).parent)
 
     # The user's preferences may specify a temp directory.
     user_pref_dir = bpy.context.preferences.filepaths.temporary_directory
     if user_pref_dir:
-        dirs.append(Path(user_pref_dir).resolve())
+        dirs.append(Path(os.path.abspath(user_pref_dir)))
 
     # System environment variables may specify a temp directory. Which one exists (if any) depends on the OS.
     for var in ["TEMP", "TMP", "TMP_DIR"]:
         if os.environ.get(var):
-            dirs.append(Path(os.environ[var]).resolve())
+            dirs.append(Path(os.path.abspath(os.environ[var])))
 
     # The root temp directory is always a candidate.
-    dirs.append(Path("/tmp").resolve())
+    dirs.append(Path("/tmp"))
 
     return list(set(dirs))


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When working on a blender project on a shared drive, the auto-detected assets would resolve to the full [UNC path](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#unc-paths). This would interfere with Path Mapping and Storage Profiles because paths like

`A:\Path\To\Project` would become something like `\\10.0.255.000\Path\To\Project` and mess with any storage profiles which were based on `A:\` paths. 

### What was the solution? (How)

Do not use `Path.resolve()`. `Path.resolve()` calls `os.path.realpath` under the hood, which resolves paths into their full UNC paths. While this is useful in some applications, for blender projects in the context of the Deadline Cloud service, we want to preserve the expected path for the reasons listed above.. 

### What is the impact of this change?

Shared drives no longer resolve to UNC paths

### How was this change tested?

Tested with this change on a workstation which had access to a blender project on a shared drive. Confirmed that before the change, the asset references file contained UNC paths, and afterwards, the asset references file contained the original drive letter path.

#### Please run the integration tests and paste the results below
```bash
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
[gw0] [ 25%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor 
[gw0] [ 50%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor 
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter 
[gw0] [ 75%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter 
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter 
[gw0] [100%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter 

======================================================================================== slowest 5 durations ========================================================================================
27.36s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
12.74s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
3.99s call     test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
1.34s call     test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter
0.00s setup    test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
======================================================================================== 4 passed in 45.70s =========================================================================================
```
#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

### Was this change documented?

Just through the commit title which will make it to the changelog

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*