### PR TITLE
docs: Add Windows-specific integration test setup instructions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -56,7 +56,12 @@ hatch run test-installer
 1. If you can run `blender` from your terminal or on Windows/MacOS you did a default Blender install,
    the tests will find Blender automatically. Otherwise, set the environment variable `BLENDER_EXECUTABLE`
    to the location of your Blender application.
-2. Run `hatch run integ:test`
+1. **On Windows**: Install `pywin32` into Blender's python environment manually.
+   ```bash
+    # Git Bash
+    pip install -r requirements-integ-testing.txt --python-version=<3.10 | 3.11> --only-binary=:all: --target <BLENDER_INSTALL_LOCATION>/<3.6 | 4.2>/python/lib/site-packages/
+    ```
+1. Run `hatch run integ:test`
 
 ### Manual Installation
 


### PR DESCRIPTION
Fixes #184 

### What was the problem/requirement? (What/Why)
Integration test setup on Windows has an extra step that isn't documented.

### What was the solution? (How)
add it?

### What is the impact of this change?
Setup docs are faithful to the integration test experience.

### How was this change tested?
Ran the command and verified it worked to set up integration tests.

#### Please run the integration tests and paste the results below
n/a, no submitter or adaptor changes

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below
n/a

### Was this change documented?
well

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*