### PR TITLE
ci: Add test runner setup script 

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: moorec-aws/.github/.github/workflows/reusable_integration_test.yml@mainline
+    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
     secrets: inherit
     with:
       repository: ${{ github.event.repository.name }}
@@ -21,7 +21,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: moorec-aws/.github/.github/workflows/reusable_integration_test.yml@mainline
+    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
     secrets: inherit
     with:
       repository: ${{ github.event.repository.name }}
@@ -33,7 +33,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: moorec-aws/.github/.github/workflows/reusable_integration_test.yml@mainline
+    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
     secrets: inherit
     with:
       repository: ${{ github.event.repository.name }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
+    uses: moorec-aws/.github/.github/workflows/reusable_integration_test.yml@mainline
     secrets: inherit
     with:
       repository: ${{ github.event.repository.name }}
@@ -21,7 +21,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
+    uses: moorec-aws/.github/.github/workflows/reusable_integration_test.yml@mainline
     secrets: inherit
     with:
       repository: ${{ github.event.repository.name }}
@@ -33,7 +33,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
+    uses: moorec-aws/.github/.github/workflows/reusable_integration_test.yml@mainline
     secrets: inherit
     with:
       repository: ${{ github.event.repository.name }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ dist_extras/
 plugin_env/
 wheels/
 installer/components/
+DeadlineCloudSubmitter/
 
 # License file for InstallBuilder
 license.xml

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -53,6 +53,8 @@ hatch run test-installer
 
 ### Run Integration Tests
 
+#### Local Integration Tests
+
 1. If you can run `blender` from your terminal or on Windows/MacOS you did a default Blender install,
    the tests will find Blender automatically. Otherwise, set the environment variable `BLENDER_EXECUTABLE`
    to the location of your Blender application.
@@ -62,6 +64,34 @@ hatch run test-installer
     pip install -r requirements-integ-testing.txt --python-version=<3.10 | 3.11> --only-binary=:all: --target <BLENDER_INSTALL_LOCATION>/<3.6 | 4.2>/python/lib/site-packages/
     ```
 1. Run `hatch run integ:test`
+
+#### CI Integration Tests (integ-ci environment)
+
+The `integ-ci` hatch environment is designed for automated testing in CI/CD pipelines with multiple Blender versions.
+
+**Environment Variables:**
+- `BLENDER_VERSION`: Set automatically by the hatch matrix.
+- `DEPENDENCY_BUCKET`: S3 bucket name containing Blender installers (required for setup script unless using `--public-urls`).
+
+**Usage:**
+```bash
+hatch run integ-ci:setup 
+hatch run integ-ci:test
+
+# Setup from public Blender downloads (with checksum verification)
+hatch run integ-ci:setup --public-urls
+
+# Setup with X11/Xvfb on Linux
+hatch run integ-ci:setup --install-x11
+```
+
+**Setup Script Options:**
+- `--public-urls`: Download from blender.org instead of S3 with SHA256 checksum verification
+- `--install-x11`: Install X11 libraries and start Xvfb on Linux (for headless rendering)
+- `--versions`: Specify Blender versions to install (e.g., `4.5.4 4.2.12`)
+- `--python-version`: Specify Python version for pip installs (e.g., `3.11`).
+
+The `pipeline/setup-runner.py` script downloads and installs Blender versions, then installs the submitter addon.
 
 ### Manual Installation
 

--- a/hatch.toml
+++ b/hatch.toml
@@ -38,8 +38,7 @@ build = "hatch build"
 
 [envs.integ]
 pre-install-commands = [
-  "pip install -r requirements-integ-testing.txt",
-  "pip install -r requirements-testing.txt"
+  "pip install -r requirements-integ-testing.txt -r requirements-testing.txt"
 ]
 
 [envs.integ.scripts]
@@ -49,18 +48,22 @@ test_adaptors = "pytest --no-cov {args:test/integ} -vvv --numprocesses=1 -m adap
 
 [envs.integ-ci]
 pre-install-commands = [
-  "pip install -r requirements-integ-testing.txt",
-  "pip install -r requirements-testing.txt"
+  "pip install -r requirements-integ-testing.txt -r requirements-testing.txt"
 ]
 
 [[envs.integ-ci.matrix]]
-blender = ["4.5.4", "4.2.12"]
+blender = ["4.5.4"]
+python = ["3.11"]
+
+[[envs.integ-ci.matrix]]
+blender = ["4.2.12"]
+python = ["3.11"]
 
 [envs.integ-ci.env-vars]
 BLENDER_VERSION = "{matrix:blender}"
 
 [envs.integ-ci.scripts]
-setup = "python ./pipeline/setup-runner.py --versions {matrix:blender} {args}"
+setup = "python ./pipeline/setup-runner.py --versions {matrix:blender} --python-version {matrix:python} {args}"
 test = "pytest --no-cov {args:test/integ} -vvv --numprocesses=1"
 
 [envs.codebuild.env-vars]

--- a/hatch.toml
+++ b/hatch.toml
@@ -47,6 +47,22 @@ test = "pytest --no-cov {args:test/integ} -vvv --numprocesses=1"
 test_submitters = "pytest --no-cov {args:test/integ} -vvv --numprocesses=1 -m submitter"
 test_adaptors = "pytest --no-cov {args:test/integ} -vvv --numprocesses=1 -m adaptor"
 
+[envs.integ-ci]
+pre-install-commands = [
+  "pip install -r requirements-integ-testing.txt",
+  "pip install -r requirements-testing.txt"
+]
+
+[[envs.integ-ci.matrix]]
+blender = ["4.5.4", "4.2.12"]
+
+[envs.integ-ci.env-vars]
+BLENDER_VERSION = "{matrix:blender}"
+
+[envs.integ-ci.scripts]
+setup = "python ./pipeline/setup-runner.py --versions {matrix:blender} {args}"
+test = "pytest --no-cov {args:test/integ} -vvv --numprocesses=1"
+
 [envs.codebuild.env-vars]
 SKIP_BOOTSTRAP_TEST_RESOURCES="True"
 

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -120,7 +120,8 @@ def setup_linux(python_version, install_x11=False):
             ]
         )
         if run(["pgrep", "Xvfb"], check=False).returncode != 0:
-            run(["Xvfb", ":99", "-screen", "0", "1024x768x24"], check=False)
+            # Start Xvfb in background
+            subprocess.Popen(["Xvfb", ":99", "-screen", "0", "1024x768x24"])
             run(["sleep", "2"])
         print("\nXvfb started. Run this before tests:")
         print("  export DISPLAY=:99")

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -12,6 +12,10 @@ import time
 from pathlib import Path
 
 BLENDER_VERSIONS = ["4.2.12", "4.5.4"]
+BLENDER_PYTHON_VERSIONS = {
+    "4.2.12": "3.11",
+    "4.5.4": "3.11",
+}
 USE_PUBLIC_URLS = False
 
 # SHA256 checksums from https://www.blender.org/download/
@@ -64,16 +68,13 @@ def verify_checksum(file_path, expected_checksum):
     return True
 
 
-def setup_linux(install_x11=False):
+def setup_linux(python_version, install_x11=False):
     pkg_mgr = (
         "dnf"
         if subprocess.run("command -v dnf", shell=True, capture_output=True).returncode == 0
         else "yum"
     )
     run(f"{pkg_mgr} update -y", shell=True)
-
-    run("pip install --upgrade pip hatch", shell=True)
-    run("pip install --upgrade -r requirements-development.txt", shell=True)
 
     if install_x11:
         run(
@@ -140,7 +141,7 @@ def setup_linux(install_x11=False):
     )
 
     run(
-        'pip install --upgrade --python-version 3.11 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t ./DeadlineCloudSubmitter/Submitters/Blender/python/modules',
+        f'pip install --upgrade --python-version {python_version} --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t ./DeadlineCloudSubmitter/Submitters/Blender/python/modules',
         shell=True,
     )
 
@@ -152,10 +153,7 @@ def setup_linux(install_x11=False):
         )
 
 
-def setup_windows():
-    run("pip install --upgrade pip hatch", shell=True)
-    run("pip install --upgrade -r requirements-development.txt", shell=True)
-
+def setup_windows(python_version):
     for version in BLENDER_VERSIONS:
         major_minor = ".".join(version.split(".")[:2])
         blender_dir = Path(f"C:/Tools/blender-{version}-windows-x64")
@@ -216,14 +214,14 @@ def setup_windows():
     )
 
     run(
-        'pip install --upgrade --python-version 3.11 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet pywin32 -t DeadlineCloudSubmitter\\Submitters\\Blender\\python\\modules',
+        f'pip install --upgrade --python-version {python_version} --only-binary=:all: "deadline[gui]" blender-qt-stylesheet pywin32 -t DeadlineCloudSubmitter\\Submitters\\Blender\\python\\modules',
         shell=True,
     )
 
     for version in BLENDER_VERSIONS:
         blender_python_site = f"C:/Tools/blender-{version}-windows-x64/{version.split('.')[0]}.{version.split('.')[1]}/python/lib/site-packages"
         run(
-            f"pip install --upgrade -r requirements-integ-testing.txt --python-version=3.11 --only-binary=:all: --target {blender_python_site}",
+            f"pip install --upgrade -r requirements-integ-testing.txt --python-version={python_version} --only-binary=:all: --target {blender_python_site}",
             shell=True,
         )
 
@@ -236,10 +234,7 @@ def setup_windows():
         )
 
 
-def setup_macos():
-    run("pip install --upgrade pip hatch", shell=True)
-    run("pip install --upgrade -r requirements-development.txt", shell=True)
-
+def setup_macos(python_version):
     for version in BLENDER_VERSIONS:
         major_minor = ".".join(version.split(".")[:2])
         blender_app = Path(f"/Applications/Blender-{version}.app")
@@ -279,7 +274,7 @@ def setup_macos():
     )
 
     run(
-        'pip install --upgrade --python-version 3.11 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t ./DeadlineCloudSubmitter/Submitters/Blender/python/modules',
+        f'pip install --upgrade --python-version {python_version} --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t ./DeadlineCloudSubmitter/Submitters/Blender/python/modules',
         shell=True,
     )
 
@@ -300,6 +295,9 @@ if __name__ == "__main__":
         "--versions", nargs="+", help="Blender versions to install (e.g., 4.5.4 4.2.12)"
     )
     parser.add_argument(
+        "--python-version", help="Python version to use for pip installs (e.g., 3.11)"
+    )
+    parser.add_argument(
         "--install-x11",
         action="store_true",
         help="Install X11 libraries and start Xvfb (Linux only)",
@@ -309,11 +307,24 @@ if __name__ == "__main__":
     USE_PUBLIC_URLS = args.public_urls
     if args.versions:
         BLENDER_VERSIONS = args.versions
+
+    # Use provided python version or infer from first Blender version
+    if args.python_version:
+        python_version = args.python_version
+    else:
+        python_version = BLENDER_PYTHON_VERSIONS.get(BLENDER_VERSIONS[0], "3.11")
+
     system = platform.system()
     print(f"Setting up {system} with Blender {', '.join(BLENDER_VERSIONS)}")
     print(f"Using {'public URLs' if USE_PUBLIC_URLS else 'S3 bucket'}")
+    print(f"Python version: {python_version}")
+
     if system == "Linux":
-        setup_linux(install_x11=args.install_x11)
+        setup_linux(python_version=python_version, install_x11=args.install_x11)
+    elif system == "Windows":
+        setup_windows(python_version=python_version)
+    elif system == "Darwin":
+        setup_macos(python_version=python_version)
     else:
-        {"Windows": setup_windows, "Darwin": setup_macos}[system]()
+        raise OSError(f"Unsupported OS: {system}")
     print("Setup complete!")

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -1,0 +1,319 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+#!/usr/bin/env python3
+"""Setup runner for Blender integration tests in CodeBuild."""
+import argparse
+import hashlib
+import os
+import platform
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+BLENDER_VERSIONS = ["4.2.12", "4.5.4"]
+USE_PUBLIC_URLS = False
+
+# SHA256 checksums from https://www.blender.org/download/
+BLENDER_CHECKSUMS = {
+    "4.2.12-linux-x64": "953717011e00a21bfd4ccf0e8af0d901b4c3ef09c48f14c16a18c146d858bcf7",
+    "4.5.4-linux-x64": "2e6ef8e99fc36327270429ddc8e7bad2859dd878a5a137d2e0bf0f02f6792505",
+    "4.2.12-windows-x64": "d7b77bf3a925722be87e5b5e429b584d7baa3bcc82579afa7952fc1f8c19d2e1",
+    "4.5.4-windows-x64": "0de55df1d99e4e7152605022cb648e795d5d49209c5c5c4889e1a19fb401a054",
+    "4.2.12-macos-arm64": "810bc64b89af7f9028b9d7544a34f32ad900ac6d913fd2f288895f10dc6c2527",
+    "4.5.4-macos-arm64": "7d6bd807563f0af65735cf9e21b788f6ac78bc5ceb87b96c424459785a13cd60",
+}
+
+
+def run(cmd, shell=False, check=True):
+    print(f"Running: {cmd if isinstance(cmd, str) else ' '.join(cmd)}")
+    result = subprocess.run(cmd, shell=shell)
+    if check and result.returncode != 0:
+        sys.exit(result.returncode)
+    return result
+
+
+def download_from_s3(s3_path, local_path):
+    bucket = os.environ.get("DEPENDENCY_BUCKET")
+    if not bucket:
+        print("DEPENDENCY_BUCKET not set")
+        return False
+    run(["aws", "s3", "cp", f"s3://{bucket}/{s3_path}", str(local_path), "--no-progress"])
+    return True
+
+
+def verify_checksum(file_path, expected_checksum):
+    """Verify SHA256 checksum of downloaded file."""
+    if not USE_PUBLIC_URLS:
+        return True
+
+    print(f"Verifying checksum for {file_path}...")
+    sha256 = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            sha256.update(chunk)
+
+    actual = sha256.hexdigest()
+    if actual != expected_checksum:
+        print("ERROR: Checksum mismatch!")
+        print(f"  Expected: {expected_checksum}")
+        print(f"  Actual:   {actual}")
+        sys.exit(1)
+
+    print("OK Checksum verified")
+    return True
+
+
+def setup_linux(install_x11=False):
+    pkg_mgr = (
+        "dnf"
+        if subprocess.run("command -v dnf", shell=True, capture_output=True).returncode == 0
+        else "yum"
+    )
+    run(f"{pkg_mgr} update -y", shell=True)
+
+    run("pip install --upgrade pip hatch", shell=True)
+    run("pip install --upgrade -r requirements-development.txt", shell=True)
+
+    if install_x11:
+        run(
+            f"{pkg_mgr} install -y mesa-libGL mesa-libGLU mesa-libEGL libglvnd-egl fontconfig libxcb xcb-util-cursor xcb-util-image xcb-util-keysyms xcb-util-renderutil xcb-util-wm libxkbcommon-x11 xorg-x11-server-Xvfb libX11 libXrender libXi libXrandr libXxf86vm libXfixes libXcursor libXinerama libxkbcommon libSM libICE libXt libXmu",
+            shell=True,
+        )
+        if run("pgrep Xvfb", shell=True, check=False).returncode != 0:
+            run("Xvfb :99 -screen 0 1024x768x24 &", shell=True)
+            run("sleep 2", shell=True)
+        print("\nXvfb started. Run this before tests:")
+        print("  export DISPLAY=:99")
+
+    for version in BLENDER_VERSIONS:
+        major_minor = ".".join(version.split(".")[:2])
+        blender_dir = Path(f"/opt/blender-{version}-linux-x64")
+        blender_marker = blender_dir / ".installed"
+
+        if blender_marker.exists():
+            print(f"Blender {version} already installed")
+            continue
+
+        lock_file = Path(f"/tmp/blender-{version}.lock")
+        if lock_file.exists():
+            print(f"Waiting for concurrent Blender {version} install...")
+            for _ in range(60):
+                time.sleep(1)
+                if blender_marker.exists():
+                    break
+            continue
+
+        lock_file.touch()
+        try:
+            print(f"Installing Blender {version}...")
+            blender_archive = Path(f"/tmp/blender-{version}.tar.xz")
+            if not USE_PUBLIC_URLS and download_from_s3(
+                f"blender/blender-{version}-linux-x64.tar.xz", blender_archive
+            ):
+                pass
+            elif USE_PUBLIC_URLS:
+                run(
+                    f"wget -q -O {blender_archive} https://download.blender.org/release/Blender{major_minor}/blender-{version}-linux-x64.tar.xz",
+                    shell=True,
+                )
+                verify_checksum(blender_archive, BLENDER_CHECKSUMS[f"{version}-linux-x64"])
+
+            run(f"tar -xf {blender_archive} -C /opt", shell=True)
+            run(f"chmod -R 755 {blender_dir}", shell=True)
+            blender_marker.touch()
+            blender_archive.unlink(missing_ok=True)
+        finally:
+            lock_file.unlink(missing_ok=True)
+
+    print("Installing Blender submitter...")
+    run("hatch build", shell=True)
+
+    submitter_path = Path("./DeadlineCloudSubmitter")
+    if submitter_path.exists():
+        run(f"rm -rf {submitter_path}", shell=True, check=False)
+
+    Path("./DeadlineCloudSubmitter/Submitters/Blender/python").mkdir(parents=True, exist_ok=True)
+    run(
+        "cp -r src/deadline/blender_submitter/addons/ ./DeadlineCloudSubmitter/Submitters/Blender/python/addons",
+        shell=True,
+    )
+
+    run(
+        'pip install --upgrade --python-version 3.11 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t ./DeadlineCloudSubmitter/Submitters/Blender/python/modules',
+        shell=True,
+    )
+
+    for version in BLENDER_VERSIONS:
+        blender_exe = f"/opt/blender-{version}-linux-x64/blender"
+        run(
+            f"{blender_exe} --background --python ./installer/add_submitter_to_pref.py -- --deadline_cloud_install_path $(pwd)/DeadlineCloudSubmitter/Submitters/Blender/python",
+            shell=True,
+        )
+
+
+def setup_windows():
+    run("pip install --upgrade pip hatch", shell=True)
+    run("pip install --upgrade -r requirements-development.txt", shell=True)
+
+    for version in BLENDER_VERSIONS:
+        major_minor = ".".join(version.split(".")[:2])
+        blender_dir = Path(f"C:/Tools/blender-{version}-windows-x64")
+        blender_marker = blender_dir / ".installed"
+
+        if blender_marker.exists():
+            print(f"Blender {version} already installed")
+            continue
+
+        lock_file = Path(f"C:/Temp/blender-{version}.lock")
+        lock_file.parent.mkdir(parents=True, exist_ok=True)
+
+        if lock_file.exists():
+            print(f"Waiting for concurrent Blender {version} install...")
+            for _ in range(60):
+                time.sleep(1)
+                if blender_marker.exists():
+                    break
+            continue
+
+        lock_file.touch()
+        try:
+            print(f"Installing Blender {version}...")
+            blender_zip = Path(f"C:/Tools/blender-{version}.zip")
+            blender_zip.parent.mkdir(parents=True, exist_ok=True)
+
+            if not USE_PUBLIC_URLS and download_from_s3(
+                f"blender/blender-{version}-windows-x64.zip", blender_zip
+            ):
+                pass
+            elif USE_PUBLIC_URLS:
+                run(
+                    f"powershell -Command \"Invoke-WebRequest -Uri 'https://download.blender.org/release/Blender{major_minor}/blender-{version}-windows-x64.zip' -OutFile '{blender_zip}'\"",
+                    shell=True,
+                )
+                verify_checksum(blender_zip, BLENDER_CHECKSUMS[f"{version}-windows-x64"])
+
+            run(
+                f"powershell -Command \"Expand-Archive -Path '{blender_zip}' -DestinationPath 'C:/Tools' -Force\"",
+                shell=True,
+            )
+            blender_marker.touch()
+            blender_zip.unlink(missing_ok=True)
+        finally:
+            lock_file.unlink(missing_ok=True)
+
+    print("Installing Blender submitter...")
+    run("hatch build", shell=True)
+
+    submitter_path = Path("./DeadlineCloudSubmitter")
+    if submitter_path.exists():
+        run("rmdir /s /q DeadlineCloudSubmitter", shell=True, check=False)
+
+    Path("./DeadlineCloudSubmitter/Submitters/Blender/python").mkdir(parents=True, exist_ok=True)
+    run(
+        "xcopy /E /I src\\deadline\\blender_submitter\\addons DeadlineCloudSubmitter\\Submitters\\Blender\\python\\addons",
+        shell=True,
+    )
+
+    run(
+        'pip install --upgrade --python-version 3.11 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet pywin32 -t DeadlineCloudSubmitter\\Submitters\\Blender\\python\\modules',
+        shell=True,
+    )
+
+    for version in BLENDER_VERSIONS:
+        blender_python_site = f"C:/Tools/blender-{version}-windows-x64/{version.split('.')[0]}.{version.split('.')[1]}/python/lib/site-packages"
+        run(
+            f"pip install --upgrade -r requirements-integ-testing.txt --python-version=3.11 --only-binary=:all: --target {blender_python_site}",
+            shell=True,
+        )
+
+    cwd = os.getcwd().replace("/", "\\")
+    for version in BLENDER_VERSIONS:
+        blender_exe = f"C:/Tools/blender-{version}-windows-x64/blender.exe"
+        run(
+            f'"{blender_exe}" --background --python installer\\add_submitter_to_pref.py -- --deadline_cloud_install_path {cwd}\\DeadlineCloudSubmitter\\Submitters\\Blender\\python',
+            shell=True,
+        )
+
+
+def setup_macos():
+    run("pip install --upgrade pip hatch", shell=True)
+    run("pip install --upgrade -r requirements-development.txt", shell=True)
+
+    for version in BLENDER_VERSIONS:
+        major_minor = ".".join(version.split(".")[:2])
+        blender_app = Path(f"/Applications/Blender-{version}.app")
+
+        print(f"Installing Blender {version}...")
+        blender_dmg = Path(f"/tmp/blender-{version}.dmg")
+
+        if not USE_PUBLIC_URLS and download_from_s3(
+            f"blender/blender-{version}-macos-arm64.dmg", blender_dmg
+        ):
+            pass
+        elif USE_PUBLIC_URLS:
+            run(
+                f"curl -L -o {blender_dmg} https://download.blender.org/release/Blender{major_minor}/blender-{version}-macos-arm64.dmg",
+                shell=True,
+            )
+            verify_checksum(blender_dmg, BLENDER_CHECKSUMS[f"{version}-macos-arm64"])
+
+        run(f"hdiutil attach {blender_dmg}", shell=True)
+        run(f"sudo rm -rf {blender_app}", shell=True, check=False)
+        run(f"sudo cp -R /Volumes/Blender/Blender.app {blender_app}", shell=True)
+        run("hdiutil detach /Volumes/Blender", shell=True)
+
+        blender_dmg.unlink(missing_ok=True)
+
+    print("Installing Blender submitter...")
+    run("hatch build", shell=True)
+
+    submitter_path = Path("./DeadlineCloudSubmitter")
+    if submitter_path.exists():
+        run(f"rm -rf {submitter_path}", shell=True, check=False)
+
+    Path("./DeadlineCloudSubmitter/Submitters/Blender/python").mkdir(parents=True, exist_ok=True)
+    run(
+        "cp -r src/deadline/blender_submitter/addons/ ./DeadlineCloudSubmitter/Submitters/Blender/python/addons",
+        shell=True,
+    )
+
+    run(
+        'pip install --upgrade --python-version 3.11 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t ./DeadlineCloudSubmitter/Submitters/Blender/python/modules',
+        shell=True,
+    )
+
+    for version in BLENDER_VERSIONS:
+        blender_exe = f"/Applications/Blender-{version}.app/Contents/MacOS/Blender"
+        run(
+            f"{blender_exe} --background --python ./installer/add_submitter_to_pref.py -- --deadline_cloud_install_path $(pwd)/DeadlineCloudSubmitter/Submitters/Blender/python",
+            shell=True,
+        )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Setup Blender test environment")
+    parser.add_argument(
+        "--public-urls", action="store_true", help="Download from public URLs instead of S3"
+    )
+    parser.add_argument(
+        "--versions", nargs="+", help="Blender versions to install (e.g., 4.5.4 4.2.12)"
+    )
+    parser.add_argument(
+        "--install-x11",
+        action="store_true",
+        help="Install X11 libraries and start Xvfb (Linux only)",
+    )
+    args = parser.parse_args()
+
+    USE_PUBLIC_URLS = args.public_urls
+    if args.versions:
+        BLENDER_VERSIONS = args.versions
+    system = platform.system()
+    print(f"Setting up {system} with Blender {', '.join(BLENDER_VERSIONS)}")
+    print(f"Using {'public URLs' if USE_PUBLIC_URLS else 'S3 bucket'}")
+    if system == "Linux":
+        setup_linux(install_x11=args.install_x11)
+    else:
+        {"Windows": setup_windows, "Darwin": setup_macos}[system]()
+    print("Setup complete!")

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -29,9 +29,9 @@ BLENDER_CHECKSUMS = {
 }
 
 
-def run(cmd, shell=False, check=True):
-    print(f"Running: {cmd if isinstance(cmd, str) else ' '.join(cmd)}")
-    result = subprocess.run(cmd, shell=shell)
+def run(cmd, check=True):
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd)
     if check and result.returncode != 0:
         sys.exit(result.returncode)
     return result
@@ -48,9 +48,6 @@ def download_from_s3(s3_path, local_path):
 
 def verify_checksum(file_path, expected_checksum):
     """Verify SHA256 checksum of downloaded file."""
-    if not USE_PUBLIC_URLS:
-        return True
-
     print(f"Verifying checksum for {file_path}...")
     sha256 = hashlib.sha256()
     with open(file_path, "rb") as f:
@@ -68,34 +65,77 @@ def verify_checksum(file_path, expected_checksum):
     return True
 
 
+def validate_version(version):
+    """Validate Blender version string"""
+    import re
+
+    if not re.match(r"^\d+\.\d+\.\d+$", version):
+        print(f"ERROR: Invalid version format: {version}")
+        print("Version must be in format X.Y.Z (e.g., 4.2.12)")
+        sys.exit(1)
+    return version
+
+
 def setup_linux(python_version, install_x11=False):
     pkg_mgr = (
         "dnf"
-        if subprocess.run("command -v dnf", shell=True, capture_output=True).returncode == 0
+        if subprocess.run(["command", "-v", "dnf"], capture_output=True).returncode == 0
         else "yum"
     )
-    run(f"{pkg_mgr} update -y", shell=True)
+    run([pkg_mgr, "update", "-y"])
 
+    # Optional, for running tests on a headless runner.
     if install_x11:
         run(
-            f"{pkg_mgr} install -y mesa-libGL mesa-libGLU mesa-libEGL libglvnd-egl fontconfig libxcb xcb-util-cursor xcb-util-image xcb-util-keysyms xcb-util-renderutil xcb-util-wm libxkbcommon-x11 xorg-x11-server-Xvfb libX11 libXrender libXi libXrandr libXxf86vm libXfixes libXcursor libXinerama libxkbcommon libSM libICE libXt libXmu",
-            shell=True,
+            [
+                pkg_mgr,
+                "install",
+                "-y",
+                "mesa-libGL",
+                "mesa-libGLU",
+                "mesa-libEGL",
+                "libglvnd-egl",
+                "fontconfig",
+                "libxcb",
+                "xcb-util-cursor",
+                "xcb-util-image",
+                "xcb-util-keysyms",
+                "xcb-util-renderutil",
+                "xcb-util-wm",
+                "libxkbcommon-x11",
+                "xorg-x11-server-Xvfb",
+                "libX11",
+                "libXrender",
+                "libXi",
+                "libXrandr",
+                "libXxf86vm",
+                "libXfixes",
+                "libXcursor",
+                "libXinerama",
+                "libxkbcommon",
+                "libSM",
+                "libICE",
+                "libXt",
+                "libXmu",
+            ]
         )
-        if run("pgrep Xvfb", shell=True, check=False).returncode != 0:
-            run("Xvfb :99 -screen 0 1024x768x24 &", shell=True)
-            run("sleep 2", shell=True)
+        if run(["pgrep", "Xvfb"], check=False).returncode != 0:
+            run(["Xvfb", ":99", "-screen", "0", "1024x768x24"], check=False)
+            run(["sleep", "2"])
         print("\nXvfb started. Run this before tests:")
         print("  export DISPLAY=:99")
 
     for version in BLENDER_VERSIONS:
         major_minor = ".".join(version.split(".")[:2])
         blender_dir = Path(f"/opt/blender-{version}-linux-x64")
+        # Marker file indicates successful installation, avoiding redundant reinstalls
         blender_marker = blender_dir / ".installed"
 
         if blender_marker.exists():
             print(f"Blender {version} already installed")
             continue
 
+        # Lock file prevents concurrent installations that could corrupt the installation
         lock_file = Path(f"/tmp/blender-{version}.lock")
         if lock_file.exists():
             print(f"Waiting for concurrent Blender {version} install...")
@@ -112,44 +152,69 @@ def setup_linux(python_version, install_x11=False):
             if not USE_PUBLIC_URLS and download_from_s3(
                 f"blender/blender-{version}-linux-x64.tar.xz", blender_archive
             ):
-                pass
+                verify_checksum(blender_archive, BLENDER_CHECKSUMS[f"{version}-linux-x64"])
             elif USE_PUBLIC_URLS:
                 run(
-                    f"wget -q -O {blender_archive} https://download.blender.org/release/Blender{major_minor}/blender-{version}-linux-x64.tar.xz",
-                    shell=True,
+                    [
+                        "wget",
+                        "-q",
+                        "-O",
+                        str(blender_archive),
+                        f"https://download.blender.org/release/Blender{major_minor}/blender-{version}-linux-x64.tar.xz",
+                    ]
                 )
                 verify_checksum(blender_archive, BLENDER_CHECKSUMS[f"{version}-linux-x64"])
 
-            run(f"tar -xf {blender_archive} -C /opt", shell=True)
-            run(f"chmod -R 755 {blender_dir}", shell=True)
+            run(["tar", "-xf", str(blender_archive), "-C", "/opt"])
+            run(["chmod", "-R", "755", str(blender_dir)])
             blender_marker.touch()
             blender_archive.unlink(missing_ok=True)
         finally:
             lock_file.unlink(missing_ok=True)
 
     print("Installing Blender submitter...")
-    run("hatch build", shell=True)
-
-    submitter_path = Path("./DeadlineCloudSubmitter")
-    if submitter_path.exists():
-        run(f"rm -rf {submitter_path}", shell=True, check=False)
-
-    Path("./DeadlineCloudSubmitter/Submitters/Blender/python").mkdir(parents=True, exist_ok=True)
-    run(
-        "cp -r src/deadline/blender_submitter/addons/ ./DeadlineCloudSubmitter/Submitters/Blender/python/addons",
-        shell=True,
-    )
-
-    run(
-        f'pip install --upgrade --python-version {python_version} --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t ./DeadlineCloudSubmitter/Submitters/Blender/python/modules',
-        shell=True,
-    )
+    run(["hatch", "build"])
 
     for version in BLENDER_VERSIONS:
+        major_minor = ".".join(version.split(".")[:2])
+        submitter_path = Path(f"./DeadlineCloudSubmitter/Submitters/Blender{major_minor}")
+
+        Path(f"{submitter_path}/python").mkdir(parents=True, exist_ok=True)
+        run(
+            [
+                "cp",
+                "-r",
+                "src/deadline/blender_submitter/addons/",
+                f"{submitter_path}/python/addons",
+            ]
+        )
+
+        run(
+            [
+                "pip",
+                "install",
+                "--upgrade",
+                "--python-version",
+                python_version,
+                "--only-binary=:all:",
+                "deadline[gui]",
+                "blender-qt-stylesheet",
+                "-t",
+                f"{submitter_path}/python/modules",
+            ]
+        )
+
         blender_exe = f"/opt/blender-{version}-linux-x64/blender"
         run(
-            f"{blender_exe} --background --python ./installer/add_submitter_to_pref.py -- --deadline_cloud_install_path $(pwd)/DeadlineCloudSubmitter/Submitters/Blender/python",
-            shell=True,
+            [
+                blender_exe,
+                "--background",
+                "--python",
+                "./installer/add_submitter_to_pref.py",
+                "--",
+                "--deadline_cloud_install_path",
+                f"{os.getcwd()}/{submitter_path}/python",
+            ]
         )
 
 
@@ -157,12 +222,14 @@ def setup_windows(python_version):
     for version in BLENDER_VERSIONS:
         major_minor = ".".join(version.split(".")[:2])
         blender_dir = Path(f"C:/Tools/blender-{version}-windows-x64")
+        # Marker file indicates successful installation, avoiding redundant reinstalls
         blender_marker = blender_dir / ".installed"
 
         if blender_marker.exists():
             print(f"Blender {version} already installed")
             continue
 
+        # Lock file prevents concurrent installations that could corrupt the installation
         lock_file = Path(f"C:/Temp/blender-{version}.lock")
         lock_file.parent.mkdir(parents=True, exist_ok=True)
 
@@ -183,17 +250,23 @@ def setup_windows(python_version):
             if not USE_PUBLIC_URLS and download_from_s3(
                 f"blender/blender-{version}-windows-x64.zip", blender_zip
             ):
-                pass
+                verify_checksum(blender_zip, BLENDER_CHECKSUMS[f"{version}-windows-x64"])
             elif USE_PUBLIC_URLS:
                 run(
-                    f"powershell -Command \"Invoke-WebRequest -Uri 'https://download.blender.org/release/Blender{major_minor}/blender-{version}-windows-x64.zip' -OutFile '{blender_zip}'\"",
-                    shell=True,
+                    [
+                        "powershell",
+                        "-Command",
+                        f"Invoke-WebRequest -Uri 'https://download.blender.org/release/Blender{major_minor}/blender-{version}-windows-x64.zip' -OutFile '{blender_zip}'",
+                    ]
                 )
                 verify_checksum(blender_zip, BLENDER_CHECKSUMS[f"{version}-windows-x64"])
 
             run(
-                f"powershell -Command \"Expand-Archive -Path '{blender_zip}' -DestinationPath 'C:/Tools' -Force\"",
-                shell=True,
+                [
+                    "powershell",
+                    "-Command",
+                    f"Expand-Archive -Path '{blender_zip}' -DestinationPath 'C:/Tools' -Force",
+                ]
             )
             blender_marker.touch()
             blender_zip.unlink(missing_ok=True)
@@ -201,36 +274,66 @@ def setup_windows(python_version):
             lock_file.unlink(missing_ok=True)
 
     print("Installing Blender submitter...")
-    run("hatch build", shell=True)
-
-    submitter_path = Path("./DeadlineCloudSubmitter")
-    if submitter_path.exists():
-        run("rmdir /s /q DeadlineCloudSubmitter", shell=True, check=False)
-
-    Path("./DeadlineCloudSubmitter/Submitters/Blender/python").mkdir(parents=True, exist_ok=True)
-    run(
-        "xcopy /E /I src\\deadline\\blender_submitter\\addons DeadlineCloudSubmitter\\Submitters\\Blender\\python\\addons",
-        shell=True,
-    )
-
-    run(
-        f'pip install --upgrade --python-version {python_version} --only-binary=:all: "deadline[gui]" blender-qt-stylesheet pywin32 -t DeadlineCloudSubmitter\\Submitters\\Blender\\python\\modules',
-        shell=True,
-    )
+    run(["hatch", "build"])
 
     for version in BLENDER_VERSIONS:
-        blender_python_site = f"C:/Tools/blender-{version}-windows-x64/{version.split('.')[0]}.{version.split('.')[1]}/python/lib/site-packages"
+        major_minor = ".".join(version.split(".")[:2])
+        submitter_path = f"DeadlineCloudSubmitter\\Submitters\\Blender{major_minor}"
+
+        Path(f"{submitter_path}\\python").mkdir(parents=True, exist_ok=True)
         run(
-            f"pip install --upgrade -r requirements-integ-testing.txt --python-version={python_version} --only-binary=:all: --target {blender_python_site}",
-            shell=True,
+            [
+                "xcopy",
+                "/E",
+                "/I",
+                "src\\deadline\\blender_submitter\\addons",
+                f"{submitter_path}\\python\\addons",
+            ]
         )
 
-    cwd = os.getcwd().replace("/", "\\")
-    for version in BLENDER_VERSIONS:
+        run(
+            [
+                "pip",
+                "install",
+                "--upgrade",
+                "--python-version",
+                python_version,
+                "--only-binary=:all:",
+                "deadline[gui]",
+                "blender-qt-stylesheet",
+                "pywin32",
+                "-t",
+                f"{submitter_path}\\python\\modules",
+            ]
+        )
+
+        blender_python_site = f"C:/Tools/blender-{version}-windows-x64/{version.split('.')[0]}.{version.split('.')[1]}/python/lib/site-packages"
+        run(
+            [
+                "pip",
+                "install",
+                "--upgrade",
+                "-r",
+                "requirements-integ-testing.txt",
+                f"--python-version={python_version}",
+                "--only-binary=:all:",
+                "--target",
+                blender_python_site,
+            ]
+        )
+
+        cwd = os.getcwd().replace("/", "\\")
         blender_exe = f"C:/Tools/blender-{version}-windows-x64/blender.exe"
         run(
-            f'"{blender_exe}" --background --python installer\\add_submitter_to_pref.py -- --deadline_cloud_install_path {cwd}\\DeadlineCloudSubmitter\\Submitters\\Blender\\python',
-            shell=True,
+            [
+                blender_exe,
+                "--background",
+                "--python",
+                "installer\\add_submitter_to_pref.py",
+                "--",
+                "--deadline_cloud_install_path",
+                f"{cwd}\\{submitter_path}\\python",
+            ]
         )
 
 
@@ -238,51 +341,101 @@ def setup_macos(python_version):
     for version in BLENDER_VERSIONS:
         major_minor = ".".join(version.split(".")[:2])
         blender_app = Path(f"/Applications/Blender-{version}.app")
+        # Marker file indicates successful installation, avoiding redundant reinstalls
+        # Stored outside app directory to prevent corruption
+        blender_marker = Path(
+            f"~/Library/Application Support/.blender-{version}-installed"
+        ).expanduser()
+        blender_marker.parent.mkdir(parents=True, exist_ok=True)
 
-        print(f"Installing Blender {version}...")
-        blender_dmg = Path(f"/tmp/blender-{version}.dmg")
+        if blender_marker.exists():
+            print(f"Blender {version} already installed")
+            continue
 
-        if not USE_PUBLIC_URLS and download_from_s3(
-            f"blender/blender-{version}-macos-arm64.dmg", blender_dmg
-        ):
-            pass
-        elif USE_PUBLIC_URLS:
-            run(
-                f"curl -L -o {blender_dmg} https://download.blender.org/release/Blender{major_minor}/blender-{version}-macos-arm64.dmg",
-                shell=True,
-            )
-            verify_checksum(blender_dmg, BLENDER_CHECKSUMS[f"{version}-macos-arm64"])
+        # Lock file prevents concurrent installations that could corrupt the installation
+        lock_file = Path(f"/tmp/blender-{version}.lock")
+        if lock_file.exists():
+            print(f"Waiting for concurrent Blender {version} install...")
+            for _ in range(60):
+                time.sleep(1)
+                if blender_marker.exists():
+                    break
+            continue
 
-        run(f"hdiutil attach {blender_dmg}", shell=True)
-        run(f"sudo rm -rf {blender_app}", shell=True, check=False)
-        run(f"sudo cp -R /Volumes/Blender/Blender.app {blender_app}", shell=True)
-        run("hdiutil detach /Volumes/Blender", shell=True)
+        lock_file.touch()
+        try:
+            print(f"Installing Blender {version}...")
+            blender_dmg = Path(f"/tmp/blender-{version}.dmg")
 
-        blender_dmg.unlink(missing_ok=True)
+            if not USE_PUBLIC_URLS and download_from_s3(
+                f"blender/blender-{version}-macos-arm64.dmg", blender_dmg
+            ):
+                verify_checksum(blender_dmg, BLENDER_CHECKSUMS[f"{version}-macos-arm64"])
+            elif USE_PUBLIC_URLS:
+                run(
+                    [
+                        "curl",
+                        "-L",
+                        "-o",
+                        str(blender_dmg),
+                        f"https://download.blender.org/release/Blender{major_minor}/blender-{version}-macos-arm64.dmg",
+                    ]
+                )
+                verify_checksum(blender_dmg, BLENDER_CHECKSUMS[f"{version}-macos-arm64"])
+
+            run(["hdiutil", "attach", str(blender_dmg)])
+            run(["sudo", "rm", "-rf", str(blender_app)], check=False)
+            run(["sudo", "cp", "-R", "/Volumes/Blender/Blender.app", str(blender_app)])
+            run(["hdiutil", "detach", "/Volumes/Blender"])
+
+            blender_marker.touch()
+            blender_dmg.unlink(missing_ok=True)
+        finally:
+            lock_file.unlink(missing_ok=True)
 
     print("Installing Blender submitter...")
-    run("hatch build", shell=True)
-
-    submitter_path = Path("./DeadlineCloudSubmitter")
-    if submitter_path.exists():
-        run(f"rm -rf {submitter_path}", shell=True, check=False)
-
-    Path("./DeadlineCloudSubmitter/Submitters/Blender/python").mkdir(parents=True, exist_ok=True)
-    run(
-        "cp -r src/deadline/blender_submitter/addons/ ./DeadlineCloudSubmitter/Submitters/Blender/python/addons",
-        shell=True,
-    )
-
-    run(
-        f'pip install --upgrade --python-version {python_version} --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t ./DeadlineCloudSubmitter/Submitters/Blender/python/modules',
-        shell=True,
-    )
+    run(["hatch", "build"])
 
     for version in BLENDER_VERSIONS:
+        major_minor = ".".join(version.split(".")[:2])
+        submitter_path = Path(f"./DeadlineCloudSubmitter/Submitters/Blender{major_minor}")
+
+        Path(f"{submitter_path}/python").mkdir(parents=True, exist_ok=True)
+        run(
+            [
+                "cp",
+                "-r",
+                "src/deadline/blender_submitter/addons/",
+                f"{submitter_path}/python/addons",
+            ]
+        )
+
+        run(
+            [
+                "pip",
+                "install",
+                "--upgrade",
+                "--python-version",
+                python_version,
+                "--only-binary=:all:",
+                "deadline[gui]",
+                "blender-qt-stylesheet",
+                "-t",
+                f"{submitter_path}/python/modules",
+            ]
+        )
+
         blender_exe = f"/Applications/Blender-{version}.app/Contents/MacOS/Blender"
         run(
-            f"{blender_exe} --background --python ./installer/add_submitter_to_pref.py -- --deadline_cloud_install_path $(pwd)/DeadlineCloudSubmitter/Submitters/Blender/python",
-            shell=True,
+            [
+                blender_exe,
+                "--background",
+                "--python",
+                "./installer/add_submitter_to_pref.py",
+                "--",
+                "--deadline_cloud_install_path",
+                f"{os.getcwd()}/{submitter_path}/python",
+            ]
         )
 
 
@@ -306,7 +459,15 @@ if __name__ == "__main__":
 
     USE_PUBLIC_URLS = args.public_urls
     if args.versions:
-        BLENDER_VERSIONS = args.versions
+        BLENDER_VERSIONS = [validate_version(v) for v in args.versions]
+
+    # Validate all versions have checksums
+    for version in BLENDER_VERSIONS:
+        system_suffix = {"Linux": "linux-x64", "Windows": "windows-x64", "Darwin": "macos-arm64"}
+        key = f"{version}-{system_suffix.get(platform.system())}"
+        if key not in BLENDER_CHECKSUMS:
+            print(f"ERROR: No checksum available for {key}")
+            sys.exit(1)
 
     # Use provided python version or infer from first Blender version
     if args.python_version:

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/blender_utils.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/blender_utils.py
@@ -78,8 +78,7 @@ def find_files(project_path, skip_temp=True, skip_nonexistent=True) -> list[Path
 
     # Get allowlist from environment variable (semicolon-separated on Windows, colon-separated on Unix)
     allowlist_env = os.environ.get("BLENDER_TEMP_ALLOWLIST", "")
-    separator = ";" if os.name == "nt" else ":"
-    temp_allowlist = [Path(p.strip()) for p in allowlist_env.split(separator) if p.strip()]
+    temp_allowlist = [Path(p.strip()) for p in allowlist_env.split(os.pathsep) if p.strip()]
 
     files = bpy.utils.blend_paths(absolute=True)
     files.append(project_path)

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/blender_utils.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/blender_utils.py
@@ -74,6 +74,13 @@ def find_files(project_path, skip_temp=True, skip_nonexistent=True) -> list[Path
         skip_temp: if True, skip all files from any of Blender's potential temp directories.
         skip_nonexistent: if True, skip all files that do not exist. When files are shared across machines, Blender may retain memory of original paths; this ensures that all retrieved paths exist on the local filesystem.
     """
+    import os
+
+    # Get allowlist from environment variable (semicolon-separated on Windows, colon-separated on Unix)
+    allowlist_env = os.environ.get("BLENDER_TEMP_ALLOWLIST", "")
+    separator = ";" if os.name == "nt" else ":"
+    temp_allowlist = [Path(p.strip()) for p in allowlist_env.split(separator) if p.strip()]
+
     files = bpy.utils.blend_paths(absolute=True)
     files.append(project_path)
     files = set(Path(f) for f in files)
@@ -87,7 +94,9 @@ def find_files(project_path, skip_temp=True, skip_nonexistent=True) -> list[Path
     blender_resource_path = Path(bpy.utils.resource_path("LOCAL"))
 
     def _is_in_temp(f: Path) -> bool:
-        """Returns True if the given file is in any of Blender's temp directories."""
+        """Returns True if the given file is in any of Blender's temp directories, unless it's in the allowlist."""
+        if any(f.is_relative_to(allowed) for allowed in temp_allowlist):
+            return False
         return any(f.is_relative_to(temp_dir) for temp_dir in temp_dirs)
 
     def _is_essential_brush(path: Path) -> bool:

--- a/test/integ/conftest.py
+++ b/test/integ/conftest.py
@@ -71,6 +71,16 @@ def blender_version(blender_location) -> str:
     if not match:
         raise RuntimeError(f"Could not parse Blender version from {first_line}")
     version = match.group("version")
+
+    env_version = os.environ.get("BLENDER_VERSION")
+    if env_version:
+        # Compare only major.minor (e.g., "4.5" from "4.5.4")
+        env_version_short = ".".join(env_version.split(".")[:2])
+        assert version == env_version_short, (
+            f"BLENDER_VERSION env var ({env_version}) does not match "
+            f"blender --version output ({version})"
+        )
+
     return version
 
 

--- a/test/integ/conftest.py
+++ b/test/integ/conftest.py
@@ -12,6 +12,20 @@ from pathlib import Path
 
 _BLENDER_VERSION_RE = re.compile(r"^Blender (?P<version>\d+\.\d+)\..*$")
 
+# Set BLENDER_EXECUTABLE based on platform and version
+blender_version_env = os.environ.get("BLENDER_VERSION")
+if blender_version_env and not os.environ.get("BLENDER_EXECUTABLE"):
+    if os.name == "nt":
+        os.environ["BLENDER_EXECUTABLE"] = (
+            f"C:\\Tools\\blender-{blender_version_env}-windows-x64\\blender.exe"
+        )
+    elif sys.platform == "darwin":
+        os.environ["BLENDER_EXECUTABLE"] = (
+            f"/Applications/Blender-{blender_version_env}.app/Contents/MacOS/Blender"
+        )
+    else:  # Linux
+        os.environ["BLENDER_EXECUTABLE"] = f"/opt/blender-{blender_version_env}-linux-x64/blender"
+
 
 @pytest.fixture
 def blender_location() -> Path:

--- a/test/integ/conftest.py
+++ b/test/integ/conftest.py
@@ -12,20 +12,6 @@ from pathlib import Path
 
 _BLENDER_VERSION_RE = re.compile(r"^Blender (?P<version>\d+\.\d+)\..*$")
 
-# Set BLENDER_EXECUTABLE based on platform and version
-blender_version_env = os.environ.get("BLENDER_VERSION")
-if blender_version_env and not os.environ.get("BLENDER_EXECUTABLE"):
-    if os.name == "nt":
-        os.environ["BLENDER_EXECUTABLE"] = (
-            f"C:\\Tools\\blender-{blender_version_env}-windows-x64\\blender.exe"
-        )
-    elif sys.platform == "darwin":
-        os.environ["BLENDER_EXECUTABLE"] = (
-            f"/Applications/Blender-{blender_version_env}.app/Contents/MacOS/Blender"
-        )
-    else:  # Linux
-        os.environ["BLENDER_EXECUTABLE"] = f"/opt/blender-{blender_version_env}-linux-x64/blender"
-
 
 @pytest.fixture
 def blender_location() -> Path:
@@ -33,6 +19,22 @@ def blender_location() -> Path:
     location = os.environ.get("BLENDER_EXECUTABLE")
     if location:
         return Path(location)
+
+    # If BLENDER_VERSION is set, use platform-specific path
+    blender_version_env = os.environ.get("BLENDER_VERSION")
+    if blender_version_env:
+        if os.name == "nt":
+            location = f"C:\\Tools\\blender-{blender_version_env}-windows-x64\\blender.exe"
+            if os.path.exists(location):
+                return Path(location)
+        elif sys.platform == "darwin":
+            location = f"/Applications/Blender-{blender_version_env}.app/Contents/MacOS/Blender"
+            if os.path.exists(location):
+                return Path(location)
+        else:  # Linux
+            location = f"/opt/blender-{blender_version_env}-linux-x64/blender"
+            if os.path.exists(location):
+                return Path(location)
 
     # If Blender is in the PATH, use that
     location = shutil.which("blender")

--- a/test/integ/helpers/image_comparison.py
+++ b/test/integ/helpers/image_comparison.py
@@ -17,6 +17,7 @@ def assert_all_images_close(
         expected_image_directory: The directory containing the expected images.
         actual_image_directory: The directory containing the actual images.
     """
+
     for image in (expected_image_directory).iterdir():
         if not image.is_file() or image.name == ".DS_Store":
             continue
@@ -38,9 +39,31 @@ def assert_all_images_close(
         # Check that the two images are the same within a tolerance.
         # It's normal for there to be noise in an output image, so it is unlikely that two
         # renders will be exactly the same.
-        if not np.allclose(actual, expected, atol=2):
-            # For debugging: Uncomment to write the diff image along-side the expected image with _diff suffix
-            # diff = actual - expected
-            # PIL.Image.fromarray(diff).save(expected_image_directory / f"{image.name}_diff.png")
+        # Check both: max difference and percentage of pixels outside tolerance
+        diff = np.abs(actual.astype(int) - expected.astype(int))
+        max_diff = diff.max()
+        pixels_outside_tolerance = np.sum(diff > 2)
+        total_pixels = diff.size
+        percent_outside = (pixels_outside_tolerance / total_pixels) * 100
 
-            assert False, f"Image {image.name} is not close to the expected image"
+        # Pass if max diff <= 2 OR less than 0.5% of pixels are outside tolerance
+        if max_diff > 2 and percent_outside > 0.5:
+            print(f"Expected shape: {expected.shape}, Actual shape: {actual.shape}")
+            print(
+                f"Pixels outside tolerance (>2): {pixels_outside_tolerance}/{total_pixels} ({percent_outside:.2f}%)"
+            )
+            # For debugging: Uncomment to show per-channel differences
+            # if len(expected.shape) == 3:
+            #     for i, channel in enumerate(['R', 'G', 'B', 'A'][:expected.shape[2]]):
+            #         print(f"  {channel} channel max diff: {diff[:,:,i].max()}")
+            # For debugging: Uncomment to write the diff image along-side the actual image with _diff suffix
+            # diff_img = diff.astype(np.uint8)
+            # diff_amplified = np.clip(diff_img * 50, 0, 255).astype(np.uint8)
+            # if len(diff_amplified.shape) == 3 and diff_amplified.shape[2] == 4:
+            #     diff_amplified[:,:,3] = 255
+            # PIL.Image.fromarray(diff_amplified).save(actual_image_directory / f"{image.name}_diff.png")
+            # print(f"Diff image saved to {actual_image_directory / f'{image.name}_diff.png'} (amplified 50x)")
+
+            assert (
+                False
+            ), f"Image {image.name} is not close to the expected image (max diff: {max_diff}, {percent_outside:.2f}% pixels outside tolerance)"

--- a/test/integ/helpers/test_runners.py
+++ b/test/integ/helpers/test_runners.py
@@ -9,7 +9,7 @@ from typing import Any
 
 
 def run_command(args: list[str]) -> subprocess.CompletedProcess[bytes]:
-    output = subprocess.run(args, capture_output=True)
+    output = subprocess.run(args, capture_output=True, env=os.environ.copy())
 
     print(f"Ran the following: {' '.join(output.args)}")
     print(f"\nstdout:\n\n{output.stdout.decode('utf-8', errors='replace')}")
@@ -51,17 +51,28 @@ def is_valid_template(template_location: Path) -> bool:
 
 
 def run_adaptor_test(template_path: Path, job_params: dict[str, Any], blender_location) -> None:
+    import yaml
+
     # Set BLENDER_EXECUTABLE so the adaptor will find it
     os.environ["BLENDER_EXECUTABLE"] = str(blender_location)
 
-    # Run the full job. The template may contain multiple steps, representing a test in each
-    output = run_command(
-        [
-            "openjd",
-            "run",
-            str(template_path),
-            "--job-param",
-            json.dumps(job_params),
-        ]
-    )
-    assert output.returncode == 0
+    # Parse template to get step names
+    with open(template_path) as f:
+        template = yaml.safe_load(f)
+
+    steps = [step["name"] for step in template.get("steps", [])]
+
+    # Run each step separately to avoid connection file race condition
+    for step_name in steps:
+        output = run_command(
+            [
+                "openjd",
+                "run",
+                str(template_path),
+                "--step",
+                step_name,
+                "--job-param",
+                json.dumps(job_params),
+            ]
+        )
+        assert output.returncode == 0


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to be able to run integration tests for blender across multiple versions in our CI pipeline

### What was the solution? (How)
1. Add a new hatch env called `integ-ci` environment. Add a matrix of blender versions. Add two scripts `setup` - responsible for setting up the blender application environments, and `test` - runs the integration test using the matrix versions.

2. Added a script called `setup-runner.py`. It is responsible for setting up a runner with blender application install and any require dependencies. By default it looks for a bucket assigned to the env var `DEPENDENCY_BUCKET` to obtain the installers. If passed `--public-urls` it will grab installers the blender downloads page for the versions specified in the script and match them to a sha256.  If using a linux environment you will want to pass `--install_x11`  to install required deps.

3. Various test environments use temp locations. We added some logic to the blender_utils.py that allows the specification of paths to exclude from blender tmp path filtering.

4. When testing blender cross platform each platform is not guaranteed to render output exactly the same. The atol of 2 was too strict. It will now measure the maximum difference across all pixels and if that difference is > 2 for over 0.5% it will raise an error. This should allow for a bit more wiggle room for cross platform variations but also stay strict enough that we will catch any visual differences.

5. Updated the adaptor tests that are running multiple steps to run per step due to a cleanup race condition in openjd runtime.

### What is the impact of this change?
CI/CD can run the blender integration tests for 4.2, 4.5

### How was this change tested?
Tested in a developer environment. Confirmed that the tests for Mac, Linux and Windows all passed.

https://github.com/moorec-aws/deadline-cloud-for-blender/actions/runs/19515494134

### Was this change documented?
Not yet

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*