### PR TITLE
test: Added integration tests to validate opening and closing of Blender.

### DIFF
--- a/test/integ/test_adaptor_lifecycle.py
+++ b/test/integ/test_adaptor_lifecycle.py
@@ -1,0 +1,119 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import os
+import psutil
+import time
+from pathlib import Path
+
+import pytest
+
+from deadline.blender_adaptor.BlenderAdaptor import BlenderAdaptor
+
+
+@pytest.mark.adaptor
+class TestAdaptorLifecycle:
+    """
+    Tests that validate the Blender adaptor can start and close the Blender application.
+    """
+
+    def test_adaptor_start_and_close_blender(
+        self, blender_location: Path, script_location: Path
+    ) -> None:
+        """Test that the adaptor can start and properly close Blender."""
+        # Set BLENDER_EXECUTABLE environment variable
+        os.environ["BLENDER_EXECUTABLE"] = str(blender_location)
+
+        # Use the test.blend file from minimal test directory
+        scene_file = script_location / "minimal_test" / "scene" / "test.blend"
+
+        # Create minimal init data with all required fields
+        init_data = {
+            "scene_file": str(scene_file),
+            "render_engine": "cycles",
+            "gpu_device": "NONE",
+        }
+
+        # Initialize adaptor
+        adaptor = BlenderAdaptor(init_data)
+
+        try:
+            # Start the adaptor (should start Blender)
+            adaptor.on_start()
+
+            # Verify Blender is running
+            assert adaptor._blender_is_running, "Blender should be running after on_start()"
+
+            # Get process ID and verify process is running
+            assert adaptor._blender_client
+            blender_pid = adaptor._blender_client.pid
+            assert psutil.pid_exists(
+                blender_pid
+            ), f"Blender process {blender_pid} should be running"
+
+            # Wait briefly to ensure stable state
+            time.sleep(1)
+
+            # Verify the process is still alive
+            assert adaptor._blender_client is not None
+            assert adaptor._blender_client.is_running
+            assert psutil.pid_exists(
+                blender_pid
+            ), f"Blender process {blender_pid} should still be running"
+
+        finally:
+            # Clean up (should close Blender)
+            adaptor.on_cleanup()
+
+            # Verify Blender is no longer running
+            assert not adaptor._blender_is_running, "Blender should not be running after cleanup"
+
+    def test_adaptor_cancel_closes_blender(
+        self, blender_location: Path, script_location: Path
+    ) -> None:
+        """Test that the adaptor closes Blender when a task is canceled."""
+        # Set BLENDER_EXECUTABLE environment variable
+        os.environ["BLENDER_EXECUTABLE"] = str(blender_location)
+
+        # Use the test.blend file from minimal test directory
+        scene_file = script_location / "minimal_test" / "scene" / "test.blend"
+
+        # Create init data with all required fields
+        init_data = {
+            "scene_file": str(scene_file),
+            "render_engine": "cycles",
+            "gpu_device": "NONE",
+        }
+
+        # Initialize adaptor
+        adaptor = BlenderAdaptor(init_data)
+
+        try:
+            # Start the adaptor
+            adaptor.on_start()
+
+            # Verify Blender is running
+            assert adaptor._blender_is_running, "Blender should be running after on_start()"
+
+            # Get process ID and verify process is running
+            assert adaptor._blender_client
+            blender_pid = adaptor._blender_client.pid
+            assert psutil.pid_exists(
+                blender_pid
+            ), f"Blender process {blender_pid} should be running"
+
+            # Cancel the task
+            adaptor.on_cancel()
+
+            # Wait briefly for cancellation to take effect
+            time.sleep(1)
+
+            # Verify Blender is no longer running after cancel
+            assert not adaptor._blender_is_running, "Blender should not be running after cancel"
+            assert not psutil.pid_exists(
+                blender_pid
+            ), f"Blender process {blender_pid} should be terminated"
+
+        finally:
+            # Ensure cleanup in case cancel didn't work
+            if adaptor._blender_is_running:
+                adaptor.on_cleanup()

--- a/test/integ/test_daemon_mode.py
+++ b/test/integ/test_daemon_mode.py
@@ -1,0 +1,177 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import json
+import os
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.adaptor
+class TestDaemonMode:
+    """
+    Tests that validate the Blender adaptor daemon mode functionality.
+    """
+
+    def test_daemon_start_and_stop(self, blender_location: Path, script_location: Path) -> None:
+        """Test that the blender-openjd daemon can start and stop successfully."""
+        # Set BLENDER_EXECUTABLE environment variable
+        os.environ["BLENDER_EXECUTABLE"] = str(blender_location)
+
+        # Use the test.blend file from minimal test directory
+        scene_file = script_location / "minimal_test" / "scene" / "test.blend"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            connection_file = temp_path / "connection.json"
+            init_data_file = temp_path / "init-data.yaml"
+
+            # Create init data file
+            init_data_content = f"""scene_file: {scene_file}
+render_engine: cycles
+gpu_device: NONE
+render_scene: Scene
+view_layer: ViewLayer
+output_dir: {temp_path}
+output_file_name: output_####
+output_format: PNG
+"""
+            init_data_file.write_text(init_data_content)
+
+            try:
+                # Start daemon
+                start_cmd = [
+                    "blender-openjd",
+                    "daemon",
+                    "start",
+                    "--connection-file",
+                    str(connection_file),
+                    "--init-data",
+                    f"file://{init_data_file}",
+                ]
+
+                start_process = subprocess.run(
+                    start_cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+
+                # Verify daemon started successfully
+                assert start_process.returncode == 0, f"Daemon start failed: {start_process.stderr}"
+                assert connection_file.exists(), "Connection file should be created"
+
+                # Verify connection file contains valid JSON
+                connection_data = json.loads(connection_file.read_text())
+                assert "socket" in connection_data, "Connection file should contain socket"
+
+                # Wait briefly to ensure daemon is fully started
+                time.sleep(2)
+
+            finally:
+                # Stop daemon
+                if connection_file.exists():
+                    stop_cmd = [
+                        "blender-openjd",
+                        "daemon",
+                        "stop",
+                        "--connection-file",
+                        str(connection_file),
+                    ]
+
+                    stop_process = subprocess.run(
+                        stop_cmd,
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
+                    )
+
+                    # Verify daemon stopped successfully
+                    assert (
+                        stop_process.returncode == 0
+                    ), f"Daemon stop failed: {stop_process.stderr}"
+
+    def test_daemon_run_command(self, blender_location: Path, script_location: Path) -> None:
+        """Test that the daemon can execute a run command successfully."""
+        os.environ["BLENDER_EXECUTABLE"] = str(blender_location)
+        scene_file = script_location / "minimal_test" / "scene" / "test.blend"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            connection_file = temp_path / "connection.json"
+            init_data_file = temp_path / "init-data.yaml"
+            run_data_file = temp_path / "run-data.yaml"
+
+            # Create init data file
+            init_data_content = f"""scene_file: {scene_file}
+render_engine: cycles
+gpu_device: NONE
+render_scene: Scene
+view_layer: ViewLayer
+output_dir: {temp_path}
+output_file_name: output_####
+output_format: PNG
+"""
+            init_data_file.write_text(init_data_content)
+
+            # Create run data file
+            run_data_content = """frame: 1
+camera: Camera
+"""
+            run_data_file.write_text(run_data_content)
+
+            try:
+                # Start daemon
+                start_process = subprocess.run(
+                    [
+                        "blender-openjd",
+                        "daemon",
+                        "start",
+                        "--connection-file",
+                        str(connection_file),
+                        "--init-data",
+                        f"file://{init_data_file}",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+
+                assert start_process.returncode == 0, f"Daemon start failed: {start_process.stderr}"
+                time.sleep(2)
+
+                # Execute run command
+                run_process = subprocess.run(
+                    [
+                        "blender-openjd",
+                        "daemon",
+                        "run",
+                        "--connection-file",
+                        str(connection_file),
+                        "--run-data",
+                        f"file://{run_data_file}",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=120,
+                )
+
+                # Verify run command succeeded
+                assert run_process.returncode == 0, f"Daemon run failed: {run_process.stderr}"
+
+            finally:
+                if connection_file.exists():
+                    subprocess.run(
+                        [
+                            "blender-openjd",
+                            "daemon",
+                            "stop",
+                            "--connection-file",
+                            str(connection_file),
+                        ],
+                        capture_output=True,
+                        timeout=30,
+                    )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We don't have tests that explicitly test the adaptor to make sure that it's able to open and close Blender. 

### What was the solution? (How)
Add 2 sets of integration tests that simply start the adaptor, check that Blender is running and then close the adaptor. One set uses the `BlenderAdaptor` class directly, while the other uses the adaptor daemon.

We also check that the adaptor can do a run and that it can close Blender when a cancel command is given.


### What is the impact of this change?
More tests covering basics.


### How was this change tested?
Ran tests locally.

#### Please run the integration tests and paste the results below

```

test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_start_and_close_blender 
[gw0] [ 12%] PASSED test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_start_and_close_blender 
test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_cancel_closes_blender 
[gw0] [ 25%] PASSED test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_cancel_closes_blender 
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
[gw0] [ 37%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor 
[gw0] [ 50%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor 
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter 
[gw0] [ 62%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter 
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter 
[gw0] [ 75%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter 
test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_start_and_stop 
[gw0] [ 87%] PASSED test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_start_and_stop 
test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_run_command 
[gw0] [100%] PASSED test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_run_command 

================================================================================================================================================================================= slowest 5 durations ==================================================================================================================================================================================
40.67s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
16.05s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
12.62s call     test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_run_command
8.85s call     test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_start_and_stop
3.99s call     test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_start_and_close_blender
============================================================================================================================================================================ 8 passed in 102.26s (0:01:42) =============================================================================================================================================================================
```

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*