### PR TITLE
fix: gpu_device isn't marked as required in init-data

### DIFF
--- a/devfiles/adaptor_test_template/template.yaml
+++ b/devfiles/adaptor_test_template/template.yaml
@@ -112,6 +112,7 @@ steps:
           data: |
             scene_file: {{Param.BlenderFile}}
             render_engine: {{Param.RenderEngine}}
+            gpu_device: {{Param.GPUDevice}}
             render_scene: {{Param.RenderScene}}
             render_layer: {{Param.RenderLayer}}
             camera: {{Param.Camera}}
@@ -120,10 +121,8 @@ steps:
             output_format: {{Param.OutputFormat}}
       actions:
         onEnter:
-          command: python3
+          command: blender-openjd
           args:
-            - -m
-            - blender_adaptor.BlenderAdaptor
             - daemon
             - start
             - --connection-file
@@ -133,10 +132,8 @@ steps:
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
         onExit:
-          command: python3
+          command: blender-openjd
           args:
-            - -m
-            - blender_adaptor.BlenderAdaptor
             - daemon
             - stop
             - --connection-file
@@ -152,10 +149,8 @@ steps:
           frame: {{Task.Param.Frame}}
     actions:
       onRun:
-        command: python3
+        command: blender-openjd
         args:
-          - -m
-          - blender_adaptor.BlenderAdaptor
           - daemon
           - run
           - --connection-file

--- a/src/deadline/blender_adaptor/BlenderAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/blender_adaptor/BlenderAdaptor/schemas/init_data.schema.json
@@ -36,6 +36,7 @@
     },
     "required": [
         "scene_file",
-        "render_engine"
+        "render_engine",
+        "gpu_device"
     ]
 }


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-blender/issues/272

### What was the problem/requirement? (What/Why)

Since 0.5.0 gpu_device was required but wasn't explicitly marked as required in the json schema. If users wrote their own job template or manually ported an exported bundle from 0.4 -> 0.5, then they would encounter this error:

```
0:00:03.534549	ADAPTOR_OUTPUT: INFO: Running in background daemon mode.
0:00:03.534633	ADAPTOR_OUTPUT: INFO: Loading 'init_data' schema from /Users/morgane/Library/Application Support/hatch/env/virtual/deadline-cloud-for-blender/Ras5yKni/deadline-cloud-for-blender/lib/python3.12/site-packages/deadline/blender_adaptor/BlenderAdaptor/schemas/init_data.schema.json
0:00:03.534694	ADAPTOR_OUTPUT: INFO: Loading 'run_data' schema from /Users/morgane/Library/Application Support/hatch/env/virtual/deadline-cloud-for-blender/Ras5yKni/deadline-cloud-for-blender/lib/python3.12/site-packages/deadline/blender_adaptor/BlenderAdaptor/schemas/run_data.schema.json
0:00:04.541086	openjd_fail: Error encountered while starting adaptor: 'gpu_device'
0:00:04.542278	ERROR: Entrypoint failed: openjd_fail: Error encountered while starting adaptor: 'gpu_device'
0:00:04.588801	Process pid 92174 exited with code: 1 (unsigned) / 0x1 (hex)
```

which is confusing since it's not required in the json_schema. 

> Note: all 0.5 job bundles have gpu_device specified already

### What was the solution? (How)

Add it as required then has you get this error instead:

```
0:00:03.350310	ADAPTOR_OUTPUT: INFO: Running in background daemon mode.
0:00:03.350389	ADAPTOR_OUTPUT: INFO: Loading 'init_data' schema from /Users/morgane/Library/Application Support/hatch/env/virtual/deadline-cloud-for-blender/Ras5yKni/deadline-cloud-for-blender/lib/python3.12/site-packages/deadline/blender_adaptor/BlenderAdaptor/schemas/init_data.schema.json
0:00:03.350417	ADAPTOR_OUTPUT: INFO: Loading 'run_data' schema from /Users/morgane/Library/Application Support/hatch/env/virtual/deadline-cloud-for-blender/Ras5yKni/deadline-cloud-for-blender/lib/python3.12/site-packages/deadline/blender_adaptor/BlenderAdaptor/schemas/run_data.schema.json
0:00:04.356429	openjd_fail: Error encountered while starting adaptor: 'gpu_device' is a required property
0:00:04.356627	ADAPTOR_OUTPUT: 
0:00:04.356659	ADAPTOR_OUTPUT: Failed validating 'required' in schema:
0:00:04.356683	ADAPTOR_OUTPUT:     {'$schema': 'https://json-schema.org/draft/2020-12/schema',
0:00:04.356704	ADAPTOR_OUTPUT:      'type': 'object',
0:00:04.356724	ADAPTOR_OUTPUT:      'properties': {'scene_file': {'type': 'string'},
0:00:04.356742	ADAPTOR_OUTPUT:                     'render_engine': {'enum': ['eevee',
0:00:04.356898	ADAPTOR_OUTPUT:                                                'workbench',
0:00:04.356995	ADAPTOR_OUTPUT:                                                'cycles']},
0:00:04.357022	ADAPTOR_OUTPUT:                     'gpu_device': {'type': 'string'},
0:00:04.357044	ADAPTOR_OUTPUT:                     'render_scene': {'type': 'string'},
0:00:04.357069	ADAPTOR_OUTPUT:                     'view_layer': {'type': 'string'},
0:00:04.357092	ADAPTOR_OUTPUT:                     'output_dir': {'type': 'string'},
0:00:04.357119	ADAPTOR_OUTPUT:                     'output_file_name': {'type': 'string'},
0:00:04.357148	ADAPTOR_OUTPUT:                     'output_format': {'type': 'string'},
0:00:04.357205	ADAPTOR_OUTPUT:                     'strict_error_checking': {'type': 'boolean'}},
0:00:04.357235	ADAPTOR_OUTPUT:      'required': ['scene_file', 'render_engine', 'gpu_device']}
0:00:04.357340	ADAPTOR_OUTPUT: 
0:00:04.357408	ADAPTOR_OUTPUT: On instance:
0:00:04.357433	ADAPTOR_OUTPUT:     {'scene_file': '/Users/morgane/Documents/Untitled.blend',
0:00:04.357453	ADAPTOR_OUTPUT:      'render_engine': 'cycles',
0:00:04.357473	ADAPTOR_OUTPUT:      'render_scene': 'Scene',
0:00:04.357493	ADAPTOR_OUTPUT:      'render_layer': 'CURRENT_LAYER',
0:00:04.357516	ADAPTOR_OUTPUT:      'camera': 'Camera',
0:00:04.357534	ADAPTOR_OUTPUT:      'output_dir': '/Users/morgane/Documents',
0:00:04.357559	ADAPTOR_OUTPUT:      'output_file_name': 'output_####',
0:00:04.357581	ADAPTOR_OUTPUT:      'output_format': 'PNG'}
0:00:04.393024	Process pid 9526 exited with code: 1 (unsigned) / 0x1 (hex)
```

Note: devfiles can most likely be deleted as they aren't used anywhere, but I used it for my test in this case since it didn't have the gpu_device specified.

### What is the impact of this change?

More complete information for users.

### How was this change tested?

Ran this locally to verify previous behaviour on older job bundles, and on an update job bundle

```
hatch run test
```

#### Please run the integration tests and paste the results below

Tried running them locally, but they're failing with/without the change on blender 4.5.2

### Was this change documented?

This IS documentation

### Is this a breaking change?

Nope. 0.5 already made this option a requirement. This just helps inform users.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*