### PR TITLE
feat: add submitter version info to the about dialog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 # Blender 4.1+ uses Python version 3.11
 
 dependencies = [
-    "deadline >= 0.52,< 0.55", 
+    "deadline >= 0.54,< 0.55", 
     "openjd-adaptor-runtime >= 0.7,< 0.10",
 ]
 

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
@@ -15,6 +15,7 @@ from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (
     SubmitJobToDeadlineDialog,
     JobBundlePurpose,
 )
+from deadline.client.dataclasses import SubmitterInfo
 
 from . import blender_utils as bu
 from . import sanity_checks as sc
@@ -105,6 +106,15 @@ def create_deadline_dialog(parent=None) -> SubmitJobToDeadlineDialog:
     rez_packages = f"blender-{blender_version} deadline_cloud_for_blender"
     conda_packages = f"blender={blender_version}.* blender-openjd={adaptor_version}.*"
 
+    # Create submitter info with Blender-specific information
+    submitter_info = SubmitterInfo(
+        submitter_name="Blender",
+        submitter_package_name="deadline-cloud-for-blender",
+        submitter_package_version=version,
+        host_application_name="Blender",
+        host_application_version=bpy.app.version_string,
+    )
+
     # Create and return the dialog widget.
     # dialog = SubmitJobToDeadlineDialog(
     dialog = SubmitJobToDeadlineDialog(
@@ -120,6 +130,7 @@ def create_deadline_dialog(parent=None) -> SubmitJobToDeadlineDialog:
         parent=parent,
         f=Qt.Tool,
         show_host_requirements_tab=True,
+        submitter_info=submitter_info,
     )
     dialog.setWindowFlags(Qt.WindowStaysOnTopHint)
     return dialog


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
deadline-cloud added the ability to pass along version information that can be displayed in an "About" dialog to help with debugging and knowing about the environment the submitter is running in. We need to pass along that info and update our minimum required version of deadline-cloud.

### What was the solution? (How)
Added the collecting and passing along of version information about the version of Blender and our integration.

### What is the impact of this change?
Easier to debug customer issues and know about the environment the submitter is running in.

### How was this change tested?
* `hatch run test`
* Deployed the change to my local submitter and opened up the window:
<img width="551" height="378" alt="image" src="https://github.com/user-attachments/assets/91dd641d-4ff4-473a-8d01-324d30ee1d5b" />

#### Please run the integration tests and paste the results below
```
test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_start_and_close_blender
[gw0] [ 12%] PASSED test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_start_and_close_blender
test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_cancel_closes_blender
[gw0] [ 25%] PASSED test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_cancel_closes_blender
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
[gw0] [ 37%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
[gw0] [ 50%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
[gw0] [ 62%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter
[gw0] [ 75%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter
test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_start_and_stop
[gw0] [ 87%] PASSED test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_start_and_stop
test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_run_command
[gw0] [100%] PASSED test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_run_command

========================================================================================================================================================================== slowest 5 durations ==========================================================================================================================================================================
41.59s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
16.26s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
9.97s call     test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_run_command
8.26s call     test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_start_and_stop
3.14s call     test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_start_and_close_blender
===================================================================================================================================================================== 8 passed in 102.10s (0:01:42) =====================================================================================================================================================================
```
### Was this change documented?
No

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*