### PR TITLE
feat: bundle GUI dependencies in the installer

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -107,11 +107,11 @@ These instructions make the following assumptions:
     - `cp -r src/deadline/blender_submitter/addons/ ~/DeadlineCloudSubmitter/Submitters/Blender/python/addons`
 1. Install addon dependencies:
     - For Blender 3.6-4.0 (uses python 3.10):
-        - Windows: `pip install --python-version 3.10 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t %USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python\modules`
-        - Linux/macOS: `pip install --python-version 3.10 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t ~/DeadlineCloudSubmitter/Submitters/Blender/python/modules`
+        - Windows: `pip install --python-version 3.10 --only-binary=:all: "deadline-cloud-for-blender[gui]" blender-qt-stylesheet -t %USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python\modules`
+        - Linux/macOS: `pip install --python-version 3.10 --only-binary=:all: "deadline-cloud-for-blender[gui]" blender-qt-stylesheet -t ~/DeadlineCloudSubmitter/Submitters/Blender/python/modules`
     - For Blender 4.1-4.5 (uses python 3.11):
-        - Windows: `pip install --python-version 3.11 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t %USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python\modules`
-        - Linux/macOS: `pip install --python-version 3.11 --only-binary=:all: "deadline[gui]" blender-qt-stylesheet -t ~/DeadlineCloudSubmitter/Submitters/Blender/python/modules`
+        - Windows: `pip install --python-version 3.11 --only-binary=:all: "deadline-cloud-for-blender[gui]" blender-qt-stylesheet -t %USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python\modules`
+        - Linux/macOS: `pip install --python-version 3.11 --only-binary=:all: "deadline-cloud-for-blender[gui]" blender-qt-stylesheet -t ~/DeadlineCloudSubmitter/Submitters/Blender/python/modules`
 1. Add a script directory in Blender by "Edit" > "Preferences" > "File Paths" > "Script Directories"
     * Windows: `%USERPROFILE%\DeadlineCloudSubmitter\Submitters\Blender\python`
     * Linux/macOS: `~/DeadlineCloudSubmitter/Submitters/Blender/python`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,13 @@ classifiers = [
 # Blender 4.1+ uses Python version 3.11
 
 dependencies = [
-    "deadline[gui] >= 0.54,< 0.55", 
+    "deadline >= 0.54,< 0.55",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
+]
+
+[project.optional-dependencies]
+gui = [
+    "deadline[gui] >= 0.54,< 0.55",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 # Blender 4.1+ uses Python version 3.11
 
 dependencies = [
-    "deadline >= 0.54,< 0.55", 
+    "deadline[gui] >= 0.54,< 0.55", 
     "openjd-adaptor-runtime >= 0.7,< 0.10",
 ]
 

--- a/scripts/build_addon.py
+++ b/scripts/build_addon.py
@@ -7,9 +7,12 @@ import os
 from pathlib import Path
 import shutil
 import subprocess
+import tarfile
 from tempfile import TemporaryDirectory
 import hashlib
 import re
+
+from depsBundle import _strip_pyside6
 
 parser = argparse.ArgumentParser(description="Experimental: Builds a Blender extension")
 parser.add_argument("--version", required=False)
@@ -19,12 +22,34 @@ version = args.version or "0.0.0"
 
 SUPPORTED_PLATFORMS = [
     "win_amd64",
-    "manylinux_2_17_x86_64",
-    "macosx_11_0_arm64",
-    "macosx_10_9_x86_64",
+    "manylinux_2_28_x86_64",
+    "macosx_12_0_arm64",
+    "macosx_12_0_x86_64",
 ]
 ADDON_NAME = "Deadline Cloud for Blender"
 ADDON_TAGLINE = "Submit to AWS Deadline Cloud"
+
+
+def strip_pyside6_wheel(whl_path: str) -> None:
+    """Strip a PySide6/shiboken6 wheel in-place, keeping only files in PYSIDE6_ALLOWLIST."""
+    with TemporaryDirectory() as extract_dir:
+        # Extract, strip, re-zip
+        shutil.unpack_archive(whl_path, extract_dir, "zip")
+        _strip_pyside6(Path(extract_dir))
+
+        # Rewrite RECORD from remaining files
+        dist_info = next(Path(extract_dir).glob("*.dist-info"))
+        record_path = dist_info / "RECORD"
+        with open(record_path, "w") as f:
+            for file in sorted(Path(extract_dir).rglob("*")):
+                if file.is_file() and file != record_path:
+                    f.write(f"{file.relative_to(extract_dir)},,\n")
+            f.write(f"{record_path.relative_to(extract_dir)},,\n")
+
+        os.remove(whl_path)
+        shutil.make_archive(whl_path.removesuffix(".whl"), "zip", extract_dir)
+        os.rename(whl_path.removesuffix(".whl") + ".zip", whl_path)
+
 
 with TemporaryDirectory() as temp:
     shutil.copytree(
@@ -40,11 +65,14 @@ with TemporaryDirectory() as temp:
 
     # Find the version of the deadline library specified in project.toml
     project_toml_contents = (Path(__file__).parent.parent / "pyproject.toml").read_text()
-    match = re.search(r"\"deadline .+ .+\"", project_toml_contents)
+    match = re.search(r"\"deadline\S* .+ .+\"", project_toml_contents)
     if not match:
         raise RuntimeError("Could not find the deadline version requirement in project.toml")
     deadline_version_requirement = match.group(0).replace('"', "")
     print(f"Found requirement {deadline_version_requirement} in project.toml")
+
+    # Extract the bare version spec (without extras) for downloading the sdist
+    deadline_version_spec = re.sub(r"\[.*?\]", "", deadline_version_requirement)
 
     # Download the wheels of the deadline library and its dependencies
     for platform in SUPPORTED_PLATFORMS:
@@ -61,6 +89,39 @@ with TemporaryDirectory() as temp:
             ],
             check=True,
         )
+
+    # Strip PySide6/shiboken6 wheels to only keep the modules we need
+    for whl in glob(f"{temp}/wheels/[Pp][Yy][Ss]ide6*") + glob(f"{temp}/wheels/shiboken6*"):
+        print(f"Stripping {os.path.basename(whl)}")
+        strip_pyside6_wheel(whl)
+
+    # Extract THIRD_PARTY_LICENSES files from the deadline sdist
+    licenses_dir = Path(temp) / "THIRD_PARTY_LICENSES"
+    licenses_dir.mkdir()
+    with TemporaryDirectory() as sdist_dir:
+        subprocess.run(
+            [
+                "pip",
+                "download",
+                deadline_version_spec,
+                "--no-binary=:all:",
+                "--no-deps",
+                "--dest",
+                sdist_dir,
+            ],
+            check=True,
+        )
+        sdist_tarball = next(Path(sdist_dir).glob("deadline-*.tar.gz"))
+        with tarfile.open(sdist_tarball) as tar:
+            for member in tar.getmembers():
+                if member.name.endswith("/THIRD_PARTY_LICENSES"):
+                    # e.g. deadline-0.54.2/scripts/attributions/approved_text/Linux/THIRD_PARTY_LICENSES
+                    platform_name = Path(member.name).parent.name
+                    content = tar.extractfile(member)
+                    if content:
+                        (licenses_dir / f"THIRD_PARTY_LICENSES-{platform_name}").write_bytes(
+                            content.read()
+                        )
     wheel_filenames = [os.path.basename(wheel) for wheel in glob(f"{temp}/wheels/*")]
     wheel_block = "\n".join([f'"./wheels/{filename}",' for filename in wheel_filenames])
 

--- a/scripts/depsBundle.py
+++ b/scripts/depsBundle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fnmatch
 import re
 import shutil
 import subprocess
@@ -13,6 +14,126 @@ from typing import Any
 
 SUPPORTED_PYTHON_VERSIONS = ["3.10", "3.11"]
 NATIVE_DEPENDENCIES = ["xxhash", "psutil"]
+
+PYSIDE6_VERSION = "6.8.3"
+PYSIDE6_PACKAGES = [f"PySide6-Essentials=={PYSIDE6_VERSION}", f"shiboken6=={PYSIDE6_VERSION}"]
+
+# Files to keep from PySide6 and shiboken6 pip packages after installation.
+# Derived from the deadline-cloud pyinstaller allowlist to keep the bundle minimal.
+# Everything not matching these patterns is deleted before zipping.
+PYSIDE6_ALLOWLIST = {
+    # -- shiboken6 --
+    "shiboken6/__init__.py",
+    "shiboken6/_config.py",
+    "shiboken6/Shiboken.abi3.so",
+    "shiboken6/Shiboken.pyd",
+    "shiboken6/libshiboken6.abi3.*.dylib",
+    "shiboken6/libshiboken6.abi3.so.*",
+    "shiboken6/shiboken6.abi3.dll",
+    "shiboken6/VCRUNTIME140.dll",
+    "shiboken6/VCRUNTIME140_1.dll",
+    "shiboken6/MSVCP140.dll",
+    "shiboken6-*.dist-info/*",
+    "shiboken6-*.dist-info/**/*",
+    # -- PySide6 package metadata --
+    "PySide6/__init__.py",
+    "PySide6/_config.py",
+    "PySide6/_git_pyside_version.py",
+    "PySide6-*.dist-info/*",
+    "PySide6-*.dist-info/**/*",
+    "PySide6_Essentials-*.dist-info/*",
+    # -- PySide6 Python bindings --
+    "PySide6/Qt*.abi3.so",
+    "PySide6/QtCore.pyd",
+    "PySide6/QtGui.pyd",
+    "PySide6/QtWidgets.pyd",
+    "PySide6/QtDBus.pyd",
+    "PySide6/QtSvg.pyd",
+    "PySide6/QtNetwork.pyd",
+    "PySide6/QtOpenGL.pyd",
+    "PySide6/QtOpenGLWidgets.pyd",
+    # -- PySide6/shiboken6 shared libraries --
+    "PySide6/libpyside6.abi3.*.dylib",
+    "PySide6/libpyside6.abi3.so.*",
+    "PySide6/pyside6.abi3.dll",
+    # -- Windows MSVC runtime bundled with PySide6 --
+    "PySide6/VCRUNTIME140.dll",
+    "PySide6/VCRUNTIME140_1.dll",
+    "PySide6/MSVCP140.dll",
+    "PySide6/MSVCP140_1.dll",
+    "PySide6/MSVCP140_2.dll",
+    # -- Windows OpenGL software renderer --
+    "PySide6/opengl32sw.dll",
+    # -- Qt core DLLs (Windows) --
+    "PySide6/Qt6Core.dll",
+    "PySide6/Qt6Gui.dll",
+    "PySide6/Qt6Widgets.dll",
+    "PySide6/Qt6DBus.dll",
+    "PySide6/Qt6Svg.dll",
+    # -- Qt frameworks (macOS) --
+    # fnmatch's ** doesn't do recursive matching, so we need both * and **/* patterns
+    "PySide6/Qt/lib/QtCore.framework/*",
+    "PySide6/Qt/lib/QtCore.framework/**/*",
+    "PySide6/Qt/lib/QtGui.framework/*",
+    "PySide6/Qt/lib/QtGui.framework/**/*",
+    "PySide6/Qt/lib/QtWidgets.framework/*",
+    "PySide6/Qt/lib/QtWidgets.framework/**/*",
+    "PySide6/Qt/lib/QtDBus.framework/*",
+    "PySide6/Qt/lib/QtDBus.framework/**/*",
+    "PySide6/Qt/lib/QtSvg.framework/*",
+    "PySide6/Qt/lib/QtSvg.framework/**/*",
+    # -- Qt shared libraries (Linux) --
+    "PySide6/Qt/lib/libQt6Core.so.*",
+    "PySide6/Qt/lib/libQt6Gui.so.*",
+    "PySide6/Qt/lib/libQt6Widgets.so.*",
+    "PySide6/Qt/lib/libQt6DBus.so.*",
+    "PySide6/Qt/lib/libQt6Svg.so.*",
+    "PySide6/Qt/lib/libQt6XcbQpa.so.*",
+    "PySide6/Qt/lib/libQt6WaylandClient.so.*",
+    "PySide6/Qt/lib/libQt6WaylandEglClientHwIntegration.so.*",
+    "PySide6/Qt/lib/libQt6WlShellIntegration.so.*",
+    "PySide6/Qt/lib/libQt6OpenGL.so.*",
+    "PySide6/Qt/lib/libQt6EglFSDeviceIntegration.so.*",
+    "PySide6/Qt/lib/libQt6EglFsKmsSupport.so.*",
+    # ICU (required by Qt6Core on Linux)
+    "PySide6/Qt/lib/libicui18n.so.*",
+    "PySide6/Qt/lib/libicuuc.so.*",
+    "PySide6/Qt/lib/libicudata.so.*",
+    # -- Qt plugins (macOS/Linux: Qt/plugins/, Windows: plugins/) --
+    # platforms
+    "PySide6/Qt/plugins/platforms/libqcocoa.dylib",
+    "PySide6/Qt/plugins/platforms/libqoffscreen.*",
+    "PySide6/Qt/plugins/platforms/libqminimal.*",
+    "PySide6/Qt/plugins/platforms/libqminimalegl.so",
+    "PySide6/Qt/plugins/platforms/libqxcb.so",
+    "PySide6/Qt/plugins/platforms/libqeglfs.so",
+    "PySide6/Qt/plugins/platforms/libqlinuxfb.so",
+    "PySide6/Qt/plugins/platforms/libqvkkhrdisplay.so",
+    "PySide6/Qt/plugins/platforms/libqvnc.so",
+    "PySide6/Qt/plugins/platforms/libqwayland*.so",
+    "PySide6/plugins/platforms/qwindows.dll",
+    "PySide6/plugins/platforms/qminimal.dll",
+    "PySide6/plugins/platforms/qoffscreen.dll",
+    "PySide6/plugins/platforms/qdirect2d.dll",
+    # styles
+    "PySide6/Qt/plugins/styles/libqmacstyle.dylib",
+    "PySide6/plugins/styles/qwindowsvistastyle.dll",
+    "PySide6/plugins/styles/qmodernwindowsstyle.dll",
+    # iconengines
+    "PySide6/Qt/plugins/iconengines/libqsvgicon.*",
+    "PySide6/plugins/iconengines/qsvgicon.dll",
+    # imageformats (svg only)
+    "PySide6/Qt/plugins/imageformats/libqsvg.*",
+    "PySide6/plugins/imageformats/qsvg.dll",
+    # wayland (Linux)
+    "PySide6/Qt/plugins/wayland-shell-integration/lib*.so",
+    "PySide6/Qt/plugins/wayland-decoration-client/lib*.so",
+    # platform themes (Linux)
+    "PySide6/Qt/plugins/platformthemes/lib*.so",
+    # -- Qt translations --
+    "PySide6/Qt/translations/*",
+    "PySide6/translations/*",
+}
 
 
 def _get_project_dict() -> dict[str, Any]:
@@ -134,6 +255,43 @@ def _copy_zip_to_destination(zip_path: Path) -> Path:
     return zip_destination
 
 
+def _install_pyside6(install_path: Path) -> None:
+    """Install PySide6 and shiboken6, then strip to only the files in PYSIDE6_ALLOWLIST."""
+    pip_args = [
+        "pip",
+        "install",
+        "--target",
+        str(install_path),
+        "--only-binary=:all:",
+        *PYSIDE6_PACKAGES,
+    ]
+    subprocess.run(pip_args, check=True)
+    _strip_pyside6(install_path)
+
+
+def _strip_pyside6(install_path: Path) -> None:
+    """Remove PySide6/shiboken6 files not in PYSIDE6_ALLOWLIST."""
+    for prefix in (
+        "PySide6",
+        "shiboken6",
+        "PySide6_Essentials-*.dist-info",
+        "shiboken6-*.dist-info",
+    ):
+        for pkg_dir in install_path.glob(prefix):
+            if not pkg_dir.is_dir():
+                continue
+            for path in list(pkg_dir.rglob("*")):
+                if not path.is_file():
+                    continue
+                rel = str(path.relative_to(install_path))
+                if not any(fnmatch.fnmatch(rel, pat) for pat in PYSIDE6_ALLOWLIST):
+                    path.unlink()
+            # Clean up empty directories
+            for dirpath in sorted(pkg_dir.rglob("*"), reverse=True):
+                if dirpath.is_dir() and not any(dirpath.iterdir()):
+                    dirpath.rmdir()
+
+
 def build_deps_bundle() -> None:
     with TemporaryDirectory() as wd:
         working_directory = Path(wd)
@@ -142,6 +300,7 @@ def build_deps_bundle() -> None:
         base_env = _build_base_environment(working_directory, dependencies)
         native_dependency_paths = _download_native_dependencies(working_directory, base_env)
         _copy_native_to_base_env(base_env, native_dependency_paths)
+        _install_pyside6(base_env)
         zip_path = _get_zip_path(working_directory, project_dict)
         _zip_bundle(base_env, zip_path)
         print(list(working_directory.glob("*")))

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py
@@ -4,8 +4,6 @@
 Registration of Deadline Cloud Submitter Addon + activate logger
 """
 import logging
-from pathlib import Path
-import subprocess
 import sys
 
 import bpy  # noqa
@@ -47,9 +45,6 @@ class DEADLINE_CLOUD_OT_open_dialog(Operator):
 
         See the bpy Operator docs: https://docs.blender.org/api/current/bpy.types.Operator.html
         """
-        if not self.has_gui_deps():
-            self.install_gui()
-
         from qtpy import QtCore, QtWidgets
         from .open_deadline_cloud_dialog import (
             create_deadline_dialog,
@@ -93,57 +88,8 @@ class DEADLINE_CLOUD_OT_open_dialog(Operator):
         self.report({"INFO"}, "OK!")
         return {"FINISHED"}
 
-    def draw(self, context):
-        layout = self.layout
-        col = layout.column()
-        col.label(text="Press 'OK' to install GUI dependencies. Please wait...")
-
     def invoke(self, context, event):
-        if self.has_gui_deps():
-            # don't prompt user if gui deps exist
-            return self.execute(context)
-        wm = context.window_manager
-        return wm.invoke_props_dialog(self)
-
-    def has_gui_deps(self):
-        try:
-            import qtpy  # noqa
-            from .open_deadline_cloud_dialog import (  # noqa
-                create_deadline_dialog,
-            )
-        except Exception as e:
-            # qtpy throws a QtBindingsNotFoundError when running
-            # from qtpy import QtBindingsNotFoundError
-            if not (type(e).__name__ == "QtBindingsNotFoundError" or isinstance(e, ImportError)):
-                raise
-            return False
-
-        return True
-
-    def install_gui(self):
-        import deadline.client
-
-        deadline.client.version
-        pip_install_command = [
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            f"deadline[gui]=={deadline.client.version}",
-        ]
-        # module_directory assumes relative install location of:
-        #   * [installdir]/Submitters/Blender/python/addons/deadline_cloud_blender_submitter/__init__.py
-        #   * [installdir]/Submitters/Blender/python/modules/
-        module_directory = Path(__file__).parent.parent.parent / "modules"
-        if module_directory.exists():
-            _logger.info(f"Missing GUI libraries, installing deadline[gui] to {module_directory}")
-            pip_install_command.extend(["--target", str(module_directory)])
-        else:
-            _logger.info(
-                "Missing GUI libraries with non-standard set-up, installing deadline[gui] into Blender's python"
-            )
-
-        subprocess.run(pip_install_command)
+        return self.execute(context)
 
 
 def deadline_cloud_dialog_topbar_btn(self, context):

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
@@ -128,11 +128,11 @@ def create_deadline_dialog(parent=None) -> SubmitJobToDeadlineDialog:
         attachments=attachments,
         on_create_job_bundle_callback=_create_bundle,
         parent=parent,
-        f=Qt.Tool,
+        f=Qt.WindowType.Tool,
         show_host_requirements_tab=True,
         submitter_info=submitter_info,
     )
-    dialog.setWindowFlags(Qt.WindowStaysOnTopHint)
+    dialog.setWindowFlags(Qt.WindowType.WindowStaysOnTopHint)
     return dialog
 
 

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/sanity_checks.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/sanity_checks.py
@@ -100,13 +100,13 @@ def _prompt_unsaved_changes():
     msg = QtWidgets.QMessageBox()
     msg.setText("Scene has unsaved changes.")
     msg.setWindowTitle("Blender")
-    msg.addButton("Save", QtWidgets.QMessageBox.YesRole)
-    msg.addButton("Don't Save", QtWidgets.QMessageBox.NoRole)
-    msg.addButton(QtWidgets.QMessageBox.Cancel)
+    msg.addButton("Save", QtWidgets.QMessageBox.ButtonRole.YesRole)
+    msg.addButton("Don't Save", QtWidgets.QMessageBox.ButtonRole.NoRole)
+    msg.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
     return_value = msg.exec()
     if return_value == 0:
         bpy.ops.wm.save_mainfile()
-    elif return_value == QtWidgets.QMessageBox.Cancel:
+    elif return_value == QtWidgets.QMessageBox.StandardButton.Cancel:
         raise RuntimeError("Submission cancelled.")
 
 

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/scene_settings_widget.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/scene_settings_widget.py
@@ -142,7 +142,9 @@ class SceneSettingsWidget(QWidget):
             )
             layout.addWidget(self.include_adaptor_wheels, qt_pos_index, 0)
 
-        layout.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 10, 0)
+        layout.addItem(
+            QSpacerItem(0, 0, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding), 10, 0
+        )
 
         self._fill_scenes_box()
         self._fill_cameras_box()
@@ -275,11 +277,11 @@ class SceneSettingsWidget(QWidget):
 
     def activate_enable_gpu_changed(self, state):
         """Set the activated/deactivated status of the GPU Device text box."""
-        self.gpu_device_box.setEnabled(Qt.CheckState(state) == Qt.Checked)
+        self.gpu_device_box.setEnabled(Qt.CheckState(state) == Qt.CheckState.Checked)
 
     def activate_frame_override_changed(self, state):
         """Set the activated/deactivated status of the Frame override text box."""
-        self.frame_override_txt.setEnabled(Qt.CheckState(state) == Qt.Checked)
+        self.frame_override_txt.setEnabled(Qt.CheckState(state) == Qt.CheckState.Checked)
 
 
 class FileSearchLineEdit(QWidget):
@@ -308,10 +310,10 @@ class FileSearchLineEdit(QWidget):
                 self,
                 "Open Directory",
                 self.get_text(),
-                QFileDialog.ShowDirsOnly | QFileDialog.DontResolveSymlinks,
+                QFileDialog.Option.ShowDirsOnly | QFileDialog.Option.DontResolveSymlinks,
             )
         else:
-            new_txt = QFileDialog.getOpenFileName(self, "Select File", self.get_text())
+            new_txt, _ = QFileDialog.getOpenFileName(self, "Select File", self.get_text())
 
         if new_txt:
             self.set_text(new_txt)

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -96,6 +96,16 @@ def _validate_files(installation_path: Path) -> None:
     assert "xxhash" in module_dir
     assert "psutil" in module_dir
 
+    # Verify PySide6/shiboken6 are bundled and stripped correctly
+    assert "PySide6" in module_dir
+    assert "shiboken6" in module_dir
+    pyside_dir = [f.name for f in (python_dir / "modules" / "PySide6").iterdir()]
+    assert "QtCore.abi3.so" in pyside_dir or "QtCore.pyd" in pyside_dir
+    assert "QtWidgets.abi3.so" in pyside_dir or "QtWidgets.pyd" in pyside_dir
+    # Verify unused Qt modules were stripped by the allowlist
+    assert "lupdate" not in pyside_dir
+    assert "lrelease" not in pyside_dir
+
     # Check the blender module is here and there's a version file
     addon_dir = [
         f.name for f in (python_dir / "addons" / "deadline_cloud_blender_submitter").iterdir()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to install Qt in the installer instead of requiring a install step during the first run of the submitter.

### What was the solution? (How)
Bundle it in the installer. Copy the allowlist of Qt files to bundle from deadline-cloud and apply it during the installer creation.

### What is the impact of this change?
Submitter can be installed offline.

### How was this change tested?
- I ran the installer and verified the installed plugin worked correctly and did not prompt to install GUI dependencies
- I inspected the install folder to make sure no unexpected Qt modules were included
- installer unit test

After updating the extension building script, I also:
- generated the extension, installed it, and verified it worked
- looked in the installed extension folder and verified it had the THIRD_PARTY_LICENSES files for all 3 platforms
- expanded a PySide wheel and verified it had only the allowlisted modules

#### Please run the integration tests and paste the results below
n/a

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below
```
    =================== 6 passed, 9 skipped, 1 warning in 44.35s ===================                                                                                                           
```

### Was this change documented?
No update needed.

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*