### PR TITLE
feat: Notify customers if newer submitter is available.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 # Blender 5.1+ uses Python version 3.13
 
 dependencies = [
-    "deadline >= 0.54,< 0.55",
+    "deadline >= 0.55.1,< 0.56",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
 ]
 

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py
@@ -8,6 +8,7 @@ import sys
 
 import bpy  # noqa
 from bpy.types import Operator
+from .update_utils import check_and_show_update_dialog
 
 from . import logutil
 
@@ -53,6 +54,9 @@ class DEADLINE_CLOUD_OT_open_dialog(Operator):
         self.app = QtWidgets.QApplication.instance()
         if not self.app:
             self.app = QtWidgets.QApplication(sys.argv)
+
+        if check_and_show_update_dialog():
+            return {"FINISHED"}
 
         try:
             # optionally use the blender_stylesheet if it exists

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/update_utils.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/update_utils.py
@@ -1,0 +1,67 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Utilities for checking and displaying update notifications."""
+
+import logging
+from dataclasses import dataclass
+
+from deadline.client.api import safe_check_for_updates, UpdateCheckResult, UpdateCheckStatus
+from deadline.client.ui.dialogs.update_available_dialog import UpdateAvailableDialog
+
+from ._version import version_tuple as adaptor_version_tuple
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _SessionState:
+    """Session-level state: once the user dismisses the update dialog,
+    don't show it again until Blender is restarted."""
+
+    update_dismissed: bool = False
+
+
+_session_state = _SessionState()
+
+
+def _check_for_update() -> UpdateCheckResult:
+    """Check if a newer version of the Blender submitter is available.
+
+    Returns:
+        An UpdateCheckResult describing whether an update is available.
+    """
+    current_version = ".".join(str(v) for v in adaptor_version_tuple[:3])
+    return safe_check_for_updates(
+        integration_name="deadline-cloud-for-blender",
+        current_version=current_version,
+    )
+
+
+def check_and_show_update_dialog() -> bool:
+    """Check for updates and show the update dialog if one is available.
+
+    If the user previously dismissed the dialog in this Blender session,
+    the check is skipped entirely.
+
+    Returns:
+        True if the user clicked Download (caller should skip opening the submitter),
+        False otherwise.
+    """
+    if _session_state.update_dismissed:
+        return False
+
+    update_result = _check_for_update()
+    if update_result.status == UpdateCheckStatus.SUCCESS and update_result.update_available:
+        update_dialog = UpdateAvailableDialog(
+            integration_name="Blender",
+            current_version=update_result.current_version or "",
+            latest_version=update_result.latest_version or "",
+            download_url=update_result.download_url or "",
+            release_notes_url="https://github.com/aws-deadline/deadline-cloud-for-blender/releases",
+        )
+        update_dialog.exec_()
+        if update_dialog.user_downloaded:
+            return True
+        # User dismissed — suppress for the rest of this Blender session
+        _session_state.update_dismissed = True
+    return False

--- a/test/unit/deadline_submitter_for_blender/test_update_utils.py
+++ b/test/unit/deadline_submitter_for_blender/test_update_utils.py
@@ -1,0 +1,162 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+from deadline.client.api import UpdateCheckResult, UpdateCheckStatus
+
+from deadline.blender_submitter.addons.deadline_cloud_blender_submitter.update_utils import (
+    _check_for_update,
+    check_and_show_update_dialog,
+)
+
+
+class TestCheckForUpdate:
+    """Tests for _check_for_update()."""
+
+    @patch(
+        "deadline.blender_submitter.addons.deadline_cloud_blender_submitter.update_utils.safe_check_for_updates"
+    )
+    def test_returns_result_on_success(self, mock_check):
+        # GIVEN
+        expected = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.9.0",
+            update_available=True,
+            latest_version="0.10.0",
+        )
+        mock_check.return_value = expected
+
+        # WHEN
+        result = _check_for_update()
+
+        # THEN
+        assert result is expected
+        mock_check.assert_called_once()
+
+    @patch(
+        "deadline.blender_submitter.addons.deadline_cloud_blender_submitter.update_utils.safe_check_for_updates"
+    )
+    def test_returns_error_result_on_unexpected_error(self, mock_check):
+        # GIVEN — safe_check_for_updates returns an error result, never raises
+        expected = UpdateCheckResult(
+            status=UpdateCheckStatus.UNEXPECTED_ERROR,
+            current_version="0.9.0",
+            error_message="Unexpected error: something broke",
+        )
+        mock_check.return_value = expected
+
+        # WHEN
+        result = _check_for_update()
+
+        # THEN
+        assert result is expected
+        assert result.update_available is False
+
+    @patch(
+        "deadline.blender_submitter.addons.deadline_cloud_blender_submitter.update_utils.safe_check_for_updates"
+    )
+    def test_passes_correct_integration_name(self, mock_check):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.9.0",
+        )
+
+        # WHEN
+        _check_for_update()
+
+        # THEN
+        call_kwargs = mock_check.call_args[1]
+        assert call_kwargs["integration_name"] == "deadline-cloud-for-blender"
+
+
+class TestCheckAndShowUpdateDialog:
+    """Tests for check_and_show_update_dialog()."""
+
+    @patch(
+        "deadline.blender_submitter.addons.deadline_cloud_blender_submitter.update_utils._check_for_update"
+    )
+    def test_returns_false_when_no_update(self, mock_check):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.10.0",
+            update_available=False,
+        )
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is False
+
+    @patch(
+        "deadline.blender_submitter.addons.deadline_cloud_blender_submitter.update_utils._check_for_update"
+    )
+    def test_returns_false_on_error_status(self, mock_check):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.NETWORK_ERROR,
+            current_version="0.9.0",
+            update_available=False,
+        )
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is False
+
+    @patch(
+        "deadline.blender_submitter.addons.deadline_cloud_blender_submitter.update_utils.UpdateAvailableDialog"
+    )
+    @patch(
+        "deadline.blender_submitter.addons.deadline_cloud_blender_submitter.update_utils._check_for_update"
+    )
+    def test_shows_dialog_and_returns_true_when_user_downloads(self, mock_check, mock_dialog_cls):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.9.0",
+            update_available=True,
+            latest_version="0.10.0",
+            download_url="https://example.com/installer",
+        )
+        mock_dialog = MagicMock()
+        mock_dialog.user_downloaded = True
+        mock_dialog_cls.return_value = mock_dialog
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is True
+        mock_dialog.exec_.assert_called_once()
+
+    @patch(
+        "deadline.blender_submitter.addons.deadline_cloud_blender_submitter.update_utils.UpdateAvailableDialog"
+    )
+    @patch(
+        "deadline.blender_submitter.addons.deadline_cloud_blender_submitter.update_utils._check_for_update"
+    )
+    def test_shows_dialog_and_returns_false_when_user_dismisses(self, mock_check, mock_dialog_cls):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.9.0",
+            update_available=True,
+            latest_version="0.10.0",
+            download_url="https://example.com/installer",
+        )
+        mock_dialog = MagicMock()
+        mock_dialog.user_downloaded = False
+        mock_dialog_cls.return_value = mock_dialog
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is False
+        mock_dialog.exec_.assert_called_once()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Customers did not know whether they were on the latest submitter or not. This means they would not have the latest bug fixes or features to work with our product. 

### What was the solution? (How)

This adds a dialog which checks our download manifests and if there's a new update available notifies customer  that. 

Depends on: https://github.com/aws-deadline/deadline-cloud/pull/1070

<img width="412" height="223" alt="image" src="https://github.com/user-attachments/assets/8d931ffc-b380-424d-a9e2-ffea3ee0e947" />

Customers can deactivate the feature in the settings. 

<img width="603" height="244" alt="image" src="https://github.com/user-attachments/assets/4201e914-a1f1-4a1a-9606-68dc49e2ccab" />

### What is the impact of this change?

Customers hopefully are always on the latest updated submitter. 

### How was this change tested?

| # | Test Case | Steps | Expected Result | Pass? |
|---|-----------|-------|-----------------|-------|
| | **Config GUI — setting visible** | | | |
| 1 | Setting in config GUI | Open Blender → Deadline Cloud → Settings | "Show submitter update notifications" checkbox is visible | YES |
| | **Config disabled — no dialog** | | | |
| 2 | Notification disabled via GUI | Uncheck "Show submitter update notifications" → Apply → close & reopen submitter | No network call, no dialog, submitter opens normally | YES |
| | **Config enabled, no internet — graceful failure** | | | |
| 3 | Re-enable notification via GUI | Check "Show submitter update notifications" → Apply | Setting updated | YES |
| 4 | No internet / firewall | Disconnect network → open submitter | Submitter opens normally, no crash, no visible error | YES |
| | **Config enabled, internet available, no update** | | | |
| 5 | Current == latest | Restore network, ensure installed version matches manifest | No dialog, submitter opens normally | YES |
| 6 | Current > latest (dev build) | Install a version newer than manifest | No dialog, submitter opens normally | YES |
| | **Config enabled, internet available, update exists** | | | |
| 7 | Current < latest | Install an older version than manifest | Update dialog appears | YES |
| 8 | Dialog content | Inspect the dialog | Shows "Blender", correct current & latest versions | YES |
| 9 | Dialog layout | Resize / check | Min width 400px, text wraps properly | YES |
| 10 | Dialog timing | Observe launch order | Dialog appears before Blender submitter window | YES |
| | **Dialog interactions — Dismiss** | | | |
| 11 | Click "Dismiss" | Click Dismiss button | Dialog closes, submitter opens normally | YES |
| 12 | Close via X | Click X button on dialog | Dialog closes, submitter opens normally | YES |
| | **Dialog interactions — Download** | | | |
| 13 | Click "View release notes" | Click the link | Blender GitHub releases page opens in browser | YES |
| 14 | Click "Download" | Click Download button | Correct installer URL opens in browser | YES |
| 15 | Restart reminder | After Download click | "Application Restart Required" info box appears | YES |
| | **Edge cases** | | | |
| 16 | Non-standard `_version.py` tuple | Modify version tuple | No crash | YES |


#### Please run the integration tests and paste the results below

```
test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_start_and_close_blender 
[gw0] [ 12%] PASSED test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_start_and_close_blender 
test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_cancel_closes_blender 
[gw0] [ 25%] PASSED test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_cancel_closes_blender 
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
[gw0] [ 37%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor 
[gw0] [ 50%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor 
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter 
[gw0] [ 62%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter 
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter 
[gw0] [ 75%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter 
test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_start_and_stop 
[gw0] [ 87%] PASSED test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_start_and_stop 
test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_run_command 
[gw0] [100%] PASSED test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_run_command 

================================================================= slowest 5 durations ==================================================================
27.53s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
13.24s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
9.04s call     test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_run_command
7.82s call     test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter
7.77s call     test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_start_and_stop
============================================================= 8 passed in 84.37s (0:01:24) =============================================================
```


#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

No

### Was this change documented?

Yes

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*