### PR TITLE
chore: clean stale addons dir before xcopy on CI Windows runner

### DIFF
--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -6,6 +6,7 @@ import argparse
 import hashlib
 import os
 import platform
+import shutil
 import subprocess
 import sys
 import time
@@ -276,6 +277,13 @@ def setup_windows(python_version):
         submitter_path = f"DeadlineCloudSubmitter\\Submitters\\Blender{major_minor}"
 
         Path(f"{submitter_path}\\python").mkdir(parents=True, exist_ok=True)
+
+        # Remove stale addons directory from previous runs on reserved capacity instances.
+        # Windows xcopy fails with exit code 4 when copying into an existing destination.
+        addons_path = Path(f"{submitter_path}\\python\\addons")
+        if addons_path.exists():
+            shutil.rmtree(addons_path)
+
         run(
             [
                 "xcopy",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The Windows mainline integration test (`deadline-cloud-for-blender-mainline-windows-integ`) fails during `hatch run integ-ci:setup` with `xcopy` exit code 4 ("Insufficient memory"). 

The build runs on a reserved capacity (`baseCapacity: 1`) where a single g5.4xlarge instance is reused across builds. The `DeadlineCloudSubmitter\Submitters\Blender4.5\python\addons` directory persists from the previous build, and `xcopy /E /I` fails when the destination already contains files. The "Insufficient memory" message is a known misleading Windows xcopy error — the instance has 64 GB RAM and 181 GB free disk.

### What was the solution? (How)

Remove the stale `addons` destination directory before running `xcopy` in `setup_windows()`. This is scoped to only the `addons` subdirectory that `xcopy` targets, leaving the rest of `DeadlineCloudSubmitter` (e.g. `modules/`) untouched. Linux and macOS are not affected since `cp -r` overwrites existing files silently.

### What is the impact of this change?

Windows integration tests on reserved capacity fleet instances will no longer fail due to stale `addons` directories from previous builds. No impact on Linux, macOS, or any non-CI workflows.

### How was this change tested?
`hatch run test`

#### Please run the integration tests and paste the results below

Will monitor the CI run upon code merge.

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

N/A — only `pipeline/setup-runner.py` was modified.

### Was this change documented?

No documentation changes needed. This is a CI-only fix.

### Is this a breaking change?

No.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*