### PR TITLE
chore: update python versions

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     uses: aws-deadline/.github/.github/workflows/reusable_python_build.yml@mainline
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -138,10 +138,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.13'
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch "virtualenv<21"
+          pip install --upgrade hatch
       - name: Build
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -16,6 +16,7 @@ BLENDER_PYTHON_VERSIONS = {
     "4.2.12": "3.11",
     "4.5.4": "3.11",
     "5.0.1": "3.11",
+    "5.1.0": "3.13",
 }
 USE_PUBLIC_URLS = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Operating System :: POSIX :: Linux",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: MacOS",
@@ -28,8 +29,10 @@ classifiers = [
   "Intended Audience :: Developers",
   "Intended Audience :: End Users/Desktop",
 ]
+# Blender 2.9 uses Python version 3.9
 # Blender 3.1-4.0 uses Python version 3.10
-# Blender 4.1+ uses Python version 3.11
+# Blender 4.1-5.0 uses Python version 3.11
+# Blender 5.1+ uses Python version 3.13
 
 dependencies = [
     "deadline >= 0.54,< 0.55",

--- a/scripts/depsBundle.py
+++ b/scripts/depsBundle.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10", "3.11"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10", "3.11", "3.13"]
 NATIVE_DEPENDENCIES = ["xxhash", "psutil"]
 
 PYSIDE6_VERSION = "6.8.3"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

some out of date info for python support

### What was the solution? (How)

take a look at python version usage and update it. Note that this only preps 5.1 support (3.13) and doesn't actually add it to the integration tests

### What is the impact of this change?

more accurate info

### How was this change tested?

```
hatch run lint
hatch run test
```

### Was this change documented?

N/A

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*