### PR TITLE
ci: specify permissions that workflows pass to jobs/actions

### DIFF
--- a/.github/workflows/build_installers.yml
+++ b/.github/workflows/build_installers.yml
@@ -33,6 +33,9 @@ jobs:
     if: (github.repository == 'aws-deadline/deadline-cloud-for-blender')
     name: Build Installer
     uses: aws-deadline/.github/.github/workflows/reusable_build_installers.yml@mainline
+    permissions:
+      contents: read
+      id-token: write
     secrets: inherit
     with:
       environment: ${{inputs.environment}}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,3 +12,5 @@ jobs:
   Analysis:
     name: Analysis
     uses: aws-deadline/.github/.github/workflows/reusable_codeql.yml@mainline
+    permissions:
+      security-events: write

--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -20,6 +20,9 @@ jobs:
   Bump:
     name: Version Bump
     uses: aws-deadline/.github/.github/workflows/reusable_bump.yml@mainline
+    permissions:
+      contents: write
+      pull-requests: write
     secrets: inherit
     with:
       force_version_bump: ${{ inputs.force_version_bump }}

--- a/.github/workflows/responded.yml
+++ b/.github/workflows/responded.yml
@@ -6,3 +6,6 @@ on:
 jobs:
   check-for-response:
     uses: aws-deadline/.github/.github/workflows/reusable_responded.yml@mainline
+    permissions:
+      issues: write
+      pull-requests: write

--- a/.github/workflows/stale_prs_and_issues.yml
+++ b/.github/workflows/stale_prs_and_issues.yml
@@ -7,3 +7,7 @@ on:
 jobs:
   check-for-stales:
     uses: aws-deadline/.github/.github/workflows/reusable_stale_prs_and_issues.yml@mainline
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to pass the specific permissions required by the re-usable workflows

### What was the solution? (How)
Add the permissions required by to run the re-usable workflows.

https://github.com/aws-deadline/.github/tree/mainline/.github/workflows

### What is the impact of this change?
Permissions are scoped to the requirement

### How was this change tested?

N/A - Will be confirmed after merge


### Was this change documented?

N/A

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*