### PR TITLE
chore: update changelog with the 0.5.0 breaking change informational note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ These changes are experimental and are subject to change without warning
 
 ## 0.5.0 (2025-01-13)
 
+### BREAKING CHANGES
+* The blender-openjd adaptor now requires that gpu_device is specified in init_data. This value can be set to NONE if a GPU is not used.
+
 
 ### Features
 * Enable GPU rendering from submitter ([`7a4f8bc`](https://github.com/aws-deadline/deadline-cloud-for-blender/commit/7a4f8bc28f55059b77a6f6d31baa39766fe56c98))


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-blender/issues/271

Updated changelog to indicate what broke from 0.4 -> 0.5 and how an older job template can be updated to support the new adaptor. Will update release notes once this is approved.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*