### PR TITLE
fix: unnecessary brush assets included as job attachments

### DIFF
--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/blender_utils.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/blender_utils.py
@@ -78,20 +78,42 @@ def find_files(project_path, skip_temp=True, skip_nonexistent=True) -> list[Path
     files.append(project_path)
     files = set(Path(f) for f in files)
 
+    temp_dirs = []
     if skip_temp:
         temp_dirs = _get_blender_temp_dirs()
         _logger.debug(f"Resolved Blender temp directories: {temp_dirs}")
 
-        def is_in_temp(f: Path):
-            """Returns True if the given file is in any of Blender's temp directories."""
-            return any(f.is_relative_to(temp_dir) for temp_dir in temp_dirs)
+    # Path where Blender stores its built-in brush asset .blend files
+    blender_resource_path = Path(bpy.utils.resource_path("LOCAL"))
 
-        files = (f for f in files if not is_in_temp(f))
+    def _is_in_temp(f: Path) -> bool:
+        """Returns True if the given file is in any of Blender's temp directories."""
+        return any(f.is_relative_to(temp_dir) for temp_dir in temp_dirs)
 
-    if skip_nonexistent:
-        files = (f for f in files if f.exists())
+    def _is_essential_brush(path: Path) -> bool:
+        """
+        Returns True if the given file is a built-in brush asset.
+        Any paths to files within the local Blender resource folder prefixed with
+        'essentials_brushes-' are filtered out since these are bundled with Blender and appear
+        to be unneccesary for just rendering. These files were previously included in the main
+        .blend file but with 4.3+ they are now separate assets in the Blender install
+        https://code.blender.org/2024/07/brush-assets-is-out/#new-brush-workflow
+        """
+        return path.is_relative_to(blender_resource_path) and path.name.startswith(
+            "essentials_brushes-"
+        )
 
-    return [Path(os.path.abspath(f)) for f in files]
+    filtered_files = []
+    for file in files:
+        if (
+            (skip_temp and _is_in_temp(file))
+            or (skip_nonexistent and not file.exists())
+            or _is_essential_brush(file)
+        ):
+            continue
+        filtered_files.append(Path(os.path.abspath(file)))
+
+    return filtered_files
 
 
 def _get_blender_temp_dirs() -> list[Path]:

--- a/test/unit/deadline_submitter_for_blender/test_blender_utils.py
+++ b/test/unit/deadline_submitter_for_blender/test_blender_utils.py
@@ -1,0 +1,90 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# Ensure the submitter can be imported.
+SUBMITTER_DIR = (
+    Path(__file__).parent.parent.parent.parent
+    / "src"
+    / "deadline"
+    / "blender_submitter"
+    / "addons"
+    / "deadline_cloud_blender_submitter"
+)
+sys.path.append(str(SUBMITTER_DIR))
+
+import blender_utils as bu  # noqa: E402
+
+
+class TestFindFiles:
+
+    def test_find_files(self, tmp_path):
+        """Test all filtering functionality. temp files, non-existent files, and essential brushes."""
+
+        # GIVEN
+
+        project_dir = Path(tmp_path, "project")
+        project_dir.mkdir()
+        project_file = Path(project_dir, "test.blend")
+        project_file.write_text("blend file content")
+
+        # Create temp directory and file
+        temp_dir = Path(tmp_path, "TEMP")
+        temp_dir.mkdir()
+        temp_file = Path(temp_dir, "temp_texture.png")
+        temp_file.write_text("temp texture")
+
+        # Create brush directory and files
+        blender_resource_dir = Path(tmp_path, "blender", "XX")
+        brush_dir = Path(blender_resource_dir, "datafiles", "assets", "brushes")
+        brush_dir.mkdir(parents=True)
+        essential_brush = Path(brush_dir, "essentials_brushes-sculpt.blend")
+        custom_brush = Path(brush_dir, "custom_brush.blend")
+        essential_brush.write_text("essential brush")
+        custom_brush.write_text("custom brush")
+
+        # Create valid project files
+        texture_dir = Path(project_dir, "textures")
+        texture_dir.mkdir(parents=True)
+        valid_file1 = Path(project_dir, "valid_image.png")
+        valid_file2 = Path(project_dir, "textures", "valid_texture2.png")
+        valid_file1.write_text("valid image")
+        valid_file2.write_text("valid texture")
+
+        # File that doesn't exist
+        missing_file = Path(project_dir, "missing_texture.png")
+
+        all_files = [
+            temp_file,
+            missing_file,
+            essential_brush,
+            valid_file1,
+            valid_file2,
+            custom_brush,
+        ]
+
+        with (
+            patch("blender_utils.bpy.utils.blend_paths", return_value=all_files),
+            patch("blender_utils.bpy.utils.resource_path", return_value=blender_resource_dir),
+            patch("blender_utils._get_blender_temp_dirs", return_value=[temp_dir]),
+        ):
+
+            # WHEN
+
+            found_files = bu.find_files(project_file)
+
+            # THEN
+
+            # Verify filtered files are not in results
+            assert temp_file not in found_files
+            assert missing_file not in found_files
+            assert essential_brush not in found_files
+
+            # Verify included files are in results
+            assert project_file in found_files
+            assert valid_file1 in found_files
+            assert valid_file2 in found_files
+            assert custom_brush in found_files
+            assert len(found_files) == 4


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
In versions of Blender 4.3+ even the default cube scene was detecting additional assets to upload. These assets appear to be built-in brush assets in the Blender install. Even if a brush hasn't been used yet in the scene at least one seems to be returned by the call to `bpy.utils.blend_paths()`. It's unclear if this is intentional behaviour or if `bpy.utils.blend_paths` should filter these out since the [API docs](https://docs.blender.org/api/current/bpy.utils.html#bpy.utils.blend_paths) say that function returns __external__ files only(which I guess these are since they are external to the scene).
### What was the solution? (How)
Based on my reading this was a [change](https://code.blender.org/2024/07/brush-assets-is-out/#new-brush-workflow) in Blender 4.3+ where brushes are no longer baked into the .blend file but instead stored as external assets, including the built-in ones. My understanding of [Blender brushes](https://docs.blender.org/manual/en/latest/sculpt_paint/brush/introduction.html) is that they are used to manipulate the current scene by modifying the geometry or visuals and you can save out different brushes with different characteristics. I couldn't find anything suggesting that these brush assets are actually needed at render time once the scene is saved and sent to the farm. I also did not run into any issues when submitting renders without including the brush assets that were being returned by `bpy.utils.blend_paths`.

Therefore, I've added an additional filter check where we collect the list of input attachments and filter out any that are located within the local Blender resources directory(from calling bpy.utils.resource_paths("LOCAL")) and start with `essentials_brushes-`.

### What is the impact of this change?
No seemingly unnecessary files being detected as job attachments.

### How was this change tested?
* Created a new unit test to cover the find_files logic
* Ran manual submission tests on Windows in Blender 4.5 and 3.6.
  * Verified that the brush asset was being returned by the `bpy.utils.blend_paths()` call in 4.5, but not being added as an attachment. 
  * Verified that the jobs ran on both 3.6 and 4.5 and no notable errors in the logs due to the missing brush asset on 4.5. Outputs also looked correct.
#### Please run the integration tests and paste the results below
```
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
[gw0] [ 25%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
[gw0] [ 50%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
[gw0] [ 75%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter
[gw0] [100%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter

============================================================================================== slowest 5 durations ==============================================================================================
135.04s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
62.24s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
9.14s call     test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter
8.27s call     test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
0.01s setup    test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
========================================================================================= 4 passed in 217.80s (0:03:37) =========================================================================================
```
### Was this change documented?
No

### Is this a breaking change?
No, it shouldn't be. The only case where I could see an argument for it being possibly breaking is if a user was already for some reason creating custom asset files inside __Blender's__ resource folder with the same name prefix as the internal ones.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*