### PR TITLE
fix: include UDIM tiled image directories in job attachments

### DIFF
--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/blender_utils.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/blender_utils.py
@@ -82,6 +82,19 @@ def find_files(project_path, skip_temp=True, skip_nonexistent=True) -> list[Path
 
     files = bpy.utils.blend_paths(absolute=True)
     files.append(project_path)
+
+    # For UDIM tiled images, add the parent directory as an input directory
+    # rather than individual files. blend_paths() returns pattern paths for
+    # UDIM images which don't exist as literal files on disk, so they get
+    # filtered out. Adding the directory ensures all tile files are included.
+    for image in bpy.data.images:
+        if image.source == "TILED":
+            filepath = bpy.path.abspath(image.filepath, library=image.library)
+            if filepath:
+                parent_dir = str(Path(filepath).parent)
+                if parent_dir not in files:
+                    files.append(parent_dir)
+
     files = set(Path(f) for f in files)
 
     temp_dirs = []


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The Blender submitter's automatic asset detection was not picking up UDIM tiled texture files (e.g. `texture.1001.exr`, `texture.1002.exr`). `bpy.utils.blend_paths()` returns a pattern path for UDIM images (e.g. `texture.<UDIM>.exr`) rather than individual tile files. Since the pattern path doesn't exist as a literal file on disk, `find_files()` filters it out via its `skip_nonexistent` check, causing jobs to fail with missing texture errors during rendering.

### What was the solution? (How)

After collecting paths from `bpy.utils.blend_paths()`, iterate `bpy.data.images` to find images with `source == "TILED"` and add the parent directory of each tiled image's filepath as an input directory. This ensures all UDIM tile files in that directory are included in the job attachments without needing to resolve individual tile filenames.

### What is the impact of this change?

Scenes using UDIM tiled textures will now have their texture files automatically included in job attachments. Previously, users had to manually add the texture directory as an input directory in the submission dialog as a workaround. The directory-based approach may include extra files that happen to be in the same directory as the UDIM tiles, but guarantees nothing is missed.

### How was this change tested?

- Code review and manual verification of the logic against Blender's UDIM image API
- Needs verification in Blender with a UDIM scene

#### Please run the integration tests and paste the results below

_TODO: Run integration tests with a UDIM scene_

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

N/A — no installer changes, no files added or removed from `src/`.

### Was this change documented?

No documentation changes needed. This is a bug fix to existing behavior.

### Is this a breaking change?

No. This is additive — it only adds directories that were previously missing from job attachments.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
