### PR TITLE
feat: Installer now enables the Deadline addon in Blender for User Installs.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,10 +17,10 @@ hatch run build
 
 ### Build the installer
 ```bash
-hatch run build-installer --local-dev-build --platform <PLATFORM> [--install-builder-location <LOCATION> --output-dir <DIR>]
+hatch run installer:build-installer --local-dev --platform <PLATFORM> [--install-builder-location <LOCATION> --output-dir <DIR>]
 ```
 
-Run `hatch run build-installer -h` to see the full list of arguments.
+Run `hatch run installer:build-installer --help` to see the full list of arguments.
 
 ### Run tests
 

--- a/install_builder/deadline-cloud-for-blender.xml
+++ b/install_builder/deadline-cloud-for-blender.xml
@@ -1,5 +1,5 @@
 <!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
-<component>
+<componentGroup>
     <name>deadline_cloud_for_blender</name>
     <description>Deadline Cloud for Blender 3.6-4.2</description>
     <detailedDescription>Blender plugin for submitting jobs to AWS Deadline Cloud</detailedDescription>
@@ -27,6 +27,20 @@
             </distributionFileList>
         </folder>
         <folder>
+            <description>Blender files</description>
+            <destination>${installdir}</destination>
+            <name>blender_settings</name>
+            <platforms>all</platforms>
+            <distributionFileList>
+                <distributionFile>
+                    <origin>add_submitter_to_pref.py</origin>
+                </distributionFile>
+                <distributionFile>
+                    <origin>remove_submitter_from_pref.py</origin>
+                </distributionFile>
+            </distributionFileList>
+        </folder>
+        <folder>
             <description>Blender dependency files</description>
             <destination>${installdir}/tmp/blender_deps</destination>
             <name>blenderdeps</name>
@@ -38,9 +52,252 @@
             </distributionFileList>
         </folder>
     </folderList>
+    <componentList>
+        <component>
+            <name>blender_36</name>
+            <description>Blender 3.6</description>
+            <selected>0</selected>
+            <parameterList>
+                <fileParameter>
+                    <name>blender_36_path</name>
+                    <description>Path to Blender 3.6</description>
+                    <explanation>Enter the path to Blender 3.6. For easiest installation, Blender should be installed before installing Deadline Cloud for Blender.</explanation>
+                    <default>${blender_36_default}</default>
+                    <allowEmptyValue>0</allowEmptyValue>
+                    <ask>yes</ask>
+                    <cliOptionName>blender-36-path</cliOptionName>
+                    <cliOptionText>Path to the Blender 3.6.</cliOptionText>
+                    <osxBundlesAreFiles>1</osxBundlesAreFiles>
+                </fileParameter>
+            </parameterList>
+            <postInstallationActionList>
+                <if>
+                    <conditionRuleList>
+                        <platformTest type="osx"/>
+                    </conditionRuleList>
+                    <actionList>
+                        <setInstallerVariable name="blender_36_path" value="${blender_36_path}/Contents/MacOS/Blender" />
+                    </actionList>
+                </if>
+                <runProgram>
+                    <program>${blender_36_path}</program>
+                    <programArguments>--background --python ${installdir}/add_submitter_to_pref.py -- --deadline_cloud_install_path ${blender_installdir}</programArguments>
+                    <abortOnError>0</abortOnError>
+                    <showMessageOnError>1</showMessageOnError>
+                    <customErrorMessage>An error occured while setting up the AWS Deadline Submitter. Visit https://github.com/aws-deadline/deadline-cloud-for-blender?tab=readme-ov-file#submitter for manual installation instructions.</customErrorMessage>
+                </runProgram>
+            </postInstallationActionList>
+            <preUninstallationActionList>
+                <if>
+                    <conditionRuleList>
+                        <platformTest type="osx"/>
+                    </conditionRuleList>
+                    <actionList>
+                        <setInstallerVariable name="blender_36_path" value="${blender_36_path}/Contents/MacOS/Blender" />
+                    </actionList>
+                </if>
+                <runProgram>
+                    <program>${blender_36_path}</program>
+                    <programArguments>--background --python ${installdir}/remove_submitter_from_pref.py -- --deadline_cloud_install_path ${blender_installdir}</programArguments>
+                    <abortOnError>0</abortOnError>
+                    <showMessageOnError>1</showMessageOnError>
+                    <customErrorMessage>An error occured while uninstalling the AWS Deadline Submitter from Blender. The addon and scripts directory may need to be removed manually.</customErrorMessage>
+                </runProgram>
+            </preUninstallationActionList>
+        </component>
+        <component>
+            <name>blender_4</name>
+            <description>Blender 4.0</description>
+            <selected>0</selected>
+            <parameterList>
+                <fileParameter>
+                    <name>blender_4_path</name>
+                    <description>Path to Blender 4.0</description>
+                    <explanation>Enter the path to Blender 4.0. For easiest installation, Blender should be installed before installing Deadline Cloud for Blender.</explanation>
+                    <default>${blender_4_default}</default>
+                    <allowEmptyValue>0</allowEmptyValue>
+                    <ask>yes</ask>
+                    <cliOptionName>blender-4-path</cliOptionName>
+                    <cliOptionText>Path to the Blender 4.0.</cliOptionText>
+                    <osxBundlesAreFiles>1</osxBundlesAreFiles>
+                </fileParameter>
+            </parameterList>
+            <postInstallationActionList>
+                <if>
+                    <conditionRuleList>
+                        <platformTest type="osx"/>
+                    </conditionRuleList>
+                    <actionList>
+                        <setInstallerVariable name="blender_4_path" value="${blender_4_path}/Contents/MacOS/Blender" />
+                    </actionList>
+                </if>
+                <runProgram>
+                    <program>${blender_4_path}</program>
+                    <programArguments>--background --python ${installdir}/add_submitter_to_pref.py -- --deadline_cloud_install_path ${blender_installdir}</programArguments>
+                    <abortOnError>0</abortOnError>
+                    <showMessageOnError>1</showMessageOnError>
+                    <customErrorMessage>An error occured while setting up the AWS Deadline Submitter. Visit https://github.com/aws-deadline/deadline-cloud-for-blender?tab=readme-ov-file#submitter for manual installation instructions.</customErrorMessage>
+                </runProgram>
+            </postInstallationActionList>
+            <preUninstallationActionList>
+                <if>
+                    <conditionRuleList>
+                        <platformTest type="osx"/>
+                    </conditionRuleList>
+                    <actionList>
+                        <setInstallerVariable name="blender_4_path" value="${blender_4_path}/Contents/MacOS/Blender" />
+                    </actionList>
+                </if>
+                <runProgram>
+                    <program>${blender_4_path}</program>
+                    <programArguments>--background --python ${installdir}/remove_submitter_from_pref.py -- --deadline_cloud_install_path ${blender_installdir}</programArguments>
+                    <abortOnError>0</abortOnError>
+                    <showMessageOnError>1</showMessageOnError>
+                    <customErrorMessage>An error occured while uninstalling the AWS Deadline Submitter from Blender. The addon and scripts directory may need to be removed manually.</customErrorMessage>
+                </runProgram>
+            </preUninstallationActionList>
+        </component>
+        <component>
+            <name>blender_41</name>
+            <description>Blender 4.1</description>
+            <selected>0</selected>
+            <parameterList>
+                <fileParameter>
+                    <name>blender_41_path</name>
+                    <description>Path to Blender 4.1</description>
+                    <explanation>Enter the path to Blender 4.1. For easiest installation, Blender should be installed before installing Deadline Cloud for Blender.</explanation>
+                    <default>${blender_41_default}</default>
+                    <allowEmptyValue>0</allowEmptyValue>
+                    <ask>yes</ask>
+                    <cliOptionName>blender-41-path</cliOptionName>
+                    <cliOptionText>Path to the Blender 4.1.</cliOptionText>
+                    <osxBundlesAreFiles>1</osxBundlesAreFiles>
+                </fileParameter>
+            </parameterList>
+            <postInstallationActionList>
+                <if>
+                    <conditionRuleList>
+                        <platformTest type="osx"/>
+                    </conditionRuleList>
+                    <actionList>
+                        <setInstallerVariable name="blender_41_path" value="${blender_41_path}/Contents/MacOS/Blender" />
+                    </actionList>
+                </if>
+                <runProgram>
+                    <program>${blender_41_path}</program>
+                    <programArguments>--background --python ${installdir}/add_submitter_to_pref.py -- --deadline_cloud_install_path ${blender_installdir}</programArguments>
+                    <abortOnError>0</abortOnError>
+                    <showMessageOnError>1</showMessageOnError>
+                    <customErrorMessage>An error occured while setting up the AWS Deadline Submitter. Visit https://github.com/aws-deadline/deadline-cloud-for-blender?tab=readme-ov-file#submitter for manual installation instructions.</customErrorMessage>
+                </runProgram>
+            </postInstallationActionList>
+            <preUninstallationActionList>
+                <if>
+                    <conditionRuleList>
+                        <platformTest type="osx"/>
+                    </conditionRuleList>
+                    <actionList>
+                        <setInstallerVariable name="blender_41_path" value="${blender_41_path}/Contents/MacOS/Blender" />
+                    </actionList>
+                </if>
+                <runProgram>
+                    <program>${blender_41_path}</program>
+                    <programArguments>--background --python ${installdir}/remove_submitter_from_pref.py -- --deadline_cloud_install_path ${blender_installdir}</programArguments>
+                    <abortOnError>0</abortOnError>
+                    <showMessageOnError>1</showMessageOnError>
+                    <customErrorMessage>An error occured while uninstalling the AWS Deadline Submitter from Blender. The addon and scripts directory may need to be removed manually.</customErrorMessage>
+                </runProgram>
+            </preUninstallationActionList>
+        </component>
+        <component>
+            <name>blender_42</name>
+            <description>Blender 4.2</description>
+            <selected>0</selected>
+            <parameterList>
+                <fileParameter>
+                    <name>blender_42_path</name>
+                    <description>Path to Blender 4.2</description>
+                    <explanation>Enter the path to Blender 4.2. For easiest installation, Blender should be installed before installing Deadline Cloud for Blender.</explanation>
+                    <default>${blender_42_default}</default>
+                    <allowEmptyValue>0</allowEmptyValue>
+                    <ask>yes</ask>
+                    <cliOptionName>blender-42-path</cliOptionName>
+                    <cliOptionText>Path to the Blender 4.2.</cliOptionText>
+                    <osxBundlesAreFiles>1</osxBundlesAreFiles>
+                </fileParameter>
+            </parameterList>
+            <postInstallationActionList>
+                <if>
+                    <conditionRuleList>
+                        <platformTest type="osx"/>
+                    </conditionRuleList>
+                    <actionList>
+                        <setInstallerVariable name="blender_42_path" value="${blender_42_path}/Contents/MacOS/Blender" />
+                    </actionList>
+                </if>
+                <runProgram>
+                    <program>${blender_42_path}</program>
+                    <programArguments>--background --python ${installdir}/add_submitter_to_pref.py -- --deadline_cloud_install_path ${blender_installdir}</programArguments>
+                    <abortOnError>0</abortOnError>
+                    <showMessageOnError>1</showMessageOnError>
+                    <customErrorMessage>An error occured while setting up the AWS Deadline Submitter. Visit https://github.com/aws-deadline/deadline-cloud-for-blender?tab=readme-ov-file#submitter for manual installation instructions.</customErrorMessage>
+                </runProgram>
+            </postInstallationActionList>
+            <preUninstallationActionList>
+                <if>
+                    <conditionRuleList>
+                        <platformTest type="osx"/>
+                    </conditionRuleList>
+                    <actionList>
+                        <setInstallerVariable name="blender_42_path" value="${blender_42_path}/Contents/MacOS/Blender" />
+                    </actionList>
+                </if>
+                <runProgram>
+                    <program>${blender_42_path}</program>
+                    <programArguments>--background --python ${installdir}/remove_submitter_from_pref.py -- --deadline_cloud_install_path ${blender_installdir}</programArguments>
+                    <abortOnError>0</abortOnError>
+                    <showMessageOnError>1</showMessageOnError>
+                    <customErrorMessage>An error occured while uninstalling the AWS Deadline Submitter from Blender. The addon and scripts directory may need to be removed manually.</customErrorMessage>
+                </runProgram>
+            </preUninstallationActionList>
+        </component>
+    </componentList>
     <initializationActionList>
         <setInstallerVariable name="all_components" value="${all_components} deadline_cloud_for_blender" />
         <setInstallerVariable name="individual_install" value="0"/>
+        <if>
+            <conditionRuleList>
+                <platformTest type="windows" />
+            </conditionRuleList>
+            <actionList>
+                <setInstallerVariable name="blender_36_default" value="C:\Program Files\Blender Foundation\Blender 3.6\blender.exe" />
+                <setInstallerVariable name="blender_4_default" value="C:\Program Files\Blender Foundation\Blender 4.0\blender.exe" />
+                <setInstallerVariable name="blender_41_default" value="C:\Program Files\Blender Foundation\Blender 4.1\blender.exe" />
+                <setInstallerVariable name="blender_42_default" value="C:\Program Files\Blender Foundation\Blender 4.2\blender.exe" />
+            </actionList>
+        </if>
+        <if>
+            <conditionRuleList>
+                <platformTest type="linux" />
+            </conditionRuleList>
+            <actionList>
+                <setInstallerVariable name="blender_36_default" value="/usr/local/blender" />
+                <setInstallerVariable name="blender_4_default" value="/usr/local/blender" />
+                <setInstallerVariable name="blender_41_default" value="/usr/local/blender" />
+                <setInstallerVariable name="blender_42_default" value="/usr/local/blender" />
+            </actionList>
+        </if>
+        <if>
+            <conditionRuleList>
+                <platformTest type="osx" />
+            </conditionRuleList>
+            <actionList>
+                <setInstallerVariable name="blender_36_default" value="/Applications/Blender.app" />
+                <setInstallerVariable name="blender_4_default" value="/Applications/Blender.app" />
+                <setInstallerVariable name="blender_41_default" value="/Applications/Blender.app" />
+                <setInstallerVariable name="blender_42_default" value="/Applications/Blender.app" />
+            </actionList>
+        </if>
     </initializationActionList>
     <readyToInstallActionList>
         <if>
@@ -48,10 +305,10 @@
                 <isTrue value="${individual_install}"/>
             </conditionRuleList>
             <actionList>
-                <setInstallerVariable name="blender_installdir" value="${installdir}/python" />
+                <setInstallerVariable name="blender_installdir" value="${installdir}/python" persist="1" />
             </actionList>
             <elseActionList>
-                <setInstallerVariable name="blender_installdir" value="${installdir}/Submitters/Blender/python" />
+                <setInstallerVariable name="blender_installdir" value="${installdir}/Submitters/Blender/python" persist="1" />
             </elseActionList>
         </if>
         <setInstallerVariable name="blender_addondir" value="${blender_installdir}/addons" />
@@ -74,4 +331,4 @@
             <path>${installdir}/tmp</path>
         </deleteFile>
     </postInstallationActionList>
-</component>
+</componentGroup>

--- a/install_builder/deadline-cloud-for-blender.xml
+++ b/install_builder/deadline-cloud-for-blender.xml
@@ -1,14 +1,14 @@
 <!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
 <componentGroup>
     <name>deadline_cloud_for_blender</name>
-    <description>Deadline Cloud for Blender 3.6-4.2</description>
+    <description>AWS Deadline Cloud for Blender 3.6-4.2</description>
     <detailedDescription>Blender plugin for submitting jobs to AWS Deadline Cloud</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
     <show>1</show>
     <parameterList>
         <stringParameter name="deadline_cloud_for_blender_summary" ask="0" cliOptionShow="0">
-            <value>Deadline Cloud for Blender 3.6-4.2
+            <value>AWS Deadline Cloud for Blender 3.6-4.2
 - Compatible with Blender 3.6 to 4.2
 - Install the integrated Blender submitter files to the installation directory</value>
         </stringParameter>
@@ -52,16 +52,61 @@
             </distributionFileList>
         </folder>
     </folderList>
+    <functionDefinitionList>
+        <actionDefinition name="fnSetBlenderPref">
+            <parameterList>
+                <stringParameter name="blenderPath"/>
+            </parameterList>
+            <actionList>
+                <runProgram>
+                    <program>${blenderPath}</program>
+                    <programArguments>--background --python ${installdir}/add_submitter_to_pref.py -- --deadline_cloud_install_path ${blender_installdir}</programArguments>
+                    <abortOnError>0</abortOnError>
+                    <showMessageOnError>1</showMessageOnError>
+                    <onErrorActionList>
+                        <showQuestion>
+                            <text>An error occured while setting up the AWS Deadline Cloud Submitter. Would you like to visit the AWS Deadline Cloud Github page for manual installation instructions?</text>
+                            <variable>open_github_browser</variable>
+                        </showQuestion>
+                        <if>
+                            <conditionRuleList>
+                                <isTrue value="${open_github_browser}"/>
+                            </conditionRuleList>
+                            <actionList>
+                                <launchBrowser>
+                                    <url>https://github.com/aws-deadline/deadline-cloud-for-blender?tab=readme-ov-file#submitter</url>
+                                </launchBrowser>
+                            </actionList>
+                        </if> 
+                    </onErrorActionList>
+                </runProgram>
+            </actionList>
+        </actionDefinition>
+        <actionDefinition name="fnUnsetBlenderPref">
+            <parameterList>
+                <stringParameter name="blenderPath"/>
+            </parameterList>
+            <actionList>
+                <runProgram>
+                    <program>${blenderPath}</program>
+                    <programArguments>--background --python ${installdir}/remove_submitter_from_pref.py -- --deadline_cloud_install_path ${blender_installdir}</programArguments>
+                    <abortOnError>0</abortOnError>
+                    <showMessageOnError>1</showMessageOnError>
+                    <customErrorMessage>An error occured while uninstalling the AWS Deadline Cloud Submitter from Blender. The addon and scripts directory may need to be removed manually.</customErrorMessage>
+                </runProgram>
+            </actionList>
+        </actionDefinition>
+    </functionDefinitionList>
     <componentList>
         <component>
             <name>blender_36</name>
             <description>Blender 3.6</description>
-            <selected>0</selected>
+            <selected>1</selected>
             <parameterList>
                 <fileParameter>
                     <name>blender_36_path</name>
                     <description>Path to Blender 3.6</description>
-                    <explanation>Enter the path to Blender 3.6. For easiest installation, Blender should be installed before installing Deadline Cloud for Blender.</explanation>
+                    <explanation>Enter the path to Blender 3.6. For easiest installation, Blender should be installed before installing AWS Deadline Cloud for Blender.</explanation>
                     <default>${blender_36_default}</default>
                     <allowEmptyValue>0</allowEmptyValue>
                     <ask>yes</ask>
@@ -79,13 +124,7 @@
                         <setInstallerVariable name="blender_36_path" value="${blender_36_path}/Contents/MacOS/Blender" />
                     </actionList>
                 </if>
-                <runProgram>
-                    <program>${blender_36_path}</program>
-                    <programArguments>--background --python ${installdir}/add_submitter_to_pref.py -- --deadline_cloud_install_path ${blender_installdir}</programArguments>
-                    <abortOnError>0</abortOnError>
-                    <showMessageOnError>1</showMessageOnError>
-                    <customErrorMessage>An error occured while setting up the AWS Deadline Submitter. Visit https://github.com/aws-deadline/deadline-cloud-for-blender?tab=readme-ov-file#submitter for manual installation instructions.</customErrorMessage>
-                </runProgram>
+                <fnSetBlenderPref blenderPath="${blender_36_path}"/>
             </postInstallationActionList>
             <preUninstallationActionList>
                 <if>
@@ -96,24 +135,18 @@
                         <setInstallerVariable name="blender_36_path" value="${blender_36_path}/Contents/MacOS/Blender" />
                     </actionList>
                 </if>
-                <runProgram>
-                    <program>${blender_36_path}</program>
-                    <programArguments>--background --python ${installdir}/remove_submitter_from_pref.py -- --deadline_cloud_install_path ${blender_installdir}</programArguments>
-                    <abortOnError>0</abortOnError>
-                    <showMessageOnError>1</showMessageOnError>
-                    <customErrorMessage>An error occured while uninstalling the AWS Deadline Submitter from Blender. The addon and scripts directory may need to be removed manually.</customErrorMessage>
-                </runProgram>
+                <fnUnsetBlenderPref blenderPath="${blender_36_path}"/>
             </preUninstallationActionList>
         </component>
         <component>
             <name>blender_4</name>
             <description>Blender 4.0</description>
-            <selected>0</selected>
+            <selected>1</selected>
             <parameterList>
                 <fileParameter>
                     <name>blender_4_path</name>
                     <description>Path to Blender 4.0</description>
-                    <explanation>Enter the path to Blender 4.0. For easiest installation, Blender should be installed before installing Deadline Cloud for Blender.</explanation>
+                    <explanation>Enter the path to Blender 4.0. For easiest installation, Blender should be installed before installing AWS Deadline Cloud for Blender.</explanation>
                     <default>${blender_4_default}</default>
                     <allowEmptyValue>0</allowEmptyValue>
                     <ask>yes</ask>
@@ -131,13 +164,7 @@
                         <setInstallerVariable name="blender_4_path" value="${blender_4_path}/Contents/MacOS/Blender" />
                     </actionList>
                 </if>
-                <runProgram>
-                    <program>${blender_4_path}</program>
-                    <programArguments>--background --python ${installdir}/add_submitter_to_pref.py -- --deadline_cloud_install_path ${blender_installdir}</programArguments>
-                    <abortOnError>0</abortOnError>
-                    <showMessageOnError>1</showMessageOnError>
-                    <customErrorMessage>An error occured while setting up the AWS Deadline Submitter. Visit https://github.com/aws-deadline/deadline-cloud-for-blender?tab=readme-ov-file#submitter for manual installation instructions.</customErrorMessage>
-                </runProgram>
+                <fnSetBlenderPref blenderPath="${blender_4_path}"/>
             </postInstallationActionList>
             <preUninstallationActionList>
                 <if>
@@ -148,24 +175,18 @@
                         <setInstallerVariable name="blender_4_path" value="${blender_4_path}/Contents/MacOS/Blender" />
                     </actionList>
                 </if>
-                <runProgram>
-                    <program>${blender_4_path}</program>
-                    <programArguments>--background --python ${installdir}/remove_submitter_from_pref.py -- --deadline_cloud_install_path ${blender_installdir}</programArguments>
-                    <abortOnError>0</abortOnError>
-                    <showMessageOnError>1</showMessageOnError>
-                    <customErrorMessage>An error occured while uninstalling the AWS Deadline Submitter from Blender. The addon and scripts directory may need to be removed manually.</customErrorMessage>
-                </runProgram>
+                <fnUnsetBlenderPref blenderPath="${blender_4_path}"/>
             </preUninstallationActionList>
         </component>
         <component>
             <name>blender_41</name>
             <description>Blender 4.1</description>
-            <selected>0</selected>
+            <selected>1</selected>
             <parameterList>
                 <fileParameter>
                     <name>blender_41_path</name>
                     <description>Path to Blender 4.1</description>
-                    <explanation>Enter the path to Blender 4.1. For easiest installation, Blender should be installed before installing Deadline Cloud for Blender.</explanation>
+                    <explanation>Enter the path to Blender 4.1. For easiest installation, Blender should be installed before installing AWS Deadline Cloud for Blender.</explanation>
                     <default>${blender_41_default}</default>
                     <allowEmptyValue>0</allowEmptyValue>
                     <ask>yes</ask>
@@ -183,13 +204,7 @@
                         <setInstallerVariable name="blender_41_path" value="${blender_41_path}/Contents/MacOS/Blender" />
                     </actionList>
                 </if>
-                <runProgram>
-                    <program>${blender_41_path}</program>
-                    <programArguments>--background --python ${installdir}/add_submitter_to_pref.py -- --deadline_cloud_install_path ${blender_installdir}</programArguments>
-                    <abortOnError>0</abortOnError>
-                    <showMessageOnError>1</showMessageOnError>
-                    <customErrorMessage>An error occured while setting up the AWS Deadline Submitter. Visit https://github.com/aws-deadline/deadline-cloud-for-blender?tab=readme-ov-file#submitter for manual installation instructions.</customErrorMessage>
-                </runProgram>
+                <fnSetBlenderPref blenderPath="${blender_41_path}"/>
             </postInstallationActionList>
             <preUninstallationActionList>
                 <if>
@@ -200,24 +215,18 @@
                         <setInstallerVariable name="blender_41_path" value="${blender_41_path}/Contents/MacOS/Blender" />
                     </actionList>
                 </if>
-                <runProgram>
-                    <program>${blender_41_path}</program>
-                    <programArguments>--background --python ${installdir}/remove_submitter_from_pref.py -- --deadline_cloud_install_path ${blender_installdir}</programArguments>
-                    <abortOnError>0</abortOnError>
-                    <showMessageOnError>1</showMessageOnError>
-                    <customErrorMessage>An error occured while uninstalling the AWS Deadline Submitter from Blender. The addon and scripts directory may need to be removed manually.</customErrorMessage>
-                </runProgram>
+                <fnUnsetBlenderPref blenderPath="${blender_41_path}"/>
             </preUninstallationActionList>
         </component>
         <component>
             <name>blender_42</name>
             <description>Blender 4.2</description>
-            <selected>0</selected>
+            <selected>1</selected>
             <parameterList>
                 <fileParameter>
                     <name>blender_42_path</name>
                     <description>Path to Blender 4.2</description>
-                    <explanation>Enter the path to Blender 4.2. For easiest installation, Blender should be installed before installing Deadline Cloud for Blender.</explanation>
+                    <explanation>Enter the path to Blender 4.2. For easiest installation, Blender should be installed before installing AWS Deadline Cloud for Blender.</explanation>
                     <default>${blender_42_default}</default>
                     <allowEmptyValue>0</allowEmptyValue>
                     <ask>yes</ask>
@@ -235,13 +244,7 @@
                         <setInstallerVariable name="blender_42_path" value="${blender_42_path}/Contents/MacOS/Blender" />
                     </actionList>
                 </if>
-                <runProgram>
-                    <program>${blender_42_path}</program>
-                    <programArguments>--background --python ${installdir}/add_submitter_to_pref.py -- --deadline_cloud_install_path ${blender_installdir}</programArguments>
-                    <abortOnError>0</abortOnError>
-                    <showMessageOnError>1</showMessageOnError>
-                    <customErrorMessage>An error occured while setting up the AWS Deadline Submitter. Visit https://github.com/aws-deadline/deadline-cloud-for-blender?tab=readme-ov-file#submitter for manual installation instructions.</customErrorMessage>
-                </runProgram>
+                <fnSetBlenderPref blenderPath="${blender_42_path}"/>
             </postInstallationActionList>
             <preUninstallationActionList>
                 <if>
@@ -252,17 +255,11 @@
                         <setInstallerVariable name="blender_42_path" value="${blender_42_path}/Contents/MacOS/Blender" />
                     </actionList>
                 </if>
-                <runProgram>
-                    <program>${blender_42_path}</program>
-                    <programArguments>--background --python ${installdir}/remove_submitter_from_pref.py -- --deadline_cloud_install_path ${blender_installdir}</programArguments>
-                    <abortOnError>0</abortOnError>
-                    <showMessageOnError>1</showMessageOnError>
-                    <customErrorMessage>An error occured while uninstalling the AWS Deadline Submitter from Blender. The addon and scripts directory may need to be removed manually.</customErrorMessage>
-                </runProgram>
+                <fnUnsetBlenderPref blenderPath="${blender_42_path}"/>
             </preUninstallationActionList>
         </component>
     </componentList>
-    <initializationActionList>
+    <preInitializationActionList>
         <setInstallerVariable name="all_components" value="${all_components} deadline_cloud_for_blender" />
         <setInstallerVariable name="individual_install" value="0"/>
         <if>
@@ -298,7 +295,7 @@
                 <setInstallerVariable name="blender_42_default" value="/Applications/Blender.app" />
             </actionList>
         </if>
-    </initializationActionList>
+    </preInitializationActionList>
     <readyToInstallActionList>
         <if>
             <conditionRuleList>

--- a/installer/add_submitter_to_pref.py
+++ b/installer/add_submitter_to_pref.py
@@ -1,0 +1,38 @@
+import bpy
+import addon_utils
+import argparse
+import sys
+
+
+class ArgumentParserForBlender(argparse.ArgumentParser):
+    def _get_argv_after_doubledash(self):
+        try:
+            return sys.argv[sys.argv.index("--") + 1 :]  # the list after '--'
+        except ValueError:  # '--' not in the list:
+            return []
+
+    def parse_args(self):
+        return super().parse_args(args=self._get_argv_after_doubledash())
+
+
+def main():
+    parser = ArgumentParserForBlender(description="Add Deadline Cloud to Blender preferences")
+    parser.add_argument(
+        "--deadline_cloud_install_path", required=True, help="Path to Deadline Cloud installation"
+    )
+    args = parser.parse_args()
+
+    bpy.ops.preferences.script_directory_add(directory=args.deadline_cloud_install_path)
+    bpy.utils.load_scripts(refresh_scripts=True)
+
+    for script_dir in bpy.context.preferences.filepaths.script_directories:
+        if script_dir.directory == args.deadline_cloud_install_path:
+            script_dir.name == "Deadline for Blender"
+
+    addon_utils.enable("deadline_cloud_blender_submitter", default_set=True)
+
+    bpy.ops.wm.save_userpref()
+
+
+if __name__ == "__main__":
+    main()

--- a/installer/add_submitter_to_pref.py
+++ b/installer/add_submitter_to_pref.py
@@ -1,3 +1,5 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
 import bpy
 import addon_utils
 import argparse
@@ -24,10 +26,6 @@ def main():
 
     bpy.ops.preferences.script_directory_add(directory=args.deadline_cloud_install_path)
     bpy.utils.load_scripts(refresh_scripts=True)
-
-    for script_dir in bpy.context.preferences.filepaths.script_directories:
-        if script_dir.directory == args.deadline_cloud_install_path:
-            script_dir.name == "Deadline for Blender"
 
     addon_utils.enable("deadline_cloud_blender_submitter", default_set=True)
 

--- a/installer/add_submitter_to_pref.py
+++ b/installer/add_submitter_to_pref.py
@@ -1,5 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+# Adds the Deadline Cloud Install Path to Blender's Script directory list.
+# Then enables the submitters plugin.
+
 import bpy
 import addon_utils
 import argparse

--- a/installer/remove_submitter_from_pref.py
+++ b/installer/remove_submitter_from_pref.py
@@ -1,0 +1,35 @@
+import bpy
+import addon_utils
+import argparse
+import sys
+
+
+class ArgumentParserForBlender(argparse.ArgumentParser):
+    def _get_argv_after_doubledash(self):
+        try:
+            return sys.argv[sys.argv.index("--") + 1 :]  # the list after '--'
+        except ValueError:  # '--' not in the list:
+            return []
+
+    def parse_args(self):
+        return super().parse_args(args=self._get_argv_after_doubledash())
+
+
+def main():
+    parser = ArgumentParserForBlender(description="Remove Submitter Script Directory")
+    parser.add_argument(
+        "--deadline_cloud_install_path", required=True, help="Path to Deadline Cloud installation"
+    )
+    args = parser.parse_args()
+
+    addon_utils.disable("deadline_cloud_blender_submitter", default_set=True)
+
+    for index, script_dir in enumerate(bpy.context.preferences.filepaths.script_directories):
+        if script_dir.directory == args.deadline_cloud_install_path:
+            bpy.ops.preferences.script_directory_remove(index)
+
+    bpy.ops.wm.save_userpref()
+
+
+if __name__ == "__main__":
+    main()

--- a/installer/remove_submitter_from_pref.py
+++ b/installer/remove_submitter_from_pref.py
@@ -1,3 +1,5 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
 import bpy
 import addon_utils
 import argparse

--- a/installer/remove_submitter_from_pref.py
+++ b/installer/remove_submitter_from_pref.py
@@ -1,5 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+# Disables the Deadline Blender Submitter plugin.
+# Then removes all instances of the Deadline Cloud install path from Blender's scripts directories list.
+
 import bpy
 import addon_utils
 import argparse


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We current make users perform some manual steps to install the Blender Submitter addon.

### What was the solution? (How)

I've added 2 scripts that automate the adding and removal of the Submitter addon in Blender. I've modified the Blender installer to prompt the user for paths to their Blender installs. For each install, we run the add settings script. It adds the scripts directory, refreshes and then installs the addon. The uninstaller, removes the addon and removes all instances of the chosen directory from the scripts directories. If either script fails, we show a message but don't abort the installation process. Users are still able to manually perform these steps. An error message will be shown.

New Blender component page:

<img width="551" height="377" alt="image" src="https://github.com/user-attachments/assets/c5b70d74-4dce-4bfb-8765-c4ebb485635d" />

Example path to Blender page:

<img width="549" height="378" alt="image" src="https://github.com/user-attachments/assets/f7126e8c-9c9f-46e5-9831-adfe63143a45" />

Error dialog:

<img width="552" height="375" alt="image" src="https://github.com/user-attachments/assets/3f151fa5-a992-4059-a60b-b39b16195208" />


### What is the impact of this change?

More straightforward installation!

### How was this change tested?

I built the installer locally and ran it against my local install of Blender. I also ran the scripts through Blender numerous times outside of the installer context.  

### Was this change documented?

No.

### Is this a breaking change?

No.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*