### PR TITLE
ci: add changelog section for performance improvements

### DIFF
--- a/.semantic_release/CHANGELOG.md.j2
+++ b/.semantic_release/CHANGELOG.md.j2
@@ -22,4 +22,11 @@
         {% endfor %}
     {% endif %}
 
+    {% if "performance improvements" in release["elements"] %}
+### Performance Improvements
+        {% for commit in release["elements"]["performance improvements"] %}
+* {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.commit.summary[commit.commit.summary.find(":")+1:].strip() }} ([`{{ commit.short_hash }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+        {% endfor %}
+    {% endif %}
+
 {% endfor %}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,37 @@ To send us a pull request, please:
 GitHub provides additional documentation on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
+### Conventional commits
+
+The commits in this repository are all required to use [conventional commit syntax](https://www.conventionalcommits.org/en/v1.0.0/)
+in their title to help us identify the kind of change that is being made, automatically generate the changelog, and 
+automatically identify next release version number. Only the first commit that deviates from mainline in your pull request
+must adhere to this requirement.
+
+We ask that you use these commit types in your commit titles:
+
+* `feat` - When the pull request adds a new feature or functionality;
+* `fix` - When the pull request is implementing a fix to a bug;
+* `test` - When the pull request is only implementing an addition or change to tests or the testing infrastructure;
+* `docs` - When the pull request is primarily implementing an addition or change to the package's documentation;
+* `refactor` - When the pull request is implementing only a refactor of existing code;
+* `ci` - When the pull request is implementing a change to the CI infrastructure of the packge;
+* `chore` - When the pull request is a generic maintenance task.
+* `perf` - When the pull request is a performance improvement.
+
+We also require that the type in your conventional commit title end in an exclaimation point (e.g. `feat!` or `fix!`)
+if the pull request should be considered to be a breaking change in some way. Please also include a "BREAKING CHANGE" footer
+in the description of your commit in this case ([example](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-both--and-breaking-change-footer)).
+Examples of breaking changes include:
+
+*   removing a feature of the DCC integration
+*   changing established behavior of the integration that users have come to rely on
+*   breaking backwards-compatibility between the submitter and and the adaptor
+
+If you need change a commit message, then please see the
+[GitHub documentation on the topic](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/changing-a-commit-message)
+to guide you.
+
 ## Finding contributions to work on
 
 Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,7 @@ patch_tags = [
   "feat",
   "fix",
   "refactor",
+  "perf",
 ]
 
 [tool.semantic_release.publish]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

1.  There is no development/release workflow for communicating performance improvements.
2.  There is not contributing documentation covering conventional commits

### What was the solution? (How)

[Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standardizes the `perf: ...` commit type for performance-related changes.

This followed a previous work in aws-deadline/deadline-cloud#870:

1.  adds a section to the changelog template for performance improvements
2. adds `perf` commits to the `patch_tags` setting of `python-semantic-release` so that they are considered as part of bumping a version for release
3. adds developer-facing documentation on conventional commits including the use of the `perf:` commit type for performance improvements

### What is the impact of this change?

Developers can use `perf: ...` conventional commits to communicate performance improvements. The release process will automatically produce a changelog section for performance improvements where they will be listed.

### How was this change tested?

1.  Set my local `mainline` branch to this commit
2. Added example commits using the `perf: ...` commit summary message
3. Ran:
    ```
    hatch run release:deps
    hatch run release:bump
    ```
4.  confirmed that rendered `CHANGELOG.md` contained the expected "Performance Improvements" section correctly

>   ## 0.5.6 (2025-10-23)
>   
>   
>   
>   ### Bug Fixes
>   * gpu_device isn't marked as required in init-data (#274) ([`778cc11`](https://github.com/aws-deadline/deadline-cloud-for-blender/commit/778cc11d8a75409e2c31b7efbe21ff9a2388b54b))
>   
>   ### Performance Improvements
>   * a performance improvement message ([`5bd9872`](https://github.com/aws-deadline/deadline-cloud-for-blender/commit/5bd9872c6e4ef6040194041f02c91c30d96eb26d))

#### Please run the integration tests and paste the results below

N/A

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

N/A

### Was this change documented?

I've updated `CONTRIBUTING.md` to document conventional commits including the use of the `perf: ...` commit type

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*