### PR TITLE
chore: Update deadline requirement to 0.52.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 # Blender 4.1+ uses Python version 3.11
 
 dependencies = [
-    "deadline >= 0.49,< 0.51", 
+    "deadline == 0.52.*", 
     "openjd-adaptor-runtime >= 0.7,< 0.10",
 ]
 

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
@@ -9,8 +9,12 @@ from qtpy.QtCore import Qt  # type: ignore
 
 from deadline.client import api
 from deadline.client.job_bundle._yaml import deadline_yaml_dump
+from deadline.client.job_bundle.parameters import JobParameter
 from deadline.client.job_bundle.submission import AssetReferences
-from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import SubmitJobToDeadlineDialog
+from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (
+    SubmitJobToDeadlineDialog,
+    JobBundlePurpose,
+)
 
 from . import blender_utils as bu
 from . import sanity_checks as sc
@@ -125,10 +129,10 @@ def _create_bundle(
     widget: SubmitJobToDeadlineDialog,
     job_bundle_dir: str,
     settings: tf.BlenderSubmitterUISettings,
-    queue_parameters: list[dict[str, Any]],
+    queue_parameters: list[JobParameter],
     asset_references: AssetReferences,
-    requirements: Optional[dict[str, Any]] = None,
-    purpose: Optional[str] = None,
+    host_requirements: Optional[dict[str, Any]] = None,
+    purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
 ) -> dict[str, Any]:
     """Create and write Deadline job bundle files to the given directory. Also save sticky settings.
 
@@ -142,11 +146,17 @@ def _create_bundle(
         settings: The job settings.
         queue_parameters: The queue parameters.
         asset_references: The asset references.
-        requirements: The host requirements. There are only passed if the user has specified custom host requirements in the UI. If "all available worker hosts" are selected, this is None.
+        host_requirements: The host requirements. There are only passed if the user has specified custom host requirements in the UI. If "all available worker hosts" are selected, this is None.
         purpose: The purpose of the job bundle.
     """
     return _create_bundle_internal(
-        widget, job_bundle_dir, settings, queue_parameters, asset_references, requirements, purpose
+        widget,
+        job_bundle_dir,
+        settings,
+        queue_parameters,
+        asset_references,
+        host_requirements,
+        purpose,
     )
 
 
@@ -154,10 +164,10 @@ def _create_bundle_internal(
     widget: SubmitJobToDeadlineDialog,
     job_bundle_dir: str,
     settings: tf.BlenderSubmitterUISettings,
-    queue_parameters: list[dict[str, Any]],
+    queue_parameters: list[JobParameter],
     asset_references: AssetReferences,
-    requirements: Optional[dict[str, Any]] = None,
-    purpose: Optional[str] = None,
+    host_requirements: Optional[dict[str, Any]] = None,
+    purpose: Optional[JobBundlePurpose] = None,
     prompt_for_saving=True,
 ) -> dict[str, Any]:
     """Create and write Deadline job bundle files to the given directory. Also save sticky settings.
@@ -169,7 +179,7 @@ def _create_bundle_internal(
         settings: The job settings.
         queue_parameters: The queue parameters.
         asset_references: The asset references.
-        requirements: The host requirements. There are only passed if the user has specified custom host requirements in the UI. If "all available worker hosts" are selected, this is None.
+        host_requirements: The host requirements. There are only passed if the user has specified custom host requirements in the UI. If "all available worker hosts" are selected, this is None.
         purpose: The purpose of the job bundle.
     """
     # Make sure the output path used for submission is absolute
@@ -209,7 +219,9 @@ def _create_bundle_internal(
     if settings.override_frame_range:
         common_layer_settings.frame_range = settings.frame_list
 
-    job_template = tf.fill_job_template(settings, layer_names, common_layer_settings, requirements)
+    job_template = tf.fill_job_template(
+        settings, layer_names, common_layer_settings, host_requirements
+    )
     parameter_values = tf.get_parameter_values(settings, common_layer_settings, queue_parameters)
 
     # Write the job bundle files.

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/template_filling.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/template_filling.py
@@ -16,6 +16,7 @@ from typing import Any, Optional
 
 import yaml
 from deadline.client.exceptions import DeadlineOperationError
+from deadline.client.job_bundle.parameters import JobParameter
 
 _logger = logging.getLogger(__name__)
 
@@ -372,7 +373,7 @@ def _fill_step_template(
 def get_parameter_values(
     settings: BlenderSubmitterUISettings,
     layer_settings: CommonLayerSettings,
-    queue_params: list[dict[str, Any]],
+    queue_params: list[JobParameter],
 ) -> list[dict[str, Any]]:
     """Collect the parameter values for the job bundle as a list of name/value dicts."""
 
@@ -411,8 +412,8 @@ def get_parameter_values(
     if settings.include_adaptor_wheels:
         wheels_path = str(Path(__file__).parent.parent.parent.parent / "wheels")
         params.append({"name": "OverrideAdaptorWheels", "value": wheels_path})
-        rez_param = {}
-        conda_param = {}
+        rez_param: Optional[JobParameter] = None
+        conda_param: Optional[JobParameter] = None
         # Find the Packages parameter definition in the queue params.
         for param in queue_params:
             if param["name"] == "RezPackages":


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
This is readding a previously reverted commit that we reverted due to a bug in the version of deadline-cloud that was latest at the time. #258 and #256 

We want to consume new changes from deadline-cloud and there was a breaking change that affected the submitter.

### What was the solution? (How)
Fixed all type hint issues introduced by the breaking change in deadline-cloud

### What is the impact of this change?
New deadline-cloud features

### How was this change tested?
* Manually verified by doing submissions on all operating systems of the last deadline-cloud release
* Validated in both 3.6 and 4.5 on MacOS including working submissions and new login/logout functionality

#### Please run the integration tests and paste the results below
```
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
[gw0] [ 25%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
[gw0] [ 50%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
[gw0] [ 75%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter
[gw0] [100%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter

================================================================================================================ slowest 5 durations ================================================================================================================
26.77s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
12.30s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
1.37s call     test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
1.32s call     test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter
0.00s setup    test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter
================================================================================================================ 4 passed in 42.06s =================================================================================================================

```

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*