### PR TITLE
refactor: Add a return value to the _create_bundle callback

### DIFF
--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
@@ -129,7 +129,7 @@ def _create_bundle(
     asset_references: AssetReferences,
     requirements: Optional[dict[str, Any]] = None,
     purpose: Optional[str] = None,
-) -> None:
+) -> dict[str, Any]:
     """Create and write Deadline job bundle files to the given directory. Also save sticky settings.
 
     NOTE: The parameters to this function are fixed by the Deadline API. Do not change them, even if they are unused. See the source of the `SubmitJobToDeadlineDialog` class.
@@ -145,7 +145,7 @@ def _create_bundle(
         requirements: The host requirements. There are only passed if the user has specified custom host requirements in the UI. If "all available worker hosts" are selected, this is None.
         purpose: The purpose of the job bundle.
     """
-    _create_bundle_internal(
+    return _create_bundle_internal(
         widget, job_bundle_dir, settings, queue_parameters, asset_references, requirements, purpose
     )
 
@@ -159,7 +159,7 @@ def _create_bundle_internal(
     requirements: Optional[dict[str, Any]] = None,
     purpose: Optional[str] = None,
     prompt_for_saving=True,
-) -> None:
+) -> dict[str, Any]:
     """Create and write Deadline job bundle files to the given directory. Also save sticky settings.
     The internal variation exists so that the functionality can be accessed without a UI.
 
@@ -229,6 +229,10 @@ def _create_bundle_internal(
     settings.input_filenames = sorted(attachments.input_filenames)
     scene_filename = settings.project_path
     settings.save_sticky_settings(scene_filename)
+
+    return {
+        "job_parameters": parameter_values,
+    }
 
 
 def _get_auto_detected_assets(project_path: str) -> AssetReferences:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

In anticipation of
https://github.com/aws-deadline/deadline-cloud/pull/673, "fix!: Implement improved job attachments containment warning,"
submitters need a small tweak to provide the parameter values in the return value of the GUI job bundle callback.

### What was the solution? (How)

Add a return value to the `_create_bundle` callback. The return value provides the parameter values for use as known paths in the warning message.

This change is backwards-compatible, because before that PR, the return value is ignored, and after that PR, the return value will be used to improve the message.

### What is the impact of this change?

No visible change prior to that PR merging. A better message behavior after.

### How was this change tested?

Ran the submission both with and without that PR. Added a file from C:/DataSets to the extra JA tab to provide a warning. Here are screenshots:

![BlenderWarningMessage_pre-warning-fix](https://github.com/user-attachments/assets/f9858140-976c-4cd5-82b1-5bb0c8a8e41c)

![BlenderWarningMessage_with-warning-fix](https://github.com/user-attachments/assets/bfae3150-3816-443d-91b6-20b68dcd0eae)

#### Please run the integration tests and paste the results below

```
$ export BLENDER_EXECUTABLE=c:/Program\ Files/Blender\ Foundation/Blender\ 4.4/blender.exe
$ hatch run integ:test
pre-install [1] | pip install -r requirements-integ-testing.txt
Collecting pillow==11.2.* (from -r requirements-integ-testing.txt (line 1))
  Downloading pillow-11.2.1-cp313-cp313-win_amd64.whl.metadata (9.1 kB)
Collecting numpy==2.* (from -r requirements-integ-testing.txt (line 2))
...
Installing collected packages: py-partiql-parser, xmltodict, urllib3, types-pyyaml, six, ruff, rfc3986, pywin32-ctypes, pygments, pycparser, pluggy, platformdirs, pathspec, packaging, nh3, mypy-extensions, more-itertools, mdurl, MarkupSafe, jmespath, jaraco.context, iniconfig, idna, execnet, docutils, coverage, colorama, charset-normalizer, certifi, werkzeug, requests, readme-renderer, python-dateutil, pytest, mypy, markdown-it-py, Jinja2, jaraco.functools, jaraco.classes, click, cffi, rich, responses, requests-toolbelt, pytest-xdist, pytest-cov, keyring, id, cryptography, botocore, black, twine, s3transfer, boto3, moto

Successfully installed Jinja2-3.1.6 MarkupSafe-3.0.2 black-25.1.0 boto3-1.38.29 botocore-1.38.29 certifi-2025.4.26 cffi-1.17.1 charset-normalizer-3.4.2 click-8.2.1 colorama-0.4.6 coverage-7.8.2 cryptography-45.0.3 docutils-0.21.2 execnet-2.1.1 id-1.5.0 idna-3.10 iniconfig-2.1.0 jaraco.classes-3.4.0 jaraco.context-6.0.1 jaraco.functools-4.1.0 jmespath-1.0.1 keyring-25.6.0 markdown-it-py-3.0.0 mdurl-0.1.2 more-itertools-10.7.0 moto-5.1.5 mypy-1.16.0 mypy-extensions-1.1.0 nh3-0.2.21 packaging-25.0 pathspec-0.12.1 platformdirs-4.3.8 pluggy-1.6.0 py-partiql-parser-0.6.1 pycparser-2.22 pygments-2.19.1 pytest-8.4.0 pytest-cov-6.1.1 pytest-xdist-3.7.0 python-dateutil-2.9.0.post0 pywin32-ctypes-0.2.3 readme-renderer-44.0 requests-2.32.3 requests-toolbelt-1.0.0 responses-0.25.7 rfc3986-2.0.0 rich-14.0.0 ruff-0.11.12 s3transfer-0.13.0 six-1.17.0 twine-6.1.0 types-pyyaml-6.0.12.20250516 urllib3-2.4.0 werkzeug-3.1.3 xmltodict-0.14.2
===================================================================== test session starts =====================================================================
platform win32 -- Python 3.13.3, pytest-8.4.0, pluggy-1.6.0 -- C:\Users\AppData\Local\hatch\env\virtual\deadline-cloud-for-blender\ArlCnNsV\integ\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Dev\deadline-cloud-for-blender
configfile: pyproject.toml
plugins: cov-6.1.1, xdist-3.7.0
1 worker [4 items]
scheduling tests via LoadScheduling

test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
[gw0] [ 25%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
[gw0] [ 50%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
[gw0] [ 75%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter
[gw0] [100%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter

================================================================== slowest 5 durations ===================================================================
115.90s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
46.66s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
10.95s call     test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
8.78s call     test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter
0.01s setup    test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter
============================================================= 4 passed in 185.43s (0:03:05) ==============================================================
```
### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*