### PR TITLE
chore(dev): as of hatch 1.16.0, 'hatch build' can't be run in non-builder envs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,7 +12,7 @@ The deadline.blender_adaptor package is an adaptor that renders blender scenes t
 ### Build the package
 
 ```bash
-hatch run build
+hatch build
 ```
 
 ### Build the installer

--- a/hatch.toml
+++ b/hatch.toml
@@ -27,14 +27,10 @@ build-addon = "python scripts/build_addon.py {args}"
 python = ["3.9", "3.10", "3.11", "3.12"]
 
 [envs.default.env-vars]
-SKIP_BOOTSTRAP_TEST_RESOURCES="True"
 DEADLINE_ENABLE_DEVELOPER_OPTIONS="True"
 
 [envs.installer.scripts]
 build-installer = "python {root}/scripts/build_installer_cli.py --installer-source-path {root}/installer/DeadlineCloudForBlenderSubmitter.xml {args:}"
-
-[envs.codebuild.scripts]
-build = "hatch build"
 
 [envs.integ]
 pre-install-commands = [

--- a/pipeline/build.sh
+++ b/pipeline/build.sh
@@ -6,6 +6,6 @@ set -e
 pip install --upgrade pip
 pip install --upgrade hatch
 pip install --upgrade twine
-hatch -v run codebuild:lint
-hatch run codebuild:test
-hatch -v run codebuild:build
+hatch -v run lint
+hatch run test
+hatch -v build


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

```
$ hatch run codebuild:build
...
Environment `codebuild` is not a builder environment
```

### What was the solution? (How)

Remove codebuild env since it is no longer needed

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*