### PR TITLE
ci: use os matrix when defining integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -25,39 +25,25 @@ on:
       - 'mainline'
       
 jobs:  
-  MainlineLinuxIntegrationTest:
-    name: Linux Integration Tests
+  IntegrationTests:
+    name: ${{ matrix.name }} Integration Tests
     permissions:
       id-token: write
       contents: read
+    strategy:
+      matrix:
+        fail-fast: false
+        include:
+          - os: linux
+            name: Linux
+          - os: windows
+            name: Windows
+          - os: macos
+            name: MacOS
     uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
     secrets: inherit
     with:
       repository: ${{ github.event.repository.name }}
       branch: ${{ github.event.inputs.ref_type == 'branch' && github.event.inputs.branch || 'mainline' }}
       tag: ${{ github.event.inputs.ref_type == 'tag' && github.event.inputs.tag || '' }}
-      os: linux
-  MainlineWindowsIntegrationTest:
-    name: Windows Integration Tests
-    permissions:
-      id-token: write
-      contents: read
-    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
-    secrets: inherit
-    with:
-      repository: ${{ github.event.repository.name }}
-      branch: ${{ github.event.inputs.ref_type == 'branch' && github.event.inputs.branch || 'mainline' }}
-      tag: ${{ github.event.inputs.ref_type == 'tag' && github.event.inputs.tag || '' }}
-      os: windows
-  MainlineMacOsIntegrationTest:
-    name: MacOS Integration Tests
-    permissions:
-      id-token: write
-      contents: read
-    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
-    secrets: inherit
-    with:
-      repository: ${{ github.event.repository.name }}
-      branch: ${{ github.event.inputs.ref_type == 'branch' && github.event.inputs.branch || 'mainline' }}
-      tag: ${{ github.event.inputs.ref_type == 'tag' && github.event.inputs.tag || '' }}
-      os: macos
+      os: ${{ matrix.os }}

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -29,52 +29,36 @@ jobs:
 
   UnitTests:
     needs: [TagRelease]
-    name: Unit and Integration Tests
+    name: Unit Tests
     uses: ./.github/workflows/code_quality.yml
     with:
       tag: ${{ needs.TagRelease.outputs.tag }}
 
-  LinuxIntegrationTest:
+  IntegrationTests:
     needs: [TagRelease, UnitTests]
-    name: Linux Integration Tests
+    name: ${{ matrix.name}} Integration Tests
     permissions:
       id-token: write
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: linux
+            name: Linux
+          - os: windows
+            name: Windows
+          - os: macos
+            name: MacOS
     uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
     secrets: inherit
     with:
       repository: ${{ github.event.repository.name }}
       tag: ${{ needs.TagRelease.outputs.tag }}
-      os: linux
-
-  WindowsIntegrationTest:
-    needs: [TagRelease, UnitTests]
-    name: Windows Integration Tests
-    permissions:
-      id-token: write
-      contents: read
-    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
-    secrets: inherit
-    with:
-      repository: ${{ github.event.repository.name }}
-      tag: ${{ needs.TagRelease.outputs.tag }}
-      os: windows
-
-  MacOsIntegrationTest:
-    needs: [TagRelease, UnitTests]
-    name: MacOS Integration Tests
-    permissions:
-      id-token: write
-      contents: read
-    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
-    secrets: inherit
-    with:
-      repository: ${{ github.event.repository.name }}
-      branch: ${{ needs.TagRelease.outputs.tag }}
-      os: macos
-
+      os: ${{ matrix.os }}
+      
   PreRelease:
-      needs: [TagRelease, UnitTests, LinuxIntegrationTest, WindowsIntegrationTest, MacOsIntegrationTest]
+      needs: [TagRelease, UnitTests, IntegrationTests]
       uses: aws-deadline/.github/.github/workflows/reusable_prerelease.yml@mainline
       permissions:
         id-token: write


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Simplify the integration tests specification in workflows to use an os matrix

### What was the solution? (How)
Remove duplicate code and use an os matrix

### What is the impact of this change?
less duplicate code

### How was this change tested?
In developer account, confirmed the jobs were created as expected.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*