### PR TITLE
docs: Blender powers for setup, dev, design and update Blender support version

### DIFF
--- a/.kiro/powers/blender-design-power/POWER.md
+++ b/.kiro/powers/blender-design-power/POWER.md
@@ -1,0 +1,98 @@
+---
+name: "blender-design-power"
+displayName: "Blender Design Power"
+description: "Structured design assistant for Blender features in Deadline Cloud. Creates comprehensive design documents covering data structures, UX changes, job templates, and adapter modifications."
+keywords: ["blender", "design", "python", "bpy", "cycles", "eevee"]
+author: "AWS Deadline Cloud Team"
+---
+
+# Blender Design Power
+
+## Overview
+
+A structured design assistant for creating comprehensive feature designs for Blender integration with AWS Deadline Cloud. This power helps create well-structured design documents following a consistent four-section format that covers all aspects of implementation.
+
+## Code Snippet Style Guide
+
+When including code in design documents, use **concise inline snippets** in the main sections and put **full implementations in an appendix**.
+
+### Inline Code Format
+
+Show only the relevant changes with context:
+
+```python
+def existing_function():
+    ...existing logic...
+    
+    # NEW: Add feature X support
+    if feature_x_enabled:
+        self._configure_feature_x(data)
+    
+    ...rest of function...
+```
+
+### Appendix Format
+
+Put complete implementations in a clearly marked appendix section:
+
+```markdown
+---
+
+## Appendix: Full Code Implementations
+
+<!-- REVIEW: New render handler implementation -->
+
+### A.1 CyclesHandler.configure_render (Full Implementation)
+
+\`\`\`python
+def configure_render(self, data: dict) -> None:
+    """Full implementation here..."""
+    # Complete code
+\`\`\`
+```
+
+### Guidelines
+
+1. **Data structures are the exception**: Always show full definitions - they anchor the design
+2. **Other sections**: Show what changes and where, not full implementations
+3. **Use `...` or comments** to indicate existing/unchanged code
+4. **Flag new sections** with `<!-- REVIEW: description -->` comments in the appendix
+5. **Don't include review tags** in final generated code
+
+## Research Requirements
+
+Before finalizing any design, research Blender Python API (bpy), Cycles/Eevee renderer APIs, and internet sources. Refer to **research-guide.md** for details.
+
+## Key Technical Patterns
+
+Refer to **research-guide.md** for bpy patterns, renderer detection, scene manipulation, and render settings access.
+
+## External References
+
+Refer to **external-references.md** for GitHub discussions and documentation links.
+
+## Blender-Specific Considerations
+
+### Blender Python API (bpy)
+- Scene access: `bpy.context.scene`, `bpy.data.scenes`
+- Render settings: `scene.render`, `scene.cycles`, `scene.eevee`
+- File paths: `bpy.path.abspath()` for resolving relative paths
+- Operators: `bpy.ops.*` for UI operations
+
+### Render Engines
+- **Cycles**: Path tracing renderer (`scene.cycles`)
+- **Eevee**: Real-time renderer (`scene.eevee`)
+- **Workbench**: Viewport renderer
+- Detection: `scene.render.engine` returns 'CYCLES', 'BLENDER_EEVEE', etc.
+
+### Add-on Structure
+- Manifest: `blender_manifest.toml` (Blender 4.2+) or `bl_info` dict
+- Registration: `register()` and `unregister()` functions
+- Operators: Classes inheriting from `bpy.types.Operator`
+- Panels: Classes inheriting from `bpy.types.Panel`
+
+### Job Submission Patterns
+- Scene file handling: `.blend` files
+- Asset references: Textures, caches, libraries
+- Output paths: Frame sequences, render layers
+- Frame ranges: `scene.frame_start`, `scene.frame_end`, `scene.frame_step`

--- a/.kiro/powers/blender-design-power/external-references.md
+++ b/.kiro/powers/blender-design-power/external-references.md
@@ -1,0 +1,51 @@
+# External References
+
+## AWS Deadline Cloud for Blender
+
+### GitHub Repository
+- [Main Repository](https://github.com/aws-deadline/deadline-cloud-for-blender) - Source code and documentation
+- [Issues](https://github.com/aws-deadline/deadline-cloud-for-blender/issues) - Bug reports and feature requests
+- [Pull Requests](https://github.com/aws-deadline/deadline-cloud-for-blender/pulls) - Code reviews and contributions
+- [Discussions](https://github.com/aws-deadline/deadline-cloud-for-blender/discussions) - Community discussions
+
+### Documentation
+- [User Guide](https://aws-deadline.github.io/) - End-user documentation
+- [AWS Deadline Cloud Service Docs](https://docs.aws.amazon.com/deadline-cloud/) - Service documentation
+- [Development Guide](https://github.com/aws-deadline/deadline-cloud-for-blender/blob/mainline/DEVELOPMENT.md) - Developer setup and workflows
+
+## Related Projects
+
+### Deadline Cloud
+- [Deadline Cloud GitHub](https://github.com/aws-deadline/) - All Deadline Cloud projects
+- [Deadline Cloud Client](https://github.com/aws-deadline/deadline-cloud) - Python client library
+
+### Open Job Description (OpenJD)
+- [OpenJD Specifications](https://github.com/OpenJobDescription/openjd-specifications/wiki) - Job template specifications
+- [OpenJD Adaptor Runtime](https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python) - Adaptor framework
+
+## Blender Resources
+
+### Official Blender
+- [Blender.org](https://www.blender.org/) - Official Blender website
+- [Blender Developer Portal](https://developer.blender.org/) - Development resources
+- [Blender Python API](https://docs.blender.org/api/current/) - API documentation
+
+### Community
+- [Blender Stack Exchange](https://blender.stackexchange.com/) - Q&A community
+- [Blender Artists Forum](https://blenderartists.org/) - Community forum
+- [Blender Developer Forum](https://devtalk.blender.org/) - Developer discussions
+
+## Useful GitHub Discussions
+
+When designing features, check these discussion topics for context:
+- Feature requests and enhancements
+- Bug reports related to your feature area
+- Architecture and design discussions
+- Integration patterns with AWS services
+
+## AWS Resources
+
+### AWS Deadline Cloud
+- [Service Overview](https://aws.amazon.com/deadline-cloud/) - Product page
+- [Getting Started](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/what-is-deadline-cloud.html) - Introduction guide
+- [API Reference](https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/) - Service API documentation

--- a/.kiro/powers/blender-design-power/research-guide.md
+++ b/.kiro/powers/blender-design-power/research-guide.md
@@ -1,0 +1,76 @@
+# Research Guide
+
+## Blender Python API (bpy) Resources
+
+### Official Documentation
+- [Blender Python API Documentation](https://docs.blender.org/api/current/) - Complete API reference
+- [Blender Python API Quick Start](https://docs.blender.org/api/current/info_quickstart.html) - Getting started guide
+- [Blender Python API Best Practices](https://docs.blender.org/api/current/info_best_practice.html) - Recommended patterns
+
+### Render Engine APIs
+- [Cycles API Reference](https://docs.blender.org/api/current/bpy.types.CyclesRenderSettings.html) - Cycles render settings
+- [Eevee API Reference](https://docs.blender.org/api/current/bpy.types.SceneEEVEE.html) - Eevee render settings
+- [Render Settings](https://docs.blender.org/api/current/bpy.types.RenderSettings.html) - General render configuration
+
+### Scene and Data Access
+- [Scene API](https://docs.blender.org/api/current/bpy.types.Scene.html) - Scene properties and methods
+- [Context API](https://docs.blender.org/api/current/bpy.context.html) - Accessing current context
+- [Data API](https://docs.blender.org/api/current/bpy.data.html) - Accessing Blender data blocks
+
+### File and Path Handling
+- [Path Module](https://docs.blender.org/api/current/bpy.path.html) - Path utilities including `abspath()`
+- [File I/O](https://docs.blender.org/api/current/bpy.ops.wm.html#module-bpy.ops.wm) - File operations
+
+## Key Patterns
+
+### Renderer Detection
+```python
+# Get current render engine
+engine = bpy.context.scene.render.engine
+# Returns: 'CYCLES', 'BLENDER_EEVEE', 'BLENDER_EEVEE_NEXT', 'BLENDER_WORKBENCH'
+```
+
+### Scene Manipulation
+```python
+# Access current scene
+scene = bpy.context.scene
+
+# Access all scenes
+for scene in bpy.data.scenes:
+    print(scene.name)
+
+# Switch active scene
+bpy.context.window.scene = bpy.data.scenes['SceneName']
+```
+
+### Render Settings Access
+```python
+# General render settings
+scene.render.resolution_x
+scene.render.resolution_y
+scene.render.fps
+
+# Cycles-specific settings
+scene.cycles.samples
+scene.cycles.device
+
+# Eevee-specific settings
+scene.eevee.taa_render_samples
+scene.eevee.use_gtao
+```
+
+### Frame Range
+```python
+# Get frame range
+start = scene.frame_start
+end = scene.frame_end
+step = scene.frame_step
+```
+
+## Research Workflow
+
+1. **Check Official Docs First** - Always start with the official Blender Python API documentation
+2. **Test in Blender Console** - Use Blender's Python console to experiment with API calls
+3. **Check Version Compatibility** - Note which Blender versions support specific features
+4. **Review Existing Code** - Look at similar implementations in the codebase
+5. **Search Community Resources** - Blender Stack Exchange and forums for real-world examples

--- a/.kiro/powers/blender-dev-power/POWER.md
+++ b/.kiro/powers/blender-dev-power/POWER.md
@@ -1,0 +1,151 @@
+---
+name: "blender-dev-power"
+displayName: "Blender Dev Power"
+description: "Development power for deadline-cloud-for-blender - build, lint, test, and run integration tests with Blender."
+keywords: ["blender", "deadline", "build", "test", "lint", "integration", "adaptor", "cycles", "eevee"]
+author: "AWS Deadline Cloud Team"
+---
+
+# Blender Dev Power
+
+Development power for building, testing, and debugging the deadline-cloud-for-blender project.
+
+## Overview
+
+This project is a Python package that provides:
+- **Blender Adaptor**: Runs Blender renders on Deadline Cloud workers
+- **Blender Submitter**: Add-on for submitting jobs from Blender to Deadline Cloud
+
+## Available Steering Files
+
+- **build-and-test.md** - Complete build and test workflow
+- **integration-testing.md** - Guide for running and creating integration tests
+- **troubleshooting.md** - Common issues and solutions
+
+## Prerequisites
+
+- Python 3.9-3.12
+- Blender 3.6-5.0 (Blender 3.6-4.0 uses Python 3.10, Blender 4.1+ uses Python 3.11)
+- Hatch (Python build tool): `pip install hatch`
+
+## Quick Commands
+
+### Build
+```bash
+hatch build
+```
+
+### Lint & Format
+```bash
+hatch run fmt      # Format code
+hatch run lint     # Run linter
+hatch run typing   # Type checking (mypy)
+```
+
+### Unit Tests
+```bash
+hatch run test                              # All tests
+hatch run test test/unit/path/to/test.py   # Specific file
+hatch run test -k "test_cycles"            # Pattern match
+```
+
+### Integration Tests
+
+Set `BLENDER_EXECUTABLE` environment variable if Blender is not in PATH:
+```bash
+export BLENDER_EXECUTABLE=/path/to/blender  # Linux/macOS
+set BLENDER_EXECUTABLE=C:\Path\To\blender.exe  # Windows
+```
+
+Run integration tests:
+```bash
+hatch run integ:test
+```
+
+For CI testing with multiple Blender versions:
+```bash
+hatch build  # Must build first
+hatch run integ-ci:setup --public-urls  # Download from blender.org
+hatch run integ-ci:test
+```
+
+## Test Bundles
+
+Integration tests are located in `test/integ/` and cover various rendering scenarios:
+- Cycles renderer tests
+- Eevee renderer tests
+- Scene file handling
+- Path mapping tests
+
+## Checking Logs
+
+Blender logs are typically found at:
+- **Linux**: `~/.config/blender/{version}/scripts/`
+- **macOS**: `~/Library/Application Support/Blender/{version}/scripts/`
+- **Windows**: `%APPDATA%\Blender Foundation\Blender\{version}\scripts\`
+
+View recent errors:
+```bash
+# Linux/macOS
+tail -n 100 ~/.config/blender/*/scripts/startup/bl_app_templates_system/*/startup.log
+
+# Windows (PowerShell)
+Get-Content "$env:APPDATA\Blender Foundation\Blender\*\scripts\startup.log" -Tail 100
+```
+
+## Project Structure
+
+```
+src/deadline/
+├── blender_adaptor/      # Adaptor (runs on worker)
+│   └── BlenderClient/    # Blender client and render handlers
+└── blender_submitter/    # Submitter add-on (runs in Blender)
+    └── addons/           # Blender add-on structure
+test/
+├── unit/                 # Unit tests
+└── integ/                # Integration tests
+scripts/                  # Build and test scripts
+```
+
+## Blender Add-on Development
+
+### Manual Installation
+
+1. Build the package: `hatch build`
+2. Copy add-on to Blender scripts directory:
+   ```bash
+   # Linux/macOS
+   cp -r src/deadline/blender_submitter/addons/ ~/DeadlineCloudSubmitter/Submitters/Blender/python/addons
+   
+   # Windows
+   xcopy /E /I src\deadline\blender_submitter\addons %USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python\addons
+   ```
+3. Install dependencies to Blender's Python:
+   ```bash
+   # For Blender 3.6-4.0 (Python 3.10)
+   pip install --python-version 3.10 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t ~/DeadlineCloudSubmitter/Submitters/Blender/python/modules
+   
+   # For Blender 4.1+ (Python 3.11)
+   pip install --python-version 3.11 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t ~/DeadlineCloudSubmitter/Submitters/Blender/python/modules
+   ```
+4. Add script directory in Blender: Edit > Preferences > File Paths > Script Directories
+5. Restart Blender
+
+### Experimental: Portable Add-on
+
+Build a portable Blender add-on:
+```bash
+hatch build
+hatch run build-addon
+```
+
+This creates `dist_extras/deadline-cloud-blender-addon.zip` which can be installed directly in Blender via Edit > Preferences > Add-ons > Install from Disk.
+
+## Adaptor Usage
+
+After installation, the adaptor is available as a command-line tool:
+```bash
+blender-openjd --help
+```
+
+Set `BLENDER_EXECUTABLE` environment variable to specify Blender location if not in PATH.

--- a/.kiro/powers/blender-dev-power/steering/build-and-test.md
+++ b/.kiro/powers/blender-dev-power/steering/build-and-test.md
@@ -1,0 +1,253 @@
+# Build and Test Workflow
+
+Complete build and test workflow for deadline-cloud-for-blender.
+
+## Step 1: Build the Wheel
+
+Always build a fresh wheel before testing:
+
+```bash
+hatch build
+```
+
+This creates a wheel in `dist/deadline_cloud_for_blender-*.whl`
+
+## Step 2: Run Linting and Formatting
+
+Before committing, ensure code passes all checks:
+
+```bash
+# Format code
+hatch run fmt
+
+# Run linter
+hatch run lint
+
+# Run type checker (mypy)
+hatch run typing
+```
+
+## Step 3: Run Unit Tests
+
+Run the full unit test suite:
+
+```bash
+hatch run test
+```
+
+For faster iteration, run specific tests:
+
+```bash
+# Run tests for a specific module
+hatch run test test/unit/deadline/blender_adaptor/BlenderClient/
+
+# Run a single test file
+hatch run test test/unit/deadline/blender_adaptor/BlenderClient/render_handlers/test_default_blender_handler.py
+
+# Run tests matching a pattern
+hatch run test -k "test_cycles"
+```
+
+## Step 4: Run Integration Tests
+
+Integration tests require Blender to be installed.
+
+### Set Blender Executable
+
+If Blender is not in your PATH, set the environment variable:
+
+```bash
+# Linux/macOS
+export BLENDER_EXECUTABLE=/path/to/blender
+
+# Windows (PowerShell)
+$env:BLENDER_EXECUTABLE = "C:\Program Files\Blender Foundation\Blender 4.2\blender.exe"
+
+# Windows (CMD)
+set BLENDER_EXECUTABLE=C:\Program Files\Blender Foundation\Blender 4.2\blender.exe
+```
+
+### Run Integration Tests
+
+```bash
+hatch run integ:test
+```
+
+### Windows-Specific: Install pywin32
+
+On Windows, you need to install pywin32 to Blender's Python:
+
+```bash
+# For Blender 4.1+ (Python 3.11)
+pip install -r requirements-integ-testing.txt --python-version=3.11 --only-binary=:all: --target "C:\Program Files\Blender Foundation\Blender 4.2\4.2\python\lib\site-packages\"
+
+# For Blender 3.6-4.0 (Python 3.10)
+pip install -r requirements-integ-testing.txt --python-version=3.10 --only-binary=:all: --target "C:\Program Files\Blender Foundation\Blender 4.0\4.0\python\lib\site-packages\"
+```
+
+### CI Integration Tests
+
+For testing with multiple Blender versions:
+
+```bash
+# Build package first
+hatch build
+
+# Setup Blender versions (downloads from blender.org)
+hatch run integ-ci:setup --public-urls
+
+# Run tests
+hatch run integ-ci:test
+```
+
+Setup script options:
+- `--public-urls`: Download from blender.org with SHA256 verification
+- `--install-x11`: Install X11 libraries and start Xvfb on Linux (for headless rendering)
+- `--versions 4.2.12 4.5.4`: Specify Blender versions to install
+- `--python-version 3.11`: Specify Python version for pip installs
+
+## Step 5: Build Portable Add-on
+
+Build a portable Blender add-on that can be installed directly in Blender:
+
+```bash
+hatch build
+hatch run build-addon
+```
+
+This creates `dist_extras/deadline-cloud-blender-addon.zip` which includes:
+- The add-on code
+- All dependencies (deadline, openjd-adaptor-runtime, etc.)
+- `blender_manifest.toml` for Blender 4.2+ extension system
+
+### Install Portable Add-on
+
+1. Open Blender
+2. Edit > Preferences > Add-ons
+3. Click the dropdown arrow in the upper right
+4. Click "Install from Disk..."
+5. Select `dist_extras/deadline-cloud-blender-addon.zip`
+6. Enable the "AWS Deadline Cloud" add-on
+
+## Step 6: Build Adaptor Wheels (Developer Option)
+
+For testing adaptor changes on a live Deadline Cloud farm, build wheels for all dependencies.
+
+### Prerequisites
+
+The sibling repositories must be cloned:
+```
+workspace/
+├── openjd-adaptor-runtime-for-python/
+├── deadline-cloud/
+└── deadline-cloud-for-blender/
+```
+
+Clone missing repositories:
+```bash
+cd ~/workspace/blender
+git clone https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python.git
+git clone https://github.com/aws-deadline/deadline-cloud.git
+```
+
+### Build Wheels Script
+
+Create a script to build all wheels:
+
+```bash
+#!/bin/bash
+# build_wheels.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="$(dirname "$SCRIPT_DIR")"
+WHEELS_DIR="$SCRIPT_DIR/wheels"
+
+# Clean wheels directory if requested
+if [ "$1" == "--clean" ]; then
+    rm -rf "$WHEELS_DIR"
+fi
+
+mkdir -p "$WHEELS_DIR"
+
+# Build openjd-adaptor-runtime
+if [ -d "$WORKSPACE_DIR/openjd-adaptor-runtime-for-python" ]; then
+    echo "Building openjd-adaptor-runtime..."
+    cd "$WORKSPACE_DIR/openjd-adaptor-runtime-for-python"
+    hatch build -t wheel
+    cp dist/*.whl "$WHEELS_DIR/"
+fi
+
+# Build deadline-cloud
+if [ -d "$WORKSPACE_DIR/deadline-cloud" ]; then
+    echo "Building deadline-cloud..."
+    cd "$WORKSPACE_DIR/deadline-cloud"
+    hatch build -t wheel
+    cp dist/*.whl "$WHEELS_DIR/"
+fi
+
+# Build deadline-cloud-for-blender
+echo "Building deadline-cloud-for-blender..."
+cd "$SCRIPT_DIR"
+hatch build -t wheel
+cp dist/*.whl "$WHEELS_DIR/"
+
+echo "Wheels built in $WHEELS_DIR"
+ls -lh "$WHEELS_DIR"
+```
+
+### Testing Adaptor Wheels on Workers
+
+1. **Enable developer options** in Blender submitter settings
+
+2. **Add wheels directory** to Job Attachments:
+   - In the submitter, go to Job Attachments tab
+   - Add the `wheels/` directory
+
+3. **Submit the job** - The worker will:
+   - Create a Python virtual environment
+   - Install your development wheels
+   - Use your modified adaptor to run the job
+
+## Step 7: Check Logs
+
+Blender logs are typically found at:
+
+```bash
+# Linux
+tail -n 100 ~/.config/blender/*/scripts/startup.log
+
+# macOS
+tail -n 100 ~/Library/Application\ Support/Blender/*/scripts/startup.log
+
+# Windows (PowerShell)
+Get-Content "$env:APPDATA\Blender Foundation\Blender\*\scripts\startup.log" -Tail 100
+```
+
+For adaptor logs during integration tests, check the test output directory.
+
+## Common Issues
+
+### Wrong Python Version
+Ensure Blender Python is being used:
+```bash
+blender --background --python-expr "import sys; print(sys.version)"
+```
+
+### Wheel Not Found
+Build the wheel first: `hatch build`
+
+### Blender Not Found
+Set BLENDER_EXECUTABLE environment variable or add Blender to PATH
+
+### Add-on Not Loading
+1. Verify script directory is added in Blender preferences
+2. Restart Blender after adding script directory
+3. Check for errors in Blender's system console (Window > Toggle System Console on Windows)
+
+### Integration Tests Fail on Linux
+Install X11 libraries and use Xvfb for headless rendering:
+```bash
+hatch run integ-ci:setup --install-x11
+```

--- a/.kiro/powers/blender-dev-power/steering/integration-testing.md
+++ b/.kiro/powers/blender-dev-power/steering/integration-testing.md
@@ -1,0 +1,349 @@
+# Integration Testing Guide
+
+Guide for running and creating integration tests for deadline-cloud-for-blender.
+
+## Overview
+
+Integration tests verify that the Blender adaptor correctly:
+- Launches Blender
+- Loads scene files
+- Configures render settings
+- Renders frames
+- Handles different render engines (Cycles, Eevee)
+- Manages asset references and paths
+
+## Running Integration Tests
+
+### Prerequisites
+
+1. **Blender installed** (3.6-5.0)
+2. **BLENDER_EXECUTABLE set** (if not in PATH):
+   ```bash
+   export BLENDER_EXECUTABLE=/path/to/blender
+   ```
+3. **pywin32 installed** (Windows only):
+   ```bash
+   pip install -r requirements-integ-testing.txt --python-version=3.11 --only-binary=:all: --target "C:\Program Files\Blender Foundation\Blender 4.2\4.2\python\lib\site-packages\"
+   ```
+
+### Run All Integration Tests
+
+```bash
+hatch run integ:test
+```
+
+### Run Specific Tests
+
+```bash
+# Run tests for a specific module
+hatch run integ:test test/integ/test_adaptor.py
+
+# Run tests matching a pattern
+hatch run integ:test -k "cycles"
+
+# Run with verbose output
+hatch run integ:test -v
+```
+
+## Test Structure
+
+Integration tests are located in `test/integ/` and typically include:
+
+```
+test/integ/
+├── test_adaptor.py           # Main adaptor tests
+├── test_scripts/             # Test job bundles
+│   ├── cycles_test/
+│   │   ├── expected_job_bundle/
+│   │   │   ├── template.yaml
+│   │   │   ├── parameter_values.json
+│   │   │   └── asset_references.json
+│   │   └── scene.blend
+│   └── eevee_test/
+│       └── ...
+└── conftest.py               # Pytest fixtures
+```
+
+## Creating a New Integration Test
+
+### Step 1: Create Test Scene
+
+Create a simple Blender scene that tests your feature:
+
+```python
+import bpy
+
+# Clear default scene
+bpy.ops.wm.read_homefile(use_empty=True)
+
+# Add a simple object
+bpy.ops.mesh.primitive_cube_add()
+
+# Configure render settings
+scene = bpy.context.scene
+scene.render.engine = 'CYCLES'
+scene.cycles.samples = 10
+scene.render.resolution_x = 640
+scene.render.resolution_y = 480
+scene.frame_start = 1
+scene.frame_end = 1
+
+# Save scene
+bpy.ops.wm.save_as_mainfile(filepath='/path/to/test_scene.blend')
+```
+
+### Step 2: Create Job Bundle
+
+Create a job bundle directory structure:
+
+```
+test/integ/test_scripts/my_feature_test/
+├── expected_job_bundle/
+│   ├── template.yaml
+│   ├── parameter_values.json
+│   └── asset_references.json
+└── test_scene.blend
+```
+
+#### template.yaml
+
+```yaml
+specificationVersion: 'jobtemplate-2023-09'
+name: Blender My Feature Test
+parameterDefinitions:
+  - name: BlenderFile
+    type: PATH
+    objectType: FILE
+    dataFlow: IN
+  - name: Frames
+    type: STRING
+    default: '1'
+
+steps:
+  - name: Render
+    parameterSpace:
+      taskParameterDefinitions:
+        - name: Frame
+          type: INT
+          range: "{{Param.Frames}}"
+    stepEnvironments:
+      - name: Blender
+        script:
+          actions:
+            onEnter:
+              command: blender-openjd
+              args:
+                - daemon
+                - start
+                - --path-mapping-rules
+                - file://{{Session.PathMappingRulesFile}}
+            onExit:
+              command: blender-openjd
+              args:
+                - daemon
+                - stop
+    script:
+      actions:
+        onRun:
+          command: blender-openjd
+          args:
+            - daemon
+            - run
+            - --render-scene
+            - file://{{Param.BlenderFile}}
+            - --frame
+            - "{{Task.Frame}}"
+```
+
+#### parameter_values.json
+
+```json
+{
+  "parameterValues": [
+    {
+      "name": "BlenderFile",
+      "value": "{{Session.WorkingDirectory}}/test_scene.blend"
+    },
+    {
+      "name": "Frames",
+      "value": "1"
+    }
+  ]
+}
+```
+
+#### asset_references.json
+
+```json
+{
+  "assetReferences": {
+    "inputs": {
+      "directories": [],
+      "filenames": [
+        "test_scene.blend"
+      ]
+    },
+    "outputs": {
+      "directories": []
+    }
+  }
+}
+```
+
+### Step 3: Write Test Code
+
+Add test to `test/integ/test_adaptor.py`:
+
+```python
+import pytest
+from pathlib import Path
+
+@pytest.mark.adaptor
+@pytest.mark.scene_files("test_scene.blend")
+def test_my_feature(
+    blender_client,
+    job_bundle_dir: Path,
+    output_dir: Path,
+):
+    """Test my feature with Blender adaptor."""
+    # Run the job bundle
+    blender_client.run_job_bundle(
+        job_bundle_dir=job_bundle_dir / "expected_job_bundle",
+        output_dir=output_dir,
+    )
+    
+    # Verify output
+    output_file = output_dir / "0001.png"
+    assert output_file.exists(), "Render output not found"
+    
+    # Optional: Verify image content
+    from PIL import Image
+    img = Image.open(output_file)
+    assert img.size == (640, 480), "Unexpected image size"
+```
+
+## Testing Different Render Engines
+
+### Cycles Test
+
+```python
+@pytest.mark.adaptor
+@pytest.mark.scene_files("cycles_scene.blend")
+def test_cycles_render(blender_client, job_bundle_dir, output_dir):
+    """Test Cycles renderer."""
+    blender_client.run_job_bundle(
+        job_bundle_dir=job_bundle_dir / "expected_job_bundle",
+        output_dir=output_dir,
+    )
+    # Verify output...
+```
+
+### Eevee Test
+
+```python
+@pytest.mark.adaptor
+@pytest.mark.scene_files("eevee_scene.blend")
+def test_eevee_render(blender_client, job_bundle_dir, output_dir):
+    """Test Eevee renderer."""
+    blender_client.run_job_bundle(
+        job_bundle_dir=job_bundle_dir / "expected_job_bundle",
+        output_dir=output_dir,
+    )
+    # Verify output...
+```
+
+## Testing Path Mapping
+
+Create a test with path mapping rules:
+
+```python
+@pytest.mark.adaptor
+@pytest.mark.scene_files("scene_with_textures.blend")
+def test_path_mapping(blender_client, job_bundle_dir, output_dir, tmp_path):
+    """Test path mapping for texture references."""
+    # Create path mapping rules
+    path_mapping_rules = {
+        "version": "pathmapping-1.0",
+        "path_mappings": [
+            {
+                "source_path_format": "POSIX",
+                "source_path": "/original/path",
+                "destination_path": str(tmp_path / "remapped")
+            }
+        ]
+    }
+    
+    # Run with path mapping
+    blender_client.run_job_bundle(
+        job_bundle_dir=job_bundle_dir / "expected_job_bundle",
+        output_dir=output_dir,
+        path_mapping_rules=path_mapping_rules,
+    )
+    # Verify output...
+```
+
+## CI Integration Tests
+
+For testing with multiple Blender versions in CI:
+
+```bash
+# Setup (downloads Blender versions)
+hatch run integ-ci:setup --public-urls --versions "4.2.12 4.5.4"
+
+# Run tests
+hatch run integ-ci:test
+```
+
+The `integ-ci` environment uses a matrix to test against multiple Blender versions defined in `pyproject.toml`.
+
+## Debugging Integration Tests
+
+### Enable Verbose Logging
+
+```bash
+hatch run integ:test -v -s
+```
+
+### Check Blender Output
+
+Integration tests capture Blender's stdout/stderr. Check test output for errors.
+
+### Run Blender Manually
+
+Test the adaptor manually:
+
+```bash
+# Start daemon
+blender-openjd daemon start
+
+# Run render
+blender-openjd daemon run --render-scene /path/to/scene.blend --frame 1
+
+# Stop daemon
+blender-openjd daemon stop
+```
+
+### Inspect Test Output
+
+Integration tests create output in a temporary directory. Use `--basetemp` to specify a location:
+
+```bash
+hatch run integ:test --basetemp=/tmp/blender-test-output
+```
+
+## Common Issues
+
+### Blender Not Found
+Set BLENDER_EXECUTABLE or add Blender to PATH
+
+### Headless Rendering on Linux
+Install X11 libraries and use Xvfb:
+```bash
+hatch run integ-ci:setup --install-x11
+```
+
+### Scene File Not Found
+Ensure scene files are in the correct location relative to the job bundle
+
+### Render Output Missing
+Check Blender logs and verify render settings in the scene file

--- a/.kiro/powers/blender-dev-power/steering/troubleshooting.md
+++ b/.kiro/powers/blender-dev-power/steering/troubleshooting.md
@@ -1,0 +1,316 @@
+# Troubleshooting Guide
+
+Common issues and solutions for deadline-cloud-for-blender development.
+
+## Build Issues
+
+### Hatch Not Found
+
+**Symptom**: `hatch: command not found`
+
+**Solution**:
+```bash
+# Install hatch
+pip install hatch
+
+# Add to PATH (Linux/macOS)
+export PATH="$HOME/.local/bin:$PATH"
+
+# Add to PATH (Windows PowerShell)
+$env:PATH = "$env:USERPROFILE\AppData\Roaming\Python\Python311\Scripts;$env:PATH"
+```
+
+### Build Fails with Missing Dependencies
+
+**Symptom**: Build fails with import errors
+
+**Solution**:
+```bash
+# Install development dependencies
+pip install --upgrade -r requirements-development.txt
+
+# Rebuild
+hatch build
+```
+
+### Version File Not Generated
+
+**Symptom**: `_version.py` not found
+
+**Solution**:
+```bash
+# Ensure hatch-vcs is installed
+pip install hatch-vcs
+
+# Clean and rebuild
+rm -rf dist/ build/
+hatch build
+```
+
+## Blender Add-on Issues
+
+### Add-on Not Appearing in Blender
+
+**Symptom**: Add-on not visible in Preferences > Add-ons
+
+**Solution**:
+1. Verify script directory is added:
+   - Edit > Preferences > File Paths > Script Directories
+   - Add: `~/DeadlineCloudSubmitter/Submitters/Blender/python` (Linux/macOS)
+   - Add: `%USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python` (Windows)
+
+2. Restart Blender (required after adding script directory)
+
+3. Check add-on is copied correctly:
+   ```bash
+   ls ~/DeadlineCloudSubmitter/Submitters/Blender/python/addons/deadline_cloud_blender_submitter/
+   ```
+
+### Add-on Fails to Load
+
+**Symptom**: Error when enabling add-on in Blender
+
+**Solution**:
+1. Check Blender's system console for errors:
+   - Windows: Window > Toggle System Console
+   - Linux/macOS: Run Blender from terminal to see output
+
+2. Verify dependencies are installed:
+   ```bash
+   # For Blender 4.1+ (Python 3.11)
+   pip install --python-version 3.11 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t ~/DeadlineCloudSubmitter/Submitters/Blender/python/modules
+   
+   # For Blender 3.6-4.0 (Python 3.10)
+   pip install --python-version 3.10 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t ~/DeadlineCloudSubmitter/Submitters/Blender/python/modules
+   ```
+
+3. Check Python version matches Blender:
+   ```bash
+   blender --background --python-expr "import sys; print(sys.version)"
+   ```
+
+### Import Errors in Add-on
+
+**Symptom**: `ModuleNotFoundError` when using add-on
+
+**Solution**:
+1. Verify modules directory exists and contains packages:
+   ```bash
+   ls ~/DeadlineCloudSubmitter/Submitters/Blender/python/modules/
+   ```
+
+2. Reinstall dependencies with correct Python version
+
+3. Check for conflicting packages in Blender's Python
+
+## Adaptor Issues
+
+### Blender Executable Not Found
+
+**Symptom**: `BLENDER_EXECUTABLE not set` or `blender: command not found`
+
+**Solution**:
+```bash
+# Set environment variable (Linux/macOS)
+export BLENDER_EXECUTABLE=/path/to/blender
+
+# Set environment variable (Windows PowerShell)
+$env:BLENDER_EXECUTABLE = "C:\Program Files\Blender Foundation\Blender 4.2\blender.exe"
+
+# Or add Blender to PATH
+export PATH="/path/to/blender/directory:$PATH"
+```
+
+### Adaptor Fails to Start
+
+**Symptom**: `blender-openjd daemon start` fails
+
+**Solution**:
+1. Check Blender can run in background mode:
+   ```bash
+   blender --background --python-expr "print('OK')"
+   ```
+
+2. Verify adaptor is installed:
+   ```bash
+   pip show deadline-cloud-for-blender
+   ```
+
+3. Check for port conflicts (adaptor uses socket communication)
+
+### Render Fails with Scene File Error
+
+**Symptom**: Cannot load scene file
+
+**Solution**:
+1. Verify scene file path is absolute or properly resolved
+2. Check file permissions
+3. Ensure scene file is compatible with Blender version
+4. Test loading scene manually:
+   ```bash
+   blender --background /path/to/scene.blend --python-expr "import bpy; print(bpy.context.scene.name)"
+   ```
+
+## Integration Test Issues
+
+### Tests Fail to Find Blender
+
+**Symptom**: Integration tests skip or fail with "Blender not found"
+
+**Solution**:
+```bash
+# Set BLENDER_EXECUTABLE before running tests
+export BLENDER_EXECUTABLE=/path/to/blender
+hatch run integ:test
+```
+
+### Windows: pywin32 Missing
+
+**Symptom**: `ImportError: No module named 'win32api'`
+
+**Solution**:
+```bash
+# Install pywin32 to Blender's Python
+pip install -r requirements-integ-testing.txt --python-version=3.11 --only-binary=:all: --target "C:\Program Files\Blender Foundation\Blender 4.2\4.2\python\lib\site-packages\"
+```
+
+### Linux: Headless Rendering Fails
+
+**Symptom**: Tests fail with display errors
+
+**Solution**:
+```bash
+# Install X11 libraries and Xvfb
+hatch run integ-ci:setup --install-x11
+
+# Or manually install
+sudo apt-get install xvfb libxxf86vm1 libxfixes3 libxi6 libxkbcommon0 libgl1
+
+# Run with Xvfb
+xvfb-run -a hatch run integ:test
+```
+
+### Test Output Not Generated
+
+**Symptom**: Render output files not created
+
+**Solution**:
+1. Check Blender logs for render errors
+2. Verify output path is writable
+3. Check render settings in scene file
+4. Test render manually:
+   ```bash
+   blender --background scene.blend --render-output /tmp/output --render-frame 1
+   ```
+
+## Linting and Type Checking Issues
+
+### Ruff Linting Errors
+
+**Symptom**: `hatch run lint` fails
+
+**Solution**:
+```bash
+# Auto-fix issues
+hatch run fmt
+
+# Check specific files
+hatch run lint src/deadline/blender_adaptor/
+```
+
+### Mypy Type Errors
+
+**Symptom**: `hatch run typing` fails
+
+**Solution**:
+1. Check mypy configuration in `pyproject.toml`
+2. Add type stubs for missing packages:
+   ```bash
+   pip install types-requests types-PyYAML
+   ```
+3. Use `# type: ignore` for unavoidable errors (sparingly)
+
+## Performance Issues
+
+### Slow Integration Tests
+
+**Solution**:
+1. Run specific tests instead of full suite:
+   ```bash
+   hatch run integ:test -k "test_name"
+   ```
+
+2. Use parallel test execution:
+   ```bash
+   hatch run integ:test -n auto
+   ```
+
+3. Skip slow tests during development:
+   ```bash
+   hatch run integ:test -m "not slow"
+   ```
+
+### Slow Blender Startup
+
+**Solution**:
+1. Use sticky rendering (adaptor keeps Blender open between tasks)
+2. Reduce scene complexity for tests
+3. Use lower sample counts for test renders
+
+## Debugging Tips
+
+### Enable Debug Logging
+
+```python
+import logging
+logging.basicConfig(level=logging.DEBUG)
+```
+
+### Run Adaptor in Debug Mode
+
+```bash
+# Set debug environment variable
+export OPENJD_LOG_LEVEL=DEBUG
+
+# Run adaptor
+blender-openjd daemon start
+```
+
+### Inspect Blender Scene
+
+```bash
+# Open scene in Blender GUI
+blender /path/to/scene.blend
+
+# Inspect scene from command line
+blender --background /path/to/scene.blend --python-expr "
+import bpy
+scene = bpy.context.scene
+print(f'Render engine: {scene.render.engine}')
+print(f'Frame range: {scene.frame_start}-{scene.frame_end}')
+print(f'Resolution: {scene.render.resolution_x}x{scene.render.resolution_y}')
+"
+```
+
+### Check Blender Python Environment
+
+```bash
+blender --background --python-expr "
+import sys
+print('Python version:', sys.version)
+print('Python path:', sys.path)
+import pip
+installed = pip.get_installed_distributions()
+for pkg in installed:
+    print(f'{pkg.key}: {pkg.version}')
+"
+```
+
+## Getting Help
+
+If you're still stuck:
+
+1. Check the [GitHub Issues](https://github.com/aws-deadline/deadline-cloud-for-blender/issues)
+2. Review the [Blender Python API documentation](https://docs.blender.org/api/current/)
+3. Check [OpenJD documentation](https://github.com/OpenJobDescription/openjd-specifications/wiki)
+4. Review [AWS Deadline Cloud documentation](https://docs.aws.amazon.com/deadline-cloud/)

--- a/.kiro/powers/blender-dev-setup/POWER.md
+++ b/.kiro/powers/blender-dev-setup/POWER.md
@@ -1,0 +1,181 @@
+---
+name: blender-dev-setup
+version: 1.0.0
+displayName: Blender Dev Setup
+description: Automated development environment setup for deadline-cloud-for-blender - builds packages, installs dependencies, and configures environment variables
+keywords:
+  - blender
+  - deadline
+  - setup
+  - build
+  - install
+  - environment
+  - development
+  - hatch
+  - openjd
+author: AWS Deadline Cloud
+---
+
+# Blender Dev Setup Power
+
+Automated development environment setup for deadline-cloud-for-blender project.
+
+## What This Power Does
+
+This power automates the complete development environment setup for working on the deadline-cloud-for-blender project. It handles everything from reading documentation to building packages, installing dependencies, and configuring environment variables.
+
+## Setup Steps Performed
+
+1. **Documentation Review** - Reads README.md and DEVELOPMENT.md to understand project requirements
+2. **Hatch Installation** - Installs and configures Hatch build tool
+3. **Package Build** - Builds wheel and source distributions
+4. **Blender Detection** - Verifies Blender installation (3.6-5.0)
+5. **Add-on Installation** - Installs the Blender submitter add-on
+6. **Dependencies Installation** - Installs deadline[gui], blender-qt-stylesheet
+7. **Wheel Installation** - Installs the built wheel for adaptor
+8. **OpenJD CLI Installation** - Installs openjd-cli for running integration tests
+9. **Test Packages Installation** - Installs pytest, coverage, and test dependencies
+10. **Environment Configuration** - Sets up BLENDER_EXECUTABLE and PYTHONPATH
+
+## Prerequisites
+
+- Python 3.9-3.12 installed on system
+- Blender 3.6-5.0 installed
+- Linux, macOS, or Windows operating system
+
+## Usage
+
+The power will prompt you for:
+- **Blender Version** (e.g., 3.6, 4.0, 4.2, 5.0)
+- **Blender Installation Path** (if not in standard location)
+
+If Blender is not found, the setup will provide instructions for installation.
+
+## What Gets Installed
+
+### System Python Packages
+- `hatch` - Build tool and environment manager
+
+### Blender Python Packages (via pip to modules directory)
+- `deadline[gui]` - AWS Deadline Cloud client library with GUI support
+- `blender-qt-stylesheet` - Qt stylesheet for Blender integration
+- All required dependencies
+
+### Development Packages
+- `deadline-cloud-for-blender` - The built wheel from dist/
+- `openjd-adaptor-runtime` - OpenJD adaptor runtime
+- `openjd-cli` - OpenJD command-line interface
+- `pytest` - Test framework
+- `pytest-cov` - Coverage plugin for pytest
+- `pytest-xdist` - Parallel test execution
+- `coverage` - Code coverage measurement
+
+### Environment Variables
+- `BLENDER_EXECUTABLE` - Points to blender executable
+- `PYTHONPATH` - Configures Python module search paths (if needed)
+
+## Platform-Specific Paths
+
+### Linux
+- Add-on: `~/DeadlineCloudSubmitter/Submitters/Blender/python/addons`
+- Modules: `~/DeadlineCloudSubmitter/Submitters/Blender/python/modules`
+- Blender config: `~/.config/blender/{version}/scripts/`
+
+### macOS
+- Add-on: `~/DeadlineCloudSubmitter/Submitters/Blender/python/addons`
+- Modules: `~/DeadlineCloudSubmitter/Submitters/Blender/python/modules`
+- Blender config: `~/Library/Application Support/Blender/{version}/scripts/`
+
+### Windows
+- Add-on: `%USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python\addons`
+- Modules: `%USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python\modules`
+- Blender config: `%APPDATA%\Blender Foundation\Blender\{version}\scripts\`
+
+## Output Files
+
+The power creates several reference documents:
+- `HATCH_SETUP.md` - Hatch usage guide
+- `configure_blender_env.sh` or `.ps1` - Environment configuration script
+- `verify_blender_paths.sh` or `.ps1` - Path verification script
+- `INSTALLATION_SUMMARY.md` - Complete installation summary
+- `OPENJD_SETUP_COMPLETE.md` - OpenJD usage guide
+
+## After Setup
+
+Once setup is complete, you can:
+
+### Run Unit Tests
+```bash
+hatch run test
+```
+
+### Run Integration Tests
+```bash
+hatch run integ:test
+```
+
+### Build Package
+```bash
+hatch build
+```
+
+### Format and Lint Code
+```bash
+hatch run fmt
+hatch run lint
+```
+
+### Build Portable Add-on
+```bash
+hatch run build-addon
+```
+
+## Troubleshooting
+
+### Hatch Not Found
+If hatch is not found after installation, restart your terminal or add to PATH:
+```bash
+# Linux/macOS
+export PATH="$HOME/.local/bin:$PATH"
+
+# Windows (PowerShell)
+$env:PATH = "$env:USERPROFILE\AppData\Roaming\Python\Python311\Scripts;$env:PATH"
+```
+
+### Blender Python Issues
+Verify the correct Python version for your Blender:
+- Blender 3.6-4.0: Python 3.10
+- Blender 4.1+: Python 3.11
+
+Check Blender's Python:
+```bash
+blender --background --python-expr "import sys; print(sys.version)"
+```
+
+### Add-on Not Appearing
+1. Verify script directory is added in Blender: Edit > Preferences > File Paths
+2. Restart Blender after adding script directory
+3. Enable add-on in Edit > Preferences > Add-ons (search for "AWS Deadline Cloud")
+
+### Integration Tests Failing
+Check Blender logs and ensure BLENDER_EXECUTABLE is set:
+```bash
+# Linux/macOS
+export BLENDER_EXECUTABLE=/path/to/blender
+
+# Windows
+set BLENDER_EXECUTABLE=C:\Path\To\blender.exe
+```
+
+### Windows-Specific: pywin32 Required
+On Windows, install pywin32 to Blender's Python:
+```bash
+pip install -r requirements-integ-testing.txt --python-version=3.11 --only-binary=:all: --target "C:\Program Files\Blender Foundation\Blender {version}\{version}\python\lib\site-packages\"
+```
+
+## Notes
+
+- Setup works on Linux, macOS, and Windows
+- Blender 4.2+ supports the experimental extension repository method
+- The adaptor requires Blender executable to be in PATH or BLENDER_EXECUTABLE set
+- Integration tests may require X11/Xvfb on Linux for headless rendering

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ AWS Deadline Cloud for Blender is a python package that allows users to create [
 
 This library requires:
 
-1. Blender 3.6 - 4.5,
+1. Blender 3.6 - 5.0,
 1. Python 3.9 to 3.12; and
 1. Linux, Windows, or a macOS operating system.
    * Adaptor only supports Linux and macOS


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Blender setup, testing and development workflow are currently req many manual step and some certain knowledge based to move fast
- We add support for Blender 5.0 just recently but the readme still cap at 4.5

### What was the solution? (How)
- Adding Kiro power to allow new dev onboard easily and start implementing feature faster
- Change the readme to say we support 5.0

### What is the impact of this change?
- Users are now able to use powers that help them onboard and develop with Blender

### How was this change tested?
Using power, I was able to successfully:
- Run integ tests
- Implement a small UI changes and get it build, setup and install, so I can open Blender and see the UI change

### Was this change documented?
Yes

### Is this a breaking change?
No


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*