### PR TITLE
refactor: Update integ tests to find Blender automatically

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -53,11 +53,9 @@ hatch run test-installer
 
 ### Run Integration Tests
 
-1. Set the environment variable `BLENDER_EXECUTABLE` to the location of the Blender application.
-   1. `export BLENDER_EXECUTABLE=<BlenderLocation>` on Linux and MacOS.
-      1. Default on MacOS is `/Applications/Blender.app/Contents/MacOS/Blender`
-   1. `set BLENDER_EXECUTABLE=<BlenderLocation>` on Windows.
-      1. Default on Windows is `C:\Program Files\Blender Foundation\Blender\blender.exe`
+1. If you can run `blender` from your terminal or on Windows/MacOS you did a default Blender install,
+   the tests will find Blender automatically. Otherwise, set the environment variable `BLENDER_EXECUTABLE`
+   to the location of your Blender application.
 2. Run `hatch run integ:test`
 
 ### Manual Installation

--- a/test/integ/conftest.py
+++ b/test/integ/conftest.py
@@ -2,13 +2,43 @@
 
 import pytest
 import os
+import shutil
+import sys
 
 from pathlib import Path
 
 
 @pytest.fixture
 def blender_location() -> Path:
-    return Path(os.environ["BLENDER_EXECUTABLE"])
+    # If BLENDER_EXECUTABLE is set, always use it
+    location = os.environ.get("BLENDER_EXECUTABLE")
+    if location:
+        return Path(location)
+
+    # If Blender is in the PATH, use that
+    location = shutil.which("blender")
+    if location:
+        return Path(location)
+
+    # On Windows and MacOS, look for Blender in the default install location
+    if os.name == "nt":
+        for version in ("4.4", "4.3", "4.2", "3.6"):
+            location = os.path.join(
+                os.environ["ProgramFiles"],
+                "Blender Foundation",
+                f"Blender {version}",
+                "blender.exe",
+            )
+            if os.path.exists(location):
+                return Path(location)
+    elif sys.platform == "darwin":
+        location = "/Applications/Blender.app/Contents/MacOS/Blender"
+        if os.path.exists(location):
+            return Path(location)
+
+    raise RuntimeError(
+        "Blender could not be found, set the BLENDER_EXECUTABLE environment variable to fix this."
+    )
 
 
 @pytest.fixture

--- a/test/integ/helpers/test_runners.py
+++ b/test/integ/helpers/test_runners.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+import os
 import subprocess
-import yaml
 import json
 
 from pathlib import Path
@@ -50,20 +50,18 @@ def is_valid_template(template_location: Path) -> bool:
     return output_json["status"] == "success"
 
 
-def run_adaptor_test(template_path: Path, job_params: dict[str, Any]) -> None:
-    with open(template_path) as f:
-        template = yaml.safe_load(f)
+def run_adaptor_test(template_path: Path, job_params: dict[str, Any], blender_location) -> None:
+    # Set BLENDER_EXECUTABLE so the adaptor will find it
+    os.environ["BLENDER_EXECUTABLE"] = str(blender_location)
 
-    for step in template["steps"]:
-        output = run_command(
-            [
-                "openjd",
-                "run",
-                str(template_path),
-                "--step",
-                step["name"],
-                "--job-param",
-                json.dumps(job_params),
-            ]
-        )
-        assert output.returncode == 0
+    # Run the full job. The template may contain multiple steps, representing a test in each
+    output = run_command(
+        [
+            "openjd",
+            "run",
+            str(template_path),
+            "--job-param",
+            json.dumps(job_params),
+        ]
+    )
+    assert output.returncode == 0

--- a/test/integ/test_blender_adaptors.py
+++ b/test/integ/test_blender_adaptors.py
@@ -11,10 +11,12 @@ from .helpers.test_runners import run_adaptor_test
 @pytest.mark.adaptor
 class TestAdaptors:
     """
-    Tests that ensure correct output from the Blener adaptor given a job bundle and scene file.
+    Tests that ensure correct output from the Blender adaptor given a job bundle and scene file.
     """
 
-    def test_minimal_scene_adaptor(self, script_location: Path, tmp_path: Path) -> None:
+    def test_minimal_scene_adaptor(
+        self, script_location: Path, tmp_path: Path, blender_location
+    ) -> None:
         test_file_location = script_location / "minimal_test"
         scene_location = test_file_location / "scene" / "test.blend"
         output_path = tmp_path / "output"
@@ -30,14 +32,18 @@ class TestAdaptors:
             "ResolutionY": 480,
         }
 
-        run_adaptor_test(test_file_location / "expected_job_bundle" / "template.yaml", job_params)
+        run_adaptor_test(
+            test_file_location / "expected_job_bundle" / "template.yaml",
+            job_params,
+            blender_location,
+        )
         assert_all_images_close(
             expected_image_directory=test_file_location / "expected_images",
             actual_image_directory=output_path,
         )
 
     def test_minimal_scene_with_host_requirements_adaptor(
-        self, script_location: Path, tmp_path: Path
+        self, script_location: Path, tmp_path: Path, blender_location
     ) -> None:
         test_file_location = script_location / "minimal_test_host_requirements"
         scene_location = test_file_location / "scene" / "test.blend"
@@ -55,7 +61,11 @@ class TestAdaptors:
             "ResolutionY": 480,
         }
 
-        run_adaptor_test(test_file_location / "expected_job_bundle" / "template.yaml", job_params)
+        run_adaptor_test(
+            test_file_location / "expected_job_bundle" / "template.yaml",
+            job_params,
+            blender_location,
+        )
         assert_all_images_close(
             expected_image_directory=test_file_location / "expected_images",
             actual_image_directory=output_path,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

To run the integration tests, you need to set BLENDER_EXECUTABLE, even if you've done a default install of Blender.

### What was the solution? (How)

This change makes it easier to run the integration tests that need Blender installed, when you've done a default install of Blender.

* On Windows and MacOS, have it look in the default install location.
* If `blender` can be run from a terminal, use that.
* Simplified the `openjd` CLI command to run the whole job instead of looping through the steps.

### What is the impact of this change?

It's simpler for contributors to run the integration tests.

### How was this change tested?

Ran the integration tests on Windows without setting BLENDER_EXECUTABLE.

#### Please run the integration tests and paste the results below

```
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
[gw0] [ 25%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
[gw0] [ 50%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
[gw0] [ 75%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter
[gw0] [100%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter

=== slowest 5 durations ===
26.57s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
12.47s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
1.67s call     test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
1.67s call     test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter
0.00s setup    test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
=== 4 passed in 43.09s ===
```

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*