### PR TITLE
test: print debug info during adaptor integ tests

### DIFF
--- a/test/integ/helpers/test_runners.py
+++ b/test/integ/helpers/test_runners.py
@@ -3,6 +3,7 @@
 import os
 import subprocess
 import json
+import getpass
 
 from pathlib import Path
 from typing import Any
@@ -61,6 +62,10 @@ def run_adaptor_test(template_path: Path, job_params: dict[str, Any], blender_lo
         template = yaml.safe_load(f)
 
     steps = [step["name"] for step in template.get("steps", [])]
+
+    # Print out environment debug information
+    print(f"Current User: {getpass.getuser()}")
+    print(f"Current Environment: {json.dumps(dict(os.environ), indent=2)}\n")
 
     # Run each step separately to avoid connection file race condition
     for step_name in steps:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There is a flaky integ test issue on Windows where the suspicion is that an envrionment variable to configure the correct user isn't always being set properly during the adaptor startup.

### What was the solution? (How)
This isn't a fix, but adds printing of the current environment and current user to the tests before the adaptor runs.
### What is the impact of this change?
Next time there is a failure we will have more information to narrow down the root cause and fix it.
### How was this change tested?
Ran the tests locally using `hatch run test:integ` and added an error into the adaptor tests so they would fail and print the info as expected.

#### Please run the integration tests and paste the results below
```
test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_start_and_close_blender
[gw0] [ 12%] PASSED test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_start_and_close_blender
test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_cancel_closes_blender
[gw0] [ 25%] PASSED test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_cancel_closes_blender
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
[gw0] [ 37%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
[gw0] [ 50%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
[gw0] [ 62%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter
[gw0] [ 75%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter
test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_start_and_stop
[gw0] [ 87%] PASSED test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_start_and_stop
test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_run_command
[gw0] [100%] PASSED test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_run_command

========================================================================================================================================================================== slowest 5 durations ==========================================================================================================================================================================
39.96s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
16.77s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
10.16s call     test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_run_command
8.08s call     test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_start_and_stop
2.81s call     test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_start_and_close_blender
===================================================================================================================================================================== 8 passed in 95.06s (0:01:35) ======================================================================================================================================================================
```
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*