### PR TITLE
ci: add integration tests to merges and release process

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -2,7 +2,28 @@ name: Blender Integration Tests
 
 on:
   workflow_dispatch:
-
+    inputs:
+      ref_type:
+        description: 'Reference type to test'
+        required: true
+        default: 'branch'
+        type: choice
+        options:
+          - branch
+          - tag
+      branch:
+        description: 'Branch to test (e.g., mainline, feature-branch)'
+        required: false
+        default: 'mainline'
+        type: string
+      tag:
+        description: 'Tag to test (only used when ref_type is "tag")'
+        required: false
+        type: string
+  push:
+    branches:
+      - 'mainline'
+      
 jobs:  
   MainlineLinuxIntegrationTest:
     name: Linux Integration Tests
@@ -13,8 +34,8 @@ jobs:
     secrets: inherit
     with:
       repository: ${{ github.event.repository.name }}
-      branch: mainline
-      environment: mainline
+      branch: ${{ github.event.inputs.ref_type == 'branch' && github.event.inputs.branch || 'mainline' }}
+      tag: ${{ github.event.inputs.ref_type == 'tag' && github.event.inputs.tag || '' }}
       os: linux
   MainlineWindowsIntegrationTest:
     name: Windows Integration Tests
@@ -25,8 +46,8 @@ jobs:
     secrets: inherit
     with:
       repository: ${{ github.event.repository.name }}
-      branch: mainline
-      environment: mainline
+      branch: ${{ github.event.inputs.ref_type == 'branch' && github.event.inputs.branch || 'mainline' }}
+      tag: ${{ github.event.inputs.ref_type == 'tag' && github.event.inputs.tag || '' }}
       os: windows
   MainlineMacOsIntegrationTest:
     name: MacOS Integration Tests
@@ -37,6 +58,6 @@ jobs:
     secrets: inherit
     with:
       repository: ${{ github.event.repository.name }}
-      branch: mainline
-      environment: mainline
+      branch: ${{ github.event.inputs.ref_type == 'branch' && github.event.inputs.branch || 'mainline' }}
+      tag: ${{ github.event.inputs.ref_type == 'tag' && github.event.inputs.tag || '' }}
       os: macos

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -34,8 +34,47 @@ jobs:
     with:
       tag: ${{ needs.TagRelease.outputs.tag }}
 
+  LinuxIntegrationTest:
+    needs: [TagRelease, UnitTests]
+    name: Linux Integration Tests
+    permissions:
+      id-token: write
+      contents: read
+    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
+    secrets: inherit
+    with:
+      repository: ${{ github.event.repository.name }}
+      tag: ${{ needs.TagRelease.outputs.tag }}
+      os: linux
+
+  WindowsIntegrationTest:
+    needs: [TagRelease, UnitTests]
+    name: Windows Integration Tests
+    permissions:
+      id-token: write
+      contents: read
+    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
+    secrets: inherit
+    with:
+      repository: ${{ github.event.repository.name }}
+      tag: ${{ needs.TagRelease.outputs.tag }}
+      os: windows
+
+  MacOsIntegrationTest:
+    needs: [TagRelease, UnitTests]
+    name: MacOS Integration Tests
+    permissions:
+      id-token: write
+      contents: read
+    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
+    secrets: inherit
+    with:
+      repository: ${{ github.event.repository.name }}
+      branch: ${{ needs.TagRelease.outputs.tag }}
+      os: macos
+
   PreRelease:
-      needs: [TagRelease, UnitTests]
+      needs: [TagRelease, UnitTests, LinuxIntegrationTest, WindowsIntegrationTest, MacOsIntegrationTest]
       uses: aws-deadline/.github/.github/workflows/reusable_prerelease.yml@mainline
       permissions:
         id-token: write


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Integration tests were not running as part of the release process for the Blender DCC adaptor. This meant releases could be published without validating that the integration tests pass on all supported platforms (Linux, Windows, macOS).

We also want integration tests to run when we merge to mainline

### What was the solution? (How)
Added three integration test jobs to the release_publish.yml workflow:

* LinuxIntegrationTest
* WindowsIntegrationTest
* MacOsIntegrationTest

These jobs run in parallel after the release is tagged and use the reusable integration test workflow from aws-deadline/.github. The PreRelease job now depends on all integration tests passing before proceeding with the release.

Set `integration_tests.yml` to run on push to mainline and added options for running on different branches or tags

### What is the impact of this change?
* Releases will now be blocked if integration tests fail on any platform, ensuring higher quality releases and catching platform-specific issues before they reach production.

### How was this change tested?


This change modifies the CI/CD workflow itself. Testing was done in development account but will primarily occur when the next release is triggered, at which point the integration tests will run automatically as part of the release process.

### Was this change documented?
No

### Is this a breaking change?
No.


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
