### PR TITLE
feat: add up to Blender 4.5 support to installer and repository

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,7 +17,7 @@ hatch run build
 
 ### Build the installer
 ```bash
-hatch run installer:build-installer --local-dev --platform <PLATFORM> [--install-builder-location <LOCATION> --output-dir <DIR>]
+hatch run installer:build-installer --local-dev --platform <PLATFORM> [--install-builder-path <PATH> --output-dir <DIR>]
 ```
 
 Run `hatch run installer:build-installer --help` to see the full list of arguments.
@@ -73,7 +73,7 @@ These instructions make the following assumptions:
     - For Blender 3.6-4.0 (uses python 3.10):
         - Windows: `pip install --python-version 3.10 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t %USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python\modules`
         - Linux/macOS: `pip install --python-version 3.10 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t ~/DeadlineCloudSubmitter/Submitters/Blender/python/modules`
-    - For Blender 4.1-4.2 (uses python 3.11):
+    - For Blender 4.1-4.5 (uses python 3.11):
         - Windows: `pip install --python-version 3.11 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t %USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python\modules`
         - Linux/macOS: `pip install --python-version 3.11 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t ~/DeadlineCloudSubmitter/Submitters/Blender/python/modules`
 1. Add a script directory in Blender by "Edit" > "Preferences" > "File Paths" > "Script Directories"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ AWS Deadline Cloud for Blender is a python package that allows users to create [
 
 This library requires:
 
-1. Blender 3.6 or greater,
+1. Blender 3.6 - 4.5,
 1. Python 3.9 to 3.12; and
 1. Linux, Windows, or a macOS operating system.
    * Adaptor only supports Linux and macOS

--- a/install_builder/deadline-cloud-for-blender.xml
+++ b/install_builder/deadline-cloud-for-blender.xml
@@ -1,15 +1,15 @@
 <!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
 <componentGroup>
     <name>deadline_cloud_for_blender</name>
-    <description>AWS Deadline Cloud for Blender 3.6-4.2</description>
+    <description>AWS Deadline Cloud for Blender 3.6-4.5</description>
     <detailedDescription>Blender plugin for submitting jobs to AWS Deadline Cloud</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
     <show>1</show>
     <parameterList>
         <stringParameter name="deadline_cloud_for_blender_summary" ask="0" cliOptionShow="0">
-            <value>AWS Deadline Cloud for Blender 3.6-4.2
-- Compatible with Blender 3.6 to 4.2
+            <value>AWS Deadline Cloud for Blender 3.6-4.5
+- Compatible with Blender 3.6 to 4.5
 - Install the integrated Blender submitter files to the installation directory</value>
         </stringParameter>
     </parameterList>
@@ -60,7 +60,7 @@
             <actionList>
                 <runProgram>
                     <program>${blenderPath}</program>
-                    <programArguments>--background --python ${installdir}/add_submitter_to_pref.py -- --deadline_cloud_install_path ${blender_installdir}</programArguments>
+                    <programArguments>--background --python "${installdir}/add_submitter_to_pref.py" -- --deadline_cloud_install_path "${blender_installdir}"</programArguments>
                     <abortOnError>0</abortOnError>
                     <showMessageOnError>1</showMessageOnError>
                     <onErrorActionList>
@@ -89,7 +89,7 @@
             <actionList>
                 <runProgram>
                     <program>${blenderPath}</program>
-                    <programArguments>--background --python ${installdir}/remove_submitter_from_pref.py -- --deadline_cloud_install_path ${blender_installdir}</programArguments>
+                    <programArguments>--background --python "${installdir}/remove_submitter_from_pref.py" -- --deadline_cloud_install_path "${blender_installdir}"</programArguments>
                     <abortOnError>0</abortOnError>
                     <showMessageOnError>1</showMessageOnError>
                     <customErrorMessage>An error occured while uninstalling the AWS Deadline Cloud Submitter from Blender. The addon and scripts directory may need to be removed manually.</customErrorMessage>
@@ -127,14 +127,6 @@
                 <fnSetBlenderPref blenderPath="${blender_36_path}"/>
             </postInstallationActionList>
             <preUninstallationActionList>
-                <if>
-                    <conditionRuleList>
-                        <platformTest type="osx"/>
-                    </conditionRuleList>
-                    <actionList>
-                        <setInstallerVariable name="blender_36_path" value="${blender_36_path}/Contents/MacOS/Blender" />
-                    </actionList>
-                </if>
                 <fnUnsetBlenderPref blenderPath="${blender_36_path}"/>
             </preUninstallationActionList>
         </component>
@@ -167,14 +159,6 @@
                 <fnSetBlenderPref blenderPath="${blender_4_path}"/>
             </postInstallationActionList>
             <preUninstallationActionList>
-                <if>
-                    <conditionRuleList>
-                        <platformTest type="osx"/>
-                    </conditionRuleList>
-                    <actionList>
-                        <setInstallerVariable name="blender_4_path" value="${blender_4_path}/Contents/MacOS/Blender" />
-                    </actionList>
-                </if>
                 <fnUnsetBlenderPref blenderPath="${blender_4_path}"/>
             </preUninstallationActionList>
         </component>
@@ -207,14 +191,6 @@
                 <fnSetBlenderPref blenderPath="${blender_41_path}"/>
             </postInstallationActionList>
             <preUninstallationActionList>
-                <if>
-                    <conditionRuleList>
-                        <platformTest type="osx"/>
-                    </conditionRuleList>
-                    <actionList>
-                        <setInstallerVariable name="blender_41_path" value="${blender_41_path}/Contents/MacOS/Blender" />
-                    </actionList>
-                </if>
                 <fnUnsetBlenderPref blenderPath="${blender_41_path}"/>
             </preUninstallationActionList>
         </component>
@@ -247,15 +223,103 @@
                 <fnSetBlenderPref blenderPath="${blender_42_path}"/>
             </postInstallationActionList>
             <preUninstallationActionList>
+                <fnUnsetBlenderPref blenderPath="${blender_42_path}"/>
+            </preUninstallationActionList>
+        </component>
+        <component>
+            <name>blender_43</name>
+            <description>Blender 4.3</description>
+            <selected>0</selected>
+            <parameterList>
+                <fileParameter>
+                    <name>blender_43_path</name>
+                    <description>Path to Blender 4.3</description>
+                    <explanation>Enter the path to Blender 4.3. For easiest installation, Blender should be installed before installing AWS Deadline Cloud for Blender.</explanation>
+                    <default>${blender_43_default}</default>
+                    <allowEmptyValue>0</allowEmptyValue>
+                    <ask>yes</ask>
+                    <cliOptionName>blender-43-path</cliOptionName>
+                    <cliOptionText>Path to the Blender 4.3.</cliOptionText>
+                    <osxBundlesAreFiles>1</osxBundlesAreFiles>
+                </fileParameter>
+            </parameterList>
+            <postInstallationActionList>
                 <if>
                     <conditionRuleList>
                         <platformTest type="osx"/>
                     </conditionRuleList>
                     <actionList>
-                        <setInstallerVariable name="blender_42_path" value="${blender_42_path}/Contents/MacOS/Blender" />
+                        <setInstallerVariable name="blender_43_path" value="${blender_43_path}/Contents/MacOS/Blender" />
                     </actionList>
                 </if>
-                <fnUnsetBlenderPref blenderPath="${blender_42_path}"/>
+                <fnSetBlenderPref blenderPath="${blender_43_path}"/>
+            </postInstallationActionList>
+            <preUninstallationActionList>
+                <fnUnsetBlenderPref blenderPath="${blender_43_path}"/>
+            </preUninstallationActionList>
+        </component>
+        <component>
+            <name>blender_44</name>
+            <description>Blender 4.4</description>
+            <selected>0</selected>
+            <parameterList>
+                <fileParameter>
+                    <name>blender_44_path</name>
+                    <description>Path to Blender 4.4</description>
+                    <explanation>Enter the path to Blender 4.4. For easiest installation, Blender should be installed before installing AWS Deadline Cloud for Blender.</explanation>
+                    <default>${blender_44_default}</default>
+                    <allowEmptyValue>0</allowEmptyValue>
+                    <ask>yes</ask>
+                    <cliOptionName>blender-44-path</cliOptionName>
+                    <cliOptionText>Path to the Blender 4.4.</cliOptionText>
+                    <osxBundlesAreFiles>1</osxBundlesAreFiles>
+                </fileParameter>
+            </parameterList>
+            <postInstallationActionList>
+                <if>
+                    <conditionRuleList>
+                        <platformTest type="osx"/>
+                    </conditionRuleList>
+                    <actionList>
+                        <setInstallerVariable name="blender_44_path" value="${blender_44_path}/Contents/MacOS/Blender"/>
+                    </actionList>
+                </if>
+                <fnSetBlenderPref blenderPath="${blender_44_path}"/>
+            </postInstallationActionList>
+            <preUninstallationActionList>
+                <fnUnsetBlenderPref blenderPath="${blender_44_path}"/>
+            </preUninstallationActionList>
+        </component>
+        <component>
+            <name>blender_45</name>
+            <description>Blender 4.5</description>
+            <selected>0</selected>
+            <parameterList>
+                <fileParameter>
+                    <name>blender_45_path</name>
+                    <description>Path to Blender 4.5</description>
+                    <explanation>Enter the path to Blender 4.5. For easiest installation, Blender should be installed before installing AWS Deadline Cloud for Blender.</explanation>
+                    <default>${blender_45_default}</default>
+                    <allowEmptyValue>0</allowEmptyValue>
+                    <ask>yes</ask>
+                    <cliOptionName>blender-45-path</cliOptionName>
+                    <cliOptionText>Path to the Blender 4.5</cliOptionText>
+                    <osxBundlesAreFiles>1</osxBundlesAreFiles>
+                </fileParameter>
+            </parameterList>
+            <postInstallationActionList>
+                <if>
+                    <conditionRuleList>
+                        <platformTest type="osx"/>
+                    </conditionRuleList>
+                    <actionList>
+                        <setInstallerVariable name="blender_45_path" value="${blender_45_path}/Contents/MacOS/Blender"/>
+                    </actionList>
+                </if>
+                <fnSetBlenderPref blenderPath="${blender_45_path}"/>
+            </postInstallationActionList>
+            <preUninstallationActionList>
+                <fnUnsetBlenderPref blenderPath="${blender_45_path}"/>
             </preUninstallationActionList>
         </component>
     </componentList>
@@ -271,6 +335,9 @@
                 <setInstallerVariable name="blender_4_default" value="C:\Program Files\Blender Foundation\Blender 4.0\blender.exe" />
                 <setInstallerVariable name="blender_41_default" value="C:\Program Files\Blender Foundation\Blender 4.1\blender.exe" />
                 <setInstallerVariable name="blender_42_default" value="C:\Program Files\Blender Foundation\Blender 4.2\blender.exe" />
+                <setInstallerVariable name="blender_43_default" value="C:\Program Files\Blender Foundation\Blender 4.3\blender.exe" />
+                <setInstallerVariable name="blender_44_default" value="C:\Program Files\Blender Foundation\Blender 4.4\blender.exe" />
+                <setInstallerVariable name="blender_45_default" value="C:\Program Files\Blender Foundation\Blender 4.5\blender.exe" />
             </actionList>
         </if>
         <if>
@@ -282,6 +349,9 @@
                 <setInstallerVariable name="blender_4_default" value="/usr/local/blender" />
                 <setInstallerVariable name="blender_41_default" value="/usr/local/blender" />
                 <setInstallerVariable name="blender_42_default" value="/usr/local/blender" />
+                <setInstallerVariable name="blender_43_default" value="/usr/local/blender" />
+                <setInstallerVariable name="blender_44_default" value="/usr/local/blender" />
+                <setInstallerVariable name="blender_45_default" value="/usr/local/blender" />
             </actionList>
         </if>
         <if>
@@ -293,6 +363,9 @@
                 <setInstallerVariable name="blender_4_default" value="/Applications/Blender.app" />
                 <setInstallerVariable name="blender_41_default" value="/Applications/Blender.app" />
                 <setInstallerVariable name="blender_42_default" value="/Applications/Blender.app" />
+                <setInstallerVariable name="blender_43_default" value="/Applications/Blender.app" />
+                <setInstallerVariable name="blender_44_default" value="/Applications/Blender.app" />
+                <setInstallerVariable name="blender_45_default" value="/Applications/Blender.app" />
             </actionList>
         </if>
     </preInitializationActionList>

--- a/scripts/build_installer.py
+++ b/scripts/build_installer.py
@@ -76,7 +76,7 @@ def build_installer(
     """
     if install_builder_location is None:
         raise FileNotFoundError(
-            "Could not find a default InstallBuilder path. Please specify one with '--install-builder-location'."
+            "Could not find a default InstallBuilder path. Please specify one with '--install-builder-path'."
         )
 
     if not install_builder_location.is_dir():

--- a/test/integ/conftest.py
+++ b/test/integ/conftest.py
@@ -22,7 +22,7 @@ def blender_location() -> Path:
 
     # On Windows and MacOS, look for Blender in the default install location
     if os.name == "nt":
-        for version in ("4.4", "4.3", "4.2", "3.6"):
+        for version in ("4.5", "4.4", "4.3", "4.2", "4.1", "4.0", "3.6"):
             location = os.path.join(
                 os.environ["ProgramFiles"],
                 "Blender Foundation",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Blender 4.5 released as the new LTS version and we should support it.

### What was the solution? (How)
Add support for up to Blender 4.5
* Updated READMEs
* Updated installer components
* Fixed a bug where spaces in the Windows path name were causing failures when trying to run the plugin script to install within Blender
* Removed some unnecessary variable setting for the Mac installers on uninstallation(this was verified that it works without even in non-default install locations)

### What is the impact of this change?
The submitter now reflects that it works with Blender 4.5 and in the near future it will be available as an option to install for in the submitter installer

### How was this change tested?
* Manually built installers for Windows, MacOS and Linux
  * Ran the installer on each OS with Blender 4.5 selected and verified it was installed/uninstalled correctly
  * Changed the install path of Blender to be non-default and made sure things still installed/uninstalled correctly
 
<img width="410" height="278" alt="image" src="https://github.com/user-attachments/assets/e35f54be-0eaf-46e6-b469-632ee1ef42c7" />

#### Please run the integration tests and paste the results below

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below
The existing tests all passed

### Was this change documented?
There are docs updates as part of this

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*