### PR TITLE
feat!: Added option to render with the scene's default camera.

### DIFF
--- a/src/deadline/blender_adaptor/BlenderAdaptor/schemas/run_data.schema.json
+++ b/src/deadline/blender_adaptor/BlenderAdaptor/schemas/run_data.schema.json
@@ -13,7 +13,6 @@
         }
     },
     "required": [
-        "frame",
-        "camera"
+        "frame"
     ]
 }

--- a/src/deadline/blender_adaptor/BlenderClient/render_handlers/default_blender_handler.py
+++ b/src/deadline/blender_adaptor/BlenderClient/render_handlers/default_blender_handler.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import cast
+from typing import cast, Optional
 
 import bpy  # type: ignore
 
@@ -41,7 +41,7 @@ class DefaultBlenderHandler:
 
         _logger.debug(f"Initialized {self.__class__.__name__}")
 
-    def _ensure_camera(self, data: dict) -> str:
+    def _ensure_camera(self, data: dict) -> Optional[str]:
         """
         Ensure that the camera provided in `data` exists in the scene and is renderable.
         Raises a RuntimeError otherwise.
@@ -50,7 +50,7 @@ class DefaultBlenderHandler:
         """
         camera: str = cast(str, data.get("camera", self.camera_name))
         if camera is None:
-            raise RuntimeError(f"No camera specified in data: {data}")
+            return None
 
         # The ls function returns all cameras if they are set to renderable.
         scene_cameras = [
@@ -103,9 +103,7 @@ class DefaultBlenderHandler:
         # Add submitter settings to the output filepath.
         # This includes output directory, view layer, camera, and frame.
         try:
-            bpy.context.scene.render.filepath = (
-                f"{self.output_dir}/{self.view_layer_name}_{camera}_{self.output_file_name}"
-            )
+            bpy.context.scene.render.filepath = f"{self.output_dir}/{self.view_layer_name}{'_' + camera if camera else ''}_{self.output_file_name}"
         except Exception:
             _logger.error(
                 f"Could not set the output file path. Please verify that the following are correct:\nOutput directory: {self.output_dir}\nView layer: {self.view_layer_name}\nCamera:{camera}\nOutput file prefix:{self.output_file_name}"
@@ -140,8 +138,15 @@ class DefaultBlenderHandler:
         """
         self.camera_name = data.get("camera")
         camera = self._ensure_camera(data)
-        assert self.camera_name == camera, "Camera name mismatch: this should never happen."
-        bpy.context.scene.camera = bpy.data.objects[camera]
+
+        if camera:
+            scene = bpy.context.scene
+            assert self.camera_name == camera, "Camera name mismatch: this should never happen."
+            scene.camera = bpy.data.objects[camera]
+
+            # Iterate through all markers in the scene and set the bound camera to be the selected camera
+            for marker in scene.timeline_markers:
+                marker.camera = scene.camera
 
     def set_render_scene(self, data: dict) -> None:
         """

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/sanity_checks.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/sanity_checks.py
@@ -49,7 +49,7 @@ def run_sanity_checks(settings, prompt_for_saving=True):
     # Ensure the selected camera is still in the scene
     if (
         settings.camera_selection
-        not in [ssw.COMBO_DEFAULT_ALL_RENDERABLE_CAMERAS, ssw.COMBO_USE_CAMERA_MARKERS]
+        not in [ssw.COMBO_DEFAULT_ALL_RENDERABLE_CAMERAS, ssw.COMBO_USE_DEFAULT_CAMERA]
         and settings.camera_selection not in renderable_cameras
     ):
         raise RuntimeError(

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/sanity_checks.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/sanity_checks.py
@@ -48,7 +48,8 @@ def run_sanity_checks(settings, prompt_for_saving=True):
 
     # Ensure the selected camera is still in the scene
     if (
-        settings.camera_selection != ssw.COMBO_DEFAULT_ALL_RENDERABLE_CAMERAS
+        settings.camera_selection
+        not in [ssw.COMBO_DEFAULT_ALL_RENDERABLE_CAMERAS, ssw.COMBO_USE_CAMERA_MARKERS]
         and settings.camera_selection not in renderable_cameras
     ):
         raise RuntimeError(

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/scene_settings_widget.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/scene_settings_widget.py
@@ -32,6 +32,7 @@ _logger = logging.getLogger(__name__)
 # Default values for combo boxes in the addon UI.
 COMBO_DEFAULT_ALL_RENDERABLE_CAMERAS = "All Renderable Cameras"
 COMBO_DEFAULT_ALL_RENDERABLE_LAYERS = "All Renderable Layers"
+COMBO_USE_CAMERA_MARKERS = "Use Default Camera"
 
 
 class SceneSettingsWidget(QWidget):
@@ -161,6 +162,8 @@ class SceneSettingsWidget(QWidget):
             self.cameras_box.addItem(
                 COMBO_DEFAULT_ALL_RENDERABLE_CAMERAS, COMBO_DEFAULT_ALL_RENDERABLE_CAMERAS
             )
+            self.cameras_box.addItem(COMBO_USE_CAMERA_MARKERS, COMBO_USE_CAMERA_MARKERS)
+
             for cam in selectable_cameras:
                 self.cameras_box.addItem(cam, cam)
 

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/scene_settings_widget.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/scene_settings_widget.py
@@ -32,7 +32,7 @@ _logger = logging.getLogger(__name__)
 # Default values for combo boxes in the addon UI.
 COMBO_DEFAULT_ALL_RENDERABLE_CAMERAS = "All Renderable Cameras"
 COMBO_DEFAULT_ALL_RENDERABLE_LAYERS = "All Renderable Layers"
-COMBO_USE_CAMERA_MARKERS = "Use Default Camera"
+COMBO_USE_DEFAULT_CAMERA = "Use Default Camera"
 
 
 class SceneSettingsWidget(QWidget):
@@ -162,7 +162,7 @@ class SceneSettingsWidget(QWidget):
             self.cameras_box.addItem(
                 COMBO_DEFAULT_ALL_RENDERABLE_CAMERAS, COMBO_DEFAULT_ALL_RENDERABLE_CAMERAS
             )
-            self.cameras_box.addItem(COMBO_USE_CAMERA_MARKERS, COMBO_USE_CAMERA_MARKERS)
+            self.cameras_box.addItem(COMBO_USE_DEFAULT_CAMERA, COMBO_USE_DEFAULT_CAMERA)
 
             for cam in selectable_cameras:
                 self.cameras_box.addItem(cam, cam)

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/template_filling.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/template_filling.py
@@ -354,11 +354,15 @@ def _fill_step_template(
     # NOTE this string var cross-references the constant defined in `scene_settings_widget.py`. Duplicated to avoid importing that file.
     if settings.camera_selection == "All Renderable Cameras":
         cameras = common_layer_settings.renderable_camera_names
+    elif settings.camera_selection == "Use Default Camera":
+        cameras = None
     else:
         cameras = [settings.camera_selection]
-    param_defs.append({"name": "Camera", "type": "STRING", "range": cameras})
-    run_data = step["script"]["embeddedFiles"][0]
-    run_data["data"] += "camera: '{{Task.Param.Camera}}'\n"
+
+    if cameras:
+        param_defs.append({"name": "Camera", "type": "STRING", "range": cameras})
+        run_data = step["script"]["embeddedFiles"][0]
+        run_data["data"] += "camera: '{{Task.Param.Camera}}'\n"
 
     # If host requirements are provided, inject them into the step template.
     if host_requirements:

--- a/test/unit/deadline_submitter_for_blender/test_submitter.py
+++ b/test/unit/deadline_submitter_for_blender/test_submitter.py
@@ -489,3 +489,27 @@ def test_sort_auto_detected_assets():
 
         assert auto_detected_assets.input_filenames == expected_input_filenames
         assert auto_detected_assets.input_directories == expected_input_dirs
+
+
+def test_fill_job_template_use_default_camera(submitter_settings, common_layer_settings):
+    """Test filling the job template when camera_selection is 'Use Default Camera'."""
+
+    # Set camera_selection to "Use Default Camera"
+    submitter_settings.camera_selection = "Use Default Camera"
+
+    filled = template_filling.fill_job_template(
+        submitter_settings, ["layer_1"], common_layer_settings, host_requirements=None
+    )
+
+    # Check that Camera parameter is NOT in taskParameterDefinitions
+    task_param_defs = filled["steps"][0]["parameterSpace"]["taskParameterDefinitions"]
+    camera_params = [param for param in task_param_defs if param.get("name") == "Camera"]
+    assert (
+        len(camera_params) == 0
+    ), "Camera parameter should not be defined when using default camera"
+
+    # Check that camera is NOT set in the embedded RunData file
+    run_data = filled["steps"][0]["script"]["embeddedFiles"][0]["data"]
+    assert (
+        "camera:" not in run_data
+    ), "Camera should not be set in RunData when using default camera"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The way the Submitter and Adaptor handle cameras bound to timeline markers is strange and unintuitive. 

We only allow users to either choose a specific camera or all cameras. There is no option to use the scene default or use marker bound cameras. However, when a scene with marker bound cameras is rendered, it always obeys the markers, even though the output filename includes the chosen camera. So a user could select Camera004 and render not a single frame from that camera if the bound cameras are different. This is especially weird when you select render all cameras. With render all cameras selected, a Task is created for each camera but they all render the same shots using the camera markers. 

First reported: https://github.com/aws-deadline/deadline-cloud-for-blender/issues/268

### What was the solution? (How)

I've added an option to the submitter to use the default camera. When that option is selected, the camera parameter is not set in the task definition and not included in the run-data. We will rely on Blender to set the camera. This allows camera markers to be rendered as expected. Also, the output filename will not include a camera name if this option is selected.

Additionally, I've changed the behaviour of the regular camera option. When a camera is selected, it will force Blender to render all frames with that camera, regardless of camera markers or scene defaults. This means that when selecting the render all cameras option, each task will use the corresponding camera.

Note, I didn't want to remove the markers or disable them when a camera is selected because other things could be tied to them. The markers will override the scene's camera so, when setting a specific camera, we iterate over all markers and set the camera to be the chose camera. 

<img width="570" height="516" alt="image" src="https://github.com/user-attachments/assets/3d0de1ab-b1bb-4d98-a134-5fee34c47d84" />

### What is the impact of this change?

This change will now allow users to:

- Render with markers in an expected fashion
- Render with a specific (or all) camera(s) even with markers

### How was this change tested?

Built the submitter and adaptor locally. 

Using the Submitter I exported a job bundle with the new camera option selected. The template did not contain a task parameter of the camera and camera was not defined in the run-data file. A unit test was added to ensure this.

I then ran a range of renders through the adaptor using init and run data files. 

Specifying a camera in run data always results in that camera rendering, no matter the markers or other scene defaults.
Without specifying a camera, the frames rendered used the scene default camera or cameras bound to markers.

#### Please run the integration tests and paste the results below

```

test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
[gw0] [ 25%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor 
[gw0] [ 50%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor 
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter 
[gw0] [ 75%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter 
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter 
[gw0] [100%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter 

================================================================================================================================================================================= slowest 5 durations ==================================================================================================================================================================================
45.63s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
18.04s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
3.52s call     test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
2.95s call     test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter
0.61s setup    test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
============================================================================================================================================================================= 4 passed in 73.95s (0:01:13) =============================================================================================================================================================================
```

### Was this change documented?

### Is this a breaking change?
Yes. The schema for the run-data file has been loosened, which isn't a breaking change but the behaviour of the camera options is now very different. 
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*