### PR TITLE
ci: fix fail-fast location error in integration_test.yml

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -31,8 +31,8 @@ jobs:
       id-token: write
       contents: read
     strategy:
+      fail-fast: false
       matrix:
-        fail-fast: false
         include:
           - os: linux
             name: Linux


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
fail-fast is in the incorrect location, it needs to be under strategy.

https://github.com/aws-deadline/deadline-cloud-for-blender/actions/runs/20965123811

### What was the solution? (How)
add `fail-fast: false` to strategy

### What is the impact of this change?
Integrations tests pass again

### How was this change tested?

Works in the publish workflow:
https://github.com/moorec-aws/deadline-cloud-for-blender/actions/runs/20963876915/workflow

### Was this change documented?
No

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*