### PR TITLE
revert: "chore: update to deadline-cloud 0.51.* (#256)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 # Blender 4.1+ uses Python version 3.11
 
 dependencies = [
-    "deadline == 0.51.*", 
+    "deadline >= 0.49,< 0.51", 
     "openjd-adaptor-runtime >= 0.7,< 0.10",
 ]
 

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
@@ -9,12 +9,8 @@ from qtpy.QtCore import Qt  # type: ignore
 
 from deadline.client import api
 from deadline.client.job_bundle._yaml import deadline_yaml_dump
-from deadline.client.job_bundle.parameters import JobParameter
 from deadline.client.job_bundle.submission import AssetReferences
-from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (
-    SubmitJobToDeadlineDialog,
-    JobBundlePurpose,
-)
+from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import SubmitJobToDeadlineDialog
 
 from . import blender_utils as bu
 from . import sanity_checks as sc
@@ -129,10 +125,10 @@ def _create_bundle(
     widget: SubmitJobToDeadlineDialog,
     job_bundle_dir: str,
     settings: tf.BlenderSubmitterUISettings,
-    queue_parameters: list[JobParameter],
+    queue_parameters: list[dict[str, Any]],
     asset_references: AssetReferences,
-    host_requirements: Optional[dict[str, Any]] = None,
-    purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
+    requirements: Optional[dict[str, Any]] = None,
+    purpose: Optional[str] = None,
 ) -> dict[str, Any]:
     """Create and write Deadline job bundle files to the given directory. Also save sticky settings.
 
@@ -146,17 +142,11 @@ def _create_bundle(
         settings: The job settings.
         queue_parameters: The queue parameters.
         asset_references: The asset references.
-        host_requirements: The host requirements. There are only passed if the user has specified custom host requirements in the UI. If "all available worker hosts" are selected, this is None.
+        requirements: The host requirements. There are only passed if the user has specified custom host requirements in the UI. If "all available worker hosts" are selected, this is None.
         purpose: The purpose of the job bundle.
     """
     return _create_bundle_internal(
-        widget,
-        job_bundle_dir,
-        settings,
-        queue_parameters,
-        asset_references,
-        host_requirements,
-        purpose,
+        widget, job_bundle_dir, settings, queue_parameters, asset_references, requirements, purpose
     )
 
 
@@ -164,10 +154,10 @@ def _create_bundle_internal(
     widget: SubmitJobToDeadlineDialog,
     job_bundle_dir: str,
     settings: tf.BlenderSubmitterUISettings,
-    queue_parameters: list[JobParameter],
+    queue_parameters: list[dict[str, Any]],
     asset_references: AssetReferences,
-    host_requirements: Optional[dict[str, Any]] = None,
-    purpose: Optional[JobBundlePurpose] = None,
+    requirements: Optional[dict[str, Any]] = None,
+    purpose: Optional[str] = None,
     prompt_for_saving=True,
 ) -> dict[str, Any]:
     """Create and write Deadline job bundle files to the given directory. Also save sticky settings.
@@ -179,7 +169,7 @@ def _create_bundle_internal(
         settings: The job settings.
         queue_parameters: The queue parameters.
         asset_references: The asset references.
-        host_requirements: The host requirements. There are only passed if the user has specified custom host requirements in the UI. If "all available worker hosts" are selected, this is None.
+        requirements: The host requirements. There are only passed if the user has specified custom host requirements in the UI. If "all available worker hosts" are selected, this is None.
         purpose: The purpose of the job bundle.
     """
     # Make sure the output path used for submission is absolute
@@ -219,9 +209,7 @@ def _create_bundle_internal(
     if settings.override_frame_range:
         common_layer_settings.frame_range = settings.frame_list
 
-    job_template = tf.fill_job_template(
-        settings, layer_names, common_layer_settings, host_requirements
-    )
+    job_template = tf.fill_job_template(settings, layer_names, common_layer_settings, requirements)
     parameter_values = tf.get_parameter_values(settings, common_layer_settings, queue_parameters)
 
     # Write the job bundle files.

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/template_filling.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/template_filling.py
@@ -16,7 +16,6 @@ from typing import Any, Optional
 
 import yaml
 from deadline.client.exceptions import DeadlineOperationError
-from deadline.client.job_bundle.parameters import JobParameter
 
 _logger = logging.getLogger(__name__)
 
@@ -373,7 +372,7 @@ def _fill_step_template(
 def get_parameter_values(
     settings: BlenderSubmitterUISettings,
     layer_settings: CommonLayerSettings,
-    queue_params: list[JobParameter],
+    queue_params: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     """Collect the parameter values for the job bundle as a list of name/value dicts."""
 
@@ -412,8 +411,8 @@ def get_parameter_values(
     if settings.include_adaptor_wheels:
         wheels_path = str(Path(__file__).parent.parent.parent.parent / "wheels")
         params.append({"name": "OverrideAdaptorWheels", "value": wheels_path})
-        rez_param: Optional[JobParameter] = None
-        conda_param: Optional[JobParameter] = None
+        rez_param = {}
+        conda_param = {}
         # Find the Packages parameter definition in the queue params.
         for param in queue_params:
             if param["name"] == "RezPackages":


### PR DESCRIPTION
This reverts commit 0159265ac6092f175aa5c5c6465f1c2682a995f9. There is a known bug in 0.51.0 where the submission dialog will not close automatically after submitting.

### What was the problem/requirement? (What/Why)
Bug in deadline-cloud 0.51.0: https://github.com/aws-deadline/deadline-cloud/issues/768
### What was the solution? (How)
Revert the change that upgraded and go back to using 0.50.1 as the latest
### What is the impact of this change?
No bug in the Blender submitter from the upgraded version of deadline-cloud

### How was this change tested?
It wasn't, just a revert

#### Please run the integration tests and paste the results below
No
#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below
No
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*