### PR TITLE
chore: add cross-platform adaptor test scripts

### DIFF
--- a/scripts/test-blender-adapter-run.ps1
+++ b/scripts/test-blender-adapter-run.ps1
@@ -1,0 +1,517 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Blender Adaptor Testing Script (cross-platform PowerShell)
+# Tests the deadline-cloud-for-blender adaptor directly without worker agent setup.
+#
+# Works on Linux, macOS, and Windows using PowerShell 7+ (pwsh).
+
+param(
+    [string]$JobBundleDir,
+    [string]$WheelPath = "",
+    [string]$BlenderExecutable = "",
+    [string]$BlenderPython = "",
+    [int]$Step = 0,
+    [string]$PathMappingFile = "",
+    [switch]$SkipInstall,
+    [switch]$ShowOutput,
+    [switch]$Help
+)
+
+# ------------------------------------------------------------------
+# Help
+# ------------------------------------------------------------------
+if ($Help) {
+    Write-Host "=== Blender Adaptor Testing Script Help ===" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "DESCRIPTION:" -ForegroundColor Yellow
+    Write-Host "  Tests the deadline-cloud-for-blender adaptor directly without worker agent setup."
+    Write-Host "  Uses Blender's bundled Python (Blender ships Python at <install>/<X.Y>/python/bin/...)."
+    Write-Host "  Runs on Linux, macOS, and Windows (requires PowerShell 7+)."
+    Write-Host ""
+    Write-Host "USAGE:" -ForegroundColor Yellow
+    Write-Host "  Run this script from the repository root directory:" -ForegroundColor Yellow
+    Write-Host "  pwsh ./scripts/test-blender-adapter-run.ps1 -JobBundleDir <path>" -ForegroundColor Cyan
+    Write-Host "  Example: pwsh ./scripts/test-blender-adapter-run.ps1 -JobBundleDir test_bundle" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "PARAMETERS:" -ForegroundColor Yellow
+    Write-Host "  -JobBundleDir       (Required) Path to the job bundle directory" -ForegroundColor Cyan
+    Write-Host "  -WheelPath          Path to the wheel file (auto-detected from dist/ if empty)" -ForegroundColor Cyan
+    Write-Host "  -BlenderExecutable  Path to Blender (defaults to BLENDER_EXECUTABLE env or 'blender' on PATH)" -ForegroundColor Cyan
+    Write-Host "  -BlenderPython      Path to Blender's bundled Python (derived from Blender install if empty)" -ForegroundColor Cyan
+    Write-Host "  -Step               Step index to run (default: 0)" -ForegroundColor Cyan
+    Write-Host "  -PathMappingFile    Path to JSON file with path mapping rules (optional)" -ForegroundColor Cyan
+    Write-Host "  -SkipInstall        Skip wheel installation (optional)" -ForegroundColor Cyan
+    Write-Host "  -ShowOutput         Show detailed output (optional)" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "PREREQUISITES:" -ForegroundColor Yellow
+    Write-Host "  - PowerShell 7+ (pwsh) for cross-platform use"
+    Write-Host "  - Blender installed (ships its own Python; no system Python required)"
+    Write-Host "  - PowerShell-Yaml module for YAML parsing:"
+    Write-Host "    Install-Module powershell-yaml -Scope CurrentUser -Force" -ForegroundColor Cyan
+    Write-Host ""
+    exit 0
+}
+
+# ------------------------------------------------------------------
+# Validate required parameters
+# ------------------------------------------------------------------
+if ([string]::IsNullOrEmpty($JobBundleDir)) {
+    Write-Error "JobBundleDir parameter is required. Use -Help for usage information."
+    exit 1
+}
+
+# ------------------------------------------------------------------
+# Resolve Blender executable
+# ------------------------------------------------------------------
+function Resolve-BlenderExecutable {
+    param([string]$Override)
+    if (-not [string]::IsNullOrEmpty($Override)) { return $Override }
+    if (-not [string]::IsNullOrEmpty($env:BLENDER_EXECUTABLE)) { return $env:BLENDER_EXECUTABLE }
+
+    $cmd = Get-Command "blender" -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+
+    if ($IsWindows) {
+        $candidates = Get-ChildItem "C:\Program Files\Blender Foundation" -Directory -ErrorAction SilentlyContinue |
+                      Sort-Object Name -Descending
+        foreach ($dir in $candidates) {
+            $exe = Join-Path $dir.FullName "blender.exe"
+            if (Test-Path $exe) { return $exe }
+        }
+    } elseif ($IsMacOS) {
+        $mac = "/Applications/Blender.app/Contents/MacOS/Blender"
+        if (Test-Path $mac) { return $mac }
+    } else {
+        foreach ($p in @("/usr/bin/blender", "/usr/local/bin/blender", "/snap/bin/blender")) {
+            if (Test-Path $p) { return $p }
+        }
+    }
+    return ""
+}
+
+# ------------------------------------------------------------------
+# Resolve Blender's bundled Python from the Blender executable path.
+#
+# Blender bundles Python at:
+#   Linux:   <install>/<X.Y>/python/bin/python3.<Y>
+#   macOS:   <Blender.app>/Contents/Resources/<X.Y>/python/bin/python3.<Y>
+#   Windows: <install>\<X.Y>\python\bin\python.exe
+# ------------------------------------------------------------------
+function Resolve-BlenderPython {
+    param(
+        [string]$Override,
+        [string]$BlenderExePath
+    )
+    if (-not [string]::IsNullOrEmpty($Override)) { return $Override }
+    if ([string]::IsNullOrEmpty($BlenderExePath) -or -not (Test-Path $BlenderExePath)) {
+        return ""
+    }
+
+    # Base directory that contains the Blender version folder (e.g., "5.0")
+    if ($IsMacOS -and $BlenderExePath -match "\.app/Contents/MacOS/") {
+        $appRoot = $BlenderExePath -replace "/Contents/MacOS/.*$", ""
+        $searchRoot = Join-Path $appRoot "Contents/Resources"
+    } else {
+        $searchRoot = Split-Path $BlenderExePath -Parent
+    }
+
+    if (-not (Test-Path $searchRoot)) { return "" }
+
+    # Find the newest version subdirectory that contains python/bin
+    $versionDirs = Get-ChildItem -Path $searchRoot -Directory -ErrorAction SilentlyContinue |
+                   Where-Object { $_.Name -match "^\d+\.\d+$" } |
+                   Sort-Object { [version]$_.Name } -Descending
+    foreach ($dir in $versionDirs) {
+        $pythonBin = Join-Path $dir.FullName "python/bin"
+        if (-not (Test-Path $pythonBin)) { continue }
+
+        if ($IsWindows) {
+            $exe = Join-Path $pythonBin "python.exe"
+            if (Test-Path $exe) { return $exe }
+        } else {
+            # Look for python3.<minor> (e.g., python3.11), then python3, then python
+            $candidates = Get-ChildItem -Path $pythonBin -File -ErrorAction SilentlyContinue |
+                          Where-Object { $_.Name -match "^python3\.\d+$" -or $_.Name -eq "python3" -or $_.Name -eq "python" } |
+                          Sort-Object {
+                              if ($_.Name -match "^python3\.(\d+)$") { [int]$Matches[1] }
+                              elseif ($_.Name -eq "python3") { -1 }
+                              else { -2 }
+                          } -Descending
+            if ($candidates) { return $candidates[0].FullName }
+        }
+    }
+    return ""
+}
+
+$BlenderExe = Resolve-BlenderExecutable -Override $BlenderExecutable
+if ([string]::IsNullOrEmpty($BlenderExe)) {
+    Write-Error "Could not locate Blender. Pass -BlenderExecutable or set BLENDER_EXECUTABLE."
+    exit 1
+}
+if (-not (Test-Path $BlenderExe)) {
+    Write-Error "Blender executable not found: $BlenderExe"
+    exit 1
+}
+
+$PythonPath = Resolve-BlenderPython -Override $BlenderPython -BlenderExePath $BlenderExe
+if ([string]::IsNullOrEmpty($PythonPath)) {
+    Write-Error "Could not locate Blender's bundled Python under '$BlenderExe'. Pass -BlenderPython to override."
+    exit 1
+}
+if (-not (Test-Path $PythonPath)) {
+    Write-Error "Blender Python not found: $PythonPath"
+    exit 1
+}
+
+# ------------------------------------------------------------------
+# Auto-detect wheel file
+# ------------------------------------------------------------------
+if ([string]::IsNullOrEmpty($WheelPath)) {
+    $distDir = Join-Path (Get-Location) "dist"
+    if (Test-Path $distDir) {
+        $wheelFiles = Get-ChildItem -Path $distDir -Filter "deadline_cloud_for_blender-*.whl" -ErrorAction SilentlyContinue |
+                      Sort-Object LastWriteTime -Descending
+        if ($wheelFiles) {
+            $WheelPath = $wheelFiles[0].FullName
+            Write-Host "Auto-detected wheel file: $WheelPath" -ForegroundColor Gray
+        }
+    }
+    if ([string]::IsNullOrEmpty($WheelPath)) {
+        Write-Error "No wheel files found in dist/. Build one with 'hatch build' or pass -WheelPath."
+        exit 1
+    }
+}
+
+Write-Host "=== Blender Adaptor Testing Script ===" -ForegroundColor Green
+Write-Host "Blender:        $BlenderExe" -ForegroundColor Cyan
+Write-Host "Blender Python: $PythonPath" -ForegroundColor Cyan
+Write-Host "Wheel:          $WheelPath" -ForegroundColor Cyan
+Write-Host "JobBundle:      $JobBundleDir" -ForegroundColor Cyan
+Write-Host "Step:           $Step" -ForegroundColor Cyan
+
+# ------------------------------------------------------------------
+# Prerequisites
+# ------------------------------------------------------------------
+function Test-Prerequisites {
+    Write-Host "`n--- Checking Prerequisites ---" -ForegroundColor Yellow
+
+    if (-not (Test-Path $WheelPath)) {
+        Write-Error "Wheel file not found: $WheelPath"; return $false
+    }
+    Write-Host "Wheel file found" -ForegroundColor Green
+
+    if (-not (Test-Path $JobBundleDir)) {
+        Write-Error "Job bundle directory not found: $JobBundleDir"; return $false
+    }
+    Write-Host "Job bundle directory found" -ForegroundColor Green
+
+    return $true
+}
+
+# ------------------------------------------------------------------
+# Setup environment
+# ------------------------------------------------------------------
+function Setup-Environment {
+    Write-Host "`n--- Setting Up Environment ---" -ForegroundColor Yellow
+
+    $repoPath = (Get-Location).Path
+    $submitterPath = Join-Path $repoPath "src/deadline/blender_submitter"
+    $srcPath = Join-Path $repoPath "src"
+    $pathSep = [System.IO.Path]::PathSeparator
+
+    # Put Blender's Python and Blender's executable FIRST on PATH (like 3ds Max script)
+    $blenderPythonDir = Split-Path $PythonPath -Parent
+    $blenderExeDir = Split-Path $BlenderExe -Parent
+    Write-Host "Prepending Blender directories to PATH..." -ForegroundColor Gray
+    $env:PATH = "$blenderPythonDir$pathSep$blenderExeDir$pathSep$env:PATH"
+    Write-Host "  - Blender Python dir: $blenderPythonDir" -ForegroundColor Green
+    Write-Host "  - Blender exe dir:    $blenderExeDir" -ForegroundColor Green
+
+    # PYTHONPATH for in-repo submitter code
+    if ([string]::IsNullOrEmpty($env:PYTHONPATH)) {
+        $env:PYTHONPATH = "$srcPath$pathSep$submitterPath"
+    } else {
+        $env:PYTHONPATH = "$srcPath$pathSep$submitterPath$pathSep$env:PYTHONPATH"
+    }
+    Write-Host "PYTHONPATH: $env:PYTHONPATH" -ForegroundColor Green
+
+    $env:BLENDER_EXECUTABLE = $BlenderExe
+    Write-Host "BLENDER_EXECUTABLE: $env:BLENDER_EXECUTABLE" -ForegroundColor Green
+
+    # Verify Blender's Python is the default
+    Write-Host "`n--- Verifying Python Priority ---" -ForegroundColor Yellow
+    $pythonName = if ($IsWindows) { "python" } else { "python3" }
+    $resolved = Get-Command $pythonName -ErrorAction SilentlyContinue
+    if ($resolved) {
+        $actual = $resolved.Source
+        $expectedNorm = $PythonPath.ToLower().Replace('\', '/')
+        $actualNorm = $actual.ToLower().Replace('\', '/')
+        Write-Host "Expected Blender Python: $PythonPath" -ForegroundColor Cyan
+        Write-Host "Actual default Python:   $actual" -ForegroundColor Cyan
+        if ($actualNorm -eq $expectedNorm) {
+            Write-Host "SUCCESS: Blender Python is now the default Python" -ForegroundColor Green
+        } else {
+            Write-Host "WARNING: '$pythonName' on PATH does not resolve to Blender's Python" -ForegroundColor Yellow
+            Write-Host "Commands in this script explicitly use the Blender Python path, so this is a soft warning." -ForegroundColor Yellow
+        }
+    }
+
+    Write-Host "Note: Environment changes are temporary for this session only" -ForegroundColor Yellow
+    return $true
+}
+
+# ------------------------------------------------------------------
+# Install adaptor
+# ------------------------------------------------------------------
+function Install-Adaptor {
+    Write-Host "`n--- Installing Adaptor ---" -ForegroundColor Yellow
+    Write-Host "Running: $PythonPath -m pip install `"$WheelPath`" --force-reinstall" -ForegroundColor Cyan
+
+    & $PythonPath -m pip install $WheelPath --force-reinstall
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to install adaptor (exit code: $LASTEXITCODE)"
+        return $false
+    }
+    Write-Host "Adaptor installed successfully into Blender's Python environment" -ForegroundColor Green
+    return $true
+}
+
+# ------------------------------------------------------------------
+# Build test command from job bundle
+# ------------------------------------------------------------------
+function Build-TestCommand {
+    Write-Host "`n--- Building Test Command ---" -ForegroundColor Yellow
+
+    try {
+        Import-Module powershell-yaml -ErrorAction Stop
+    } catch {
+        Write-Error "powershell-yaml module is required. Install with: Install-Module powershell-yaml -Scope CurrentUser -Force"
+        return $null
+    }
+
+    $paramFile = Join-Path $JobBundleDir "parameter_values.yaml"
+    if (-not (Test-Path $paramFile)) {
+        Write-Error "Parameter values file not found: $paramFile"; return $null
+    }
+
+    $templateFile = Join-Path $JobBundleDir "template.yaml"
+    if (-not (Test-Path $templateFile)) {
+        Write-Error "Template file not found: $templateFile"; return $null
+    }
+
+    $yamlData = ConvertFrom-Yaml (Get-Content $paramFile -Raw)
+    $templateData = ConvertFrom-Yaml (Get-Content $templateFile -Raw)
+
+    if (-not $templateData.steps -or $templateData.steps.Count -eq 0) {
+        Write-Error "No steps found in template file"; return $null
+    }
+    if ($Step -lt 0 -or $Step -ge $templateData.steps.Count) {
+        Write-Error "Step number $Step is out of range. Available: 0..$($templateData.steps.Count - 1)"
+        for ($i = 0; $i -lt $templateData.steps.Count; $i++) {
+            Write-Host "  Step $i`: $($templateData.steps[$i].name)" -ForegroundColor Gray
+        }
+        return $null
+    }
+
+    $selectedStep = $templateData.steps[$Step]
+    Write-Host "Selected step: $($selectedStep.name)" -ForegroundColor Green
+
+    # Merge defaults from template parameterDefinitions with parameter_values.yaml
+    $mergedParams = [ordered]@{}
+    if ($templateData.parameterDefinitions) {
+        foreach ($pd in $templateData.parameterDefinitions) {
+            $hasDefault = $false
+            if ($pd -is [System.Collections.IDictionary]) {
+                $hasDefault = $pd.Contains('default')
+            } elseif ($pd.PSObject.Properties.Name -contains 'default') {
+                $hasDefault = $true
+            }
+            if ($hasDefault) {
+                $mergedParams[$pd.name] = $pd.default
+            }
+        }
+    }
+    foreach ($p in $yamlData.parameterValues) {
+        $mergedParams[$p.name] = $p.value
+    }
+
+    $getValue = {
+        param($name)
+        if ($mergedParams.Contains($name)) { return $mergedParams[$name] } else { return "" }
+    }
+
+    $frames = & $getValue "Frames"
+    if ([string]::IsNullOrEmpty($frames)) { $frames = "1" }
+
+    # Camera - from task parameter definitions if present
+    $defaultCamera = ""
+    if ($selectedStep.parameterSpace -and $selectedStep.parameterSpace.taskParameterDefinitions) {
+        $cameraParam = $selectedStep.parameterSpace.taskParameterDefinitions | Where-Object { $_.name -eq "Camera" }
+        if ($cameraParam -and $cameraParam.range -and $cameraParam.range.Count -gt 0) {
+            $defaultCamera = $cameraParam.range[0]
+            Write-Host "Found camera parameter: $defaultCamera" -ForegroundColor Green
+        }
+    }
+
+    # Find initData embedded file
+    $initDataSection = $null
+    if ($selectedStep.stepEnvironments) {
+        foreach ($stepEnv in $selectedStep.stepEnvironments) {
+            if ($stepEnv.script -and $stepEnv.script.embeddedFiles) {
+                $match = $stepEnv.script.embeddedFiles | Where-Object { $_.name -eq "initData" }
+                if ($match) { $initDataSection = $match; break }
+            }
+        }
+    }
+    if (-not $initDataSection) {
+        Write-Error "Could not find initData embedded file in step '$($selectedStep.name)'"
+        return $null
+    }
+
+    # Substitute parameter placeholders using merged values
+    $initDataTemplate = $initDataSection.data
+    $placeholderRegex = [regex]'\{\{\s*Param\.([A-Za-z0-9_]+)\s*\}\}'
+    $initDataTemplate = $placeholderRegex.Replace($initDataTemplate, {
+        param($m)
+        $name = $m.Groups[1].Value
+        if ($mergedParams.Contains($name)) {
+            return [string]$mergedParams[$name]
+        }
+        Write-Host "Warning: unresolved parameter Param.$name; substituting empty string" -ForegroundColor Yellow
+        return ""
+    })
+
+    Write-Host "Substituted initData template:" -ForegroundColor Gray
+    Write-Host $initDataTemplate -ForegroundColor Gray
+
+    $initDataYaml = ConvertFrom-Yaml $initDataTemplate
+
+    # Drop empty-string / null values so the adaptor schema doesn't reject them
+    $cleaned = [ordered]@{}
+    foreach ($key in $initDataYaml.Keys) {
+        $v = $initDataYaml[$key]
+        if ($null -ne $v -and -not ($v -is [string] -and [string]::IsNullOrEmpty($v))) {
+            $cleaned[$key] = $v
+        }
+    }
+    $initData = $cleaned | ConvertTo-Json -Compress -Depth 10
+
+    # First frame only for one-shot adapter run
+    $firstFrame = 1
+    $firstToken = $frames.Split(',')[0].Trim()
+    $firstRangeStart = $firstToken.Split('-')[0]
+    if ($firstRangeStart -match '^\d+$') { $firstFrame = [int]$firstRangeStart }
+
+    $runDataObj = [ordered]@{ frame = $firstFrame }
+    if (-not [string]::IsNullOrEmpty($defaultCamera)) {
+        $runDataObj["camera"] = $defaultCamera
+    }
+    $runData = $runDataObj | ConvertTo-Json -Compress
+
+    # Write JSON to temp files (UTF-8, no BOM)
+    $tempDir = [System.IO.Path]::GetTempPath()
+    $initDataFile = Join-Path $tempDir "blender-init-data.json"
+    $runDataFile  = Join-Path $tempDir "blender-run-data.json"
+    $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+    [System.IO.File]::WriteAllText($initDataFile, $initData, $utf8NoBom)
+    [System.IO.File]::WriteAllText($runDataFile,  $runData,  $utf8NoBom)
+
+    Write-Host "`nInit Data JSON ($initDataFile):" -ForegroundColor Yellow
+    Write-Host $initData -ForegroundColor Gray
+    Write-Host "`nRun Data JSON ($runDataFile):" -ForegroundColor Yellow
+    Write-Host $runData -ForegroundColor Gray
+
+    # file:// URIs use forward slashes on all platforms
+    $initDataUri = "file://" + ($initDataFile -replace '\\', '/')
+    $runDataUri  = "file://" + ($runDataFile  -replace '\\', '/')
+
+    $cmdArgs = @(
+        "-m", "deadline.blender_adaptor.BlenderAdaptor",
+        "run",
+        "--init-data", $initDataUri,
+        "--run-data",  $runDataUri
+    )
+
+    if (-not [string]::IsNullOrEmpty($PathMappingFile)) {
+        if (-not (Test-Path $PathMappingFile)) {
+            Write-Error "Path mapping file not found: $PathMappingFile"; return $null
+        }
+        $absPathMapping = (Resolve-Path $PathMappingFile).Path
+        $pmUri = "file://" + ($absPathMapping -replace '\\', '/')
+        $cmdArgs += @("--path-mapping-rules", $pmUri)
+        Write-Host "`nPath Mapping Rules File: $absPathMapping" -ForegroundColor Yellow
+        Write-Host (Get-Content $PathMappingFile -Raw) -ForegroundColor Gray
+    }
+
+    Write-Host "`nTest Command:" -ForegroundColor Yellow
+    Write-Host "$PythonPath $($cmdArgs -join ' ')" -ForegroundColor White
+
+    $fullCommand = @($PythonPath) + $cmdArgs
+    return , $fullCommand
+}
+
+# ------------------------------------------------------------------
+# Run
+# ------------------------------------------------------------------
+function Run-Test {
+    param([string[]]$TestCommand)
+
+    Write-Host "`n--- Running Test ---" -ForegroundColor Yellow
+    $startTime = Get-Date
+    Write-Host "Started at: $startTime" -ForegroundColor Gray
+
+    $exe  = $TestCommand[0]
+    $rest = $TestCommand[1..($TestCommand.Length - 1)]
+
+    $capturedOutput = $null
+    if ($ShowOutput) {
+        & $exe @rest
+    } else {
+        $capturedOutput = & $exe @rest 2>&1
+    }
+    $exitCode = $LASTEXITCODE
+
+    $duration = (Get-Date) - $startTime
+    Write-Host "`nTest completed in $($duration.TotalSeconds) seconds (exit code: $exitCode)" -ForegroundColor Gray
+
+    if ($exitCode -eq 0) {
+        Write-Host "Test completed successfully!" -ForegroundColor Green
+        return $true
+    } else {
+        Write-Host "Test failed (exit code: $exitCode)" -ForegroundColor Red
+        if (-not $ShowOutput -and $capturedOutput) {
+            Write-Host "`nOutput:" -ForegroundColor Gray
+            $capturedOutput | ForEach-Object { Write-Host $_ -ForegroundColor Red }
+        }
+        return $false
+    }
+}
+
+# ------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------
+try {
+    if (-not (Test-Prerequisites)) { exit 1 }
+    if (-not (Setup-Environment))  { exit 1 }
+
+    if (-not $SkipInstall) {
+        if (-not (Install-Adaptor)) { exit 1 }
+    } else {
+        Write-Host "`n--- Skipping Installation ---" -ForegroundColor Yellow
+    }
+
+    $testCommand = Build-TestCommand
+    if (-not $testCommand) { exit 1 }
+
+    $success = Run-Test -TestCommand $testCommand
+    if ($success) {
+        Write-Host "`nTest completed successfully!" -ForegroundColor Green
+        exit 0
+    } else {
+        Write-Host "`nTest failed. Check the output above for details." -ForegroundColor Red
+        exit 1
+    }
+} catch {
+    Write-Error "Unexpected error: $($_.Exception.Message)"
+    exit 1
+}

--- a/scripts/test-blender-adapter-run.sh
+++ b/scripts/test-blender-adapter-run.sh
@@ -1,0 +1,503 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Blender Adaptor Testing Script (Bash)
+# Tests the deadline-cloud-for-blender adaptor directly without worker agent setup.
+# Uses Blender's bundled Python (Blender ships Python under <install>/<X.Y>/python/bin/...).
+#
+# Works on Linux, macOS, and Windows (via Git Bash / WSL).
+
+set -u
+
+# ------------------------------------------------------------------
+# Color helpers
+# ------------------------------------------------------------------
+if [ -t 1 ]; then
+    C_RESET=$'\033[0m'
+    C_RED=$'\033[31m'
+    C_GREEN=$'\033[32m'
+    C_YELLOW=$'\033[33m'
+    C_CYAN=$'\033[36m'
+    C_GRAY=$'\033[90m'
+else
+    C_RESET="" C_RED="" C_GREEN="" C_YELLOW="" C_CYAN="" C_GRAY=""
+fi
+
+info()    { printf "%s%s%s\n" "$C_CYAN"   "$*" "$C_RESET"; }
+ok()      { printf "%s%s%s\n" "$C_GREEN"  "$*" "$C_RESET"; }
+warn()    { printf "%s%s%s\n" "$C_YELLOW" "$*" "$C_RESET"; }
+err()     { printf "%s%s%s\n" "$C_RED"    "$*" "$C_RESET" >&2; }
+section() { printf "\n%s--- %s ---%s\n" "$C_YELLOW" "$*" "$C_RESET"; }
+gray()    { printf "%s%s%s\n" "$C_GRAY"   "$*" "$C_RESET"; }
+
+# ------------------------------------------------------------------
+# Defaults
+# ------------------------------------------------------------------
+JOB_BUNDLE_DIR=""
+WHEEL_PATH=""
+BLENDER_EXE=""
+BLENDER_PYTHON=""
+STEP=0
+PATH_MAPPING_FILE=""
+SKIP_INSTALL=0
+SHOW_OUTPUT=0
+
+usage() {
+    cat <<EOF
+=== Blender Adaptor Testing Script Help ===
+
+DESCRIPTION:
+  Tests the deadline-cloud-for-blender adaptor directly without worker agent setup.
+  Uses Blender's bundled Python. Runs on Linux, macOS, and Windows (via Git Bash / WSL).
+
+USAGE:
+  Run from the repository root directory:
+  ./scripts/test-blender-adapter-run.sh --job-bundle-dir <path> [options]
+
+OPTIONS:
+  -j, --job-bundle-dir <dir>    (Required) Path to the job bundle directory
+  -w, --wheel-path <path>       Path to the wheel file (auto-detects dist/*.whl if omitted)
+  -b, --blender <path>          Path to the Blender executable (defaults to BLENDER_EXECUTABLE env or 'blender' on PATH)
+  -p, --blender-python <path>   Path to Blender's bundled Python (derived from Blender install if omitted)
+  -s, --step <n>                Step index to run (default: 0)
+  -m, --path-mapping-file <p>   Path to JSON file with path mapping rules (optional)
+      --skip-install            Skip wheel installation
+      --show-output             Show detailed output
+  -h, --help                    Show this help and exit
+
+PREREQUISITES:
+  - Blender installed (ships its own Python; no system Python required)
+EOF
+}
+
+# ------------------------------------------------------------------
+# Argument parsing
+# ------------------------------------------------------------------
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -j|--job-bundle-dir)     JOB_BUNDLE_DIR="$2"; shift 2 ;;
+        --job-bundle-dir=*)      JOB_BUNDLE_DIR="${1#*=}"; shift ;;
+        -w|--wheel-path)         WHEEL_PATH="$2"; shift 2 ;;
+        --wheel-path=*)          WHEEL_PATH="${1#*=}"; shift ;;
+        -b|--blender|--blender-executable) BLENDER_EXE="$2"; shift 2 ;;
+        --blender=*|--blender-executable=*) BLENDER_EXE="${1#*=}"; shift ;;
+        -p|--blender-python)     BLENDER_PYTHON="$2"; shift 2 ;;
+        --blender-python=*)      BLENDER_PYTHON="${1#*=}"; shift ;;
+        -s|--step)               STEP="$2"; shift 2 ;;
+        --step=*)                STEP="${1#*=}"; shift ;;
+        -m|--path-mapping-file)  PATH_MAPPING_FILE="$2"; shift 2 ;;
+        --path-mapping-file=*)   PATH_MAPPING_FILE="${1#*=}"; shift ;;
+        --skip-install)          SKIP_INSTALL=1; shift ;;
+        --show-output)           SHOW_OUTPUT=1; shift ;;
+        -h|--help)               usage; exit 0 ;;
+        *) err "Unknown argument: $1"; usage; exit 1 ;;
+    esac
+done
+
+if [ -z "$JOB_BUNDLE_DIR" ]; then
+    err "JobBundleDir is required. Use --help for usage information."
+    exit 1
+fi
+
+# ------------------------------------------------------------------
+# Resolve Blender executable
+# ------------------------------------------------------------------
+resolve_blender() {
+    if [ -n "$BLENDER_EXE" ]; then echo "$BLENDER_EXE"; return; fi
+    if [ -n "${BLENDER_EXECUTABLE:-}" ]; then echo "$BLENDER_EXECUTABLE"; return; fi
+    if command -v blender >/dev/null 2>&1; then command -v blender; return; fi
+
+    case "$(uname -s)" in
+        Darwin)
+            [ -x "/Applications/Blender.app/Contents/MacOS/Blender" ] \
+                && echo "/Applications/Blender.app/Contents/MacOS/Blender" && return ;;
+        Linux|*)
+            for p in /usr/bin/blender /usr/local/bin/blender /snap/bin/blender; do
+                [ -x "$p" ] && echo "$p" && return
+            done ;;
+    esac
+    if [ -d "/c/Program Files/Blender Foundation" ]; then
+        for dir in $(ls -1d "/c/Program Files/Blender Foundation"/* 2>/dev/null | sort -r); do
+            [ -x "$dir/blender.exe" ] && echo "$dir/blender.exe" && return
+        done
+    fi
+    echo ""
+}
+
+# ------------------------------------------------------------------
+# Resolve Blender's bundled Python from the Blender executable path.
+#
+# Blender ships Python at:
+#   Linux:   <install>/<X.Y>/python/bin/python3.<Y>
+#   macOS:   <Blender.app>/Contents/Resources/<X.Y>/python/bin/python3.<Y>
+#   Windows: <install>\<X.Y>\python\bin\python.exe
+# ------------------------------------------------------------------
+resolve_blender_python() {
+    local blender_exe="$1"
+    if [ -n "$BLENDER_PYTHON" ]; then echo "$BLENDER_PYTHON"; return; fi
+    if [ -z "$blender_exe" ] || [ ! -e "$blender_exe" ]; then echo ""; return; fi
+
+    # Determine the search root (the directory that contains the <X.Y> version folder)
+    local search_root
+    case "$(uname -s)" in
+        Darwin)
+            # /Applications/Blender.app/Contents/MacOS/Blender -> /Applications/Blender.app/Contents/Resources
+            if [[ "$blender_exe" == *".app/Contents/MacOS/"* ]]; then
+                local app_root="${blender_exe%/Contents/MacOS/*}"
+                search_root="$app_root/Contents/Resources"
+            else
+                search_root="$(dirname "$blender_exe")"
+            fi
+            ;;
+        *)
+            search_root="$(dirname "$blender_exe")"
+            ;;
+    esac
+
+    if [ ! -d "$search_root" ]; then echo ""; return; fi
+
+    # Find version subdirs (e.g. "4.2", "5.0"), newest first
+    local dir python_bin exe
+    for dir in $(ls -1d "$search_root"/[0-9]*.[0-9]* 2>/dev/null | sort -rV); do
+        python_bin="$dir/python/bin"
+        if [ ! -d "$python_bin" ]; then continue; fi
+
+        case "$(uname -s)" in
+            CYGWIN*|MINGW*|MSYS*)
+                exe="$python_bin/python.exe"
+                [ -x "$exe" ] && { echo "$exe"; return; }
+                ;;
+            *)
+                # Prefer python3.<minor>, then python3, then python
+                exe="$(ls -1 "$python_bin"/python3.* 2>/dev/null | grep -E '/python3\.[0-9]+$' | sort -V | tail -n 1)"
+                if [ -n "$exe" ] && [ -x "$exe" ]; then echo "$exe"; return; fi
+                [ -x "$python_bin/python3" ] && { echo "$python_bin/python3"; return; }
+                [ -x "$python_bin/python" ] && { echo "$python_bin/python"; return; }
+                ;;
+        esac
+    done
+    echo ""
+}
+
+BLENDER_EXE="$(resolve_blender)"
+if [ -z "$BLENDER_EXE" ]; then
+    err "Could not locate Blender. Pass --blender or set BLENDER_EXECUTABLE."
+    exit 1
+fi
+if [ ! -e "$BLENDER_EXE" ]; then
+    err "Blender executable not found: $BLENDER_EXE"
+    exit 1
+fi
+
+PYTHON_PATH="$(resolve_blender_python "$BLENDER_EXE")"
+if [ -z "$PYTHON_PATH" ]; then
+    err "Could not locate Blender's bundled Python under '$BLENDER_EXE'. Pass --blender-python to override."
+    exit 1
+fi
+if [ ! -x "$PYTHON_PATH" ]; then
+    err "Blender Python not executable: $PYTHON_PATH"
+    exit 1
+fi
+
+# Ensure PyYAML is available in Blender's Python (install into Blender Python if missing)
+if ! "$PYTHON_PATH" -c "import yaml" >/dev/null 2>&1; then
+    warn "PyYAML is not installed in Blender's Python. Installing..."
+    "$PYTHON_PATH" -m pip install pyyaml || { err "Failed to install PyYAML into Blender Python"; exit 1; }
+fi
+
+# ------------------------------------------------------------------
+# Auto-detect wheel file
+# ------------------------------------------------------------------
+if [ -z "$WHEEL_PATH" ]; then
+    WHEEL_PATH="$(ls -t dist/deadline_cloud_for_blender-*.whl 2>/dev/null | head -n 1 || true)"
+    if [ -n "$WHEEL_PATH" ]; then
+        gray "Auto-detected wheel file: $WHEEL_PATH"
+    else
+        err "No wheel files found in dist/. Build one with 'hatch build' or pass --wheel-path."
+        exit 1
+    fi
+fi
+
+echo
+ok "=== Blender Adaptor Testing Script ==="
+info "Blender:        $BLENDER_EXE"
+info "Blender Python: $PYTHON_PATH"
+info "Wheel:          $WHEEL_PATH"
+info "JobBundle:      $JOB_BUNDLE_DIR"
+info "Step:           $STEP"
+
+# ------------------------------------------------------------------
+# Prerequisites
+# ------------------------------------------------------------------
+check_prereqs() {
+    section "Checking Prerequisites"
+    [ -f "$WHEEL_PATH" ] || { err "Wheel file not found: $WHEEL_PATH"; return 1; }
+    ok "Wheel file found"
+    [ -d "$JOB_BUNDLE_DIR" ] || { err "Job bundle directory not found: $JOB_BUNDLE_DIR"; return 1; }
+    ok "Job bundle directory found"
+    return 0
+}
+
+# ------------------------------------------------------------------
+# Setup environment
+# ------------------------------------------------------------------
+setup_env() {
+    section "Setting Up Environment"
+
+    local repo_path submitter_path src_path sep
+    repo_path="$(pwd)"
+    submitter_path="$repo_path/src/deadline/blender_submitter"
+    src_path="$repo_path/src"
+    sep=":"
+    case "$(uname -s)" in CYGWIN*|MINGW*|MSYS*) sep=";" ;; esac
+
+    # Put Blender's Python and executable FIRST on PATH (mirrors the 3ds Max pattern)
+    local blender_python_dir blender_exe_dir
+    blender_python_dir="$(dirname "$PYTHON_PATH")"
+    blender_exe_dir="$(dirname "$BLENDER_EXE")"
+    gray "Prepending Blender directories to PATH..."
+    export PATH="$blender_python_dir:$blender_exe_dir:$PATH"
+    ok "  - Blender Python dir: $blender_python_dir"
+    ok "  - Blender exe dir:    $blender_exe_dir"
+
+    if [ -z "${PYTHONPATH:-}" ]; then
+        export PYTHONPATH="$src_path$sep$submitter_path"
+    else
+        export PYTHONPATH="$src_path$sep$submitter_path$sep$PYTHONPATH"
+    fi
+    ok "PYTHONPATH: $PYTHONPATH"
+
+    export BLENDER_EXECUTABLE="$BLENDER_EXE"
+    ok "BLENDER_EXECUTABLE: $BLENDER_EXECUTABLE"
+
+    # Verify Blender's Python is the default python3/python on PATH
+    section "Verifying Python Priority"
+    local which_python expected_norm actual_norm
+    which_python="$(command -v python3 || command -v python || true)"
+    if [ -n "$which_python" ]; then
+        info "Expected Blender Python: $PYTHON_PATH"
+        info "Actual default Python:   $which_python"
+        expected_norm="$(printf '%s' "$PYTHON_PATH" | tr '[:upper:]' '[:lower:]' | tr '\\' '/')"
+        actual_norm="$(printf '%s' "$which_python" | tr '[:upper:]' '[:lower:]' | tr '\\' '/')"
+        if [ "$expected_norm" = "$actual_norm" ]; then
+            ok "SUCCESS: Blender Python is now the default Python"
+        else
+            warn "WARNING: 'python3' on PATH does not resolve to Blender's Python."
+            warn "         Commands in this script use the Blender Python path explicitly, so this is a soft warning."
+        fi
+    fi
+
+    warn "Note: Environment changes are temporary for this session only"
+    return 0
+}
+
+# ------------------------------------------------------------------
+# Install adaptor
+# ------------------------------------------------------------------
+install_adaptor() {
+    section "Installing Adaptor"
+    info "Running: $PYTHON_PATH -m pip install \"$WHEEL_PATH\" --force-reinstall"
+    if "$PYTHON_PATH" -m pip install "$WHEEL_PATH" --force-reinstall; then
+        ok "Adaptor installed into Blender's Python environment"
+        return 0
+    fi
+    err "Failed to install adaptor"
+    return 1
+}
+
+# ------------------------------------------------------------------
+# Build init-data and run-data JSON via a Python helper run with Blender Python
+# ------------------------------------------------------------------
+build_json_via_python() {
+    local temp_dir
+    temp_dir="$(mktemp -d)"
+    local init_file="$temp_dir/blender-init-data.json"
+    local run_file="$temp_dir/blender-run-data.json"
+
+    "$PYTHON_PATH" - "$JOB_BUNDLE_DIR" "$STEP" "$init_file" "$run_file" <<'PYEOF'
+import json, os, re, sys
+import yaml
+
+bundle_dir, step_str, init_out, run_out = sys.argv[1:5]
+step_idx = int(step_str)
+
+def die(msg):
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+param_file = os.path.join(bundle_dir, "parameter_values.yaml")
+template_file = os.path.join(bundle_dir, "template.yaml")
+if not os.path.isfile(param_file):
+    die(f"parameter_values.yaml not found: {param_file}")
+if not os.path.isfile(template_file):
+    die(f"template.yaml not found: {template_file}")
+
+with open(param_file) as f:
+    params = yaml.safe_load(f) or {}
+with open(template_file) as f:
+    template = yaml.safe_load(f) or {}
+
+# Start with defaults from the template's parameterDefinitions
+param_values = {}
+for pd in (template.get("parameterDefinitions") or []):
+    if "default" in pd:
+        param_values[pd["name"]] = pd["default"]
+# Override with explicit parameter values from parameter_values.yaml
+for p in (params.get("parameterValues") or []):
+    param_values[p["name"]] = p["value"]
+
+steps = template.get("steps") or []
+if step_idx < 0 or step_idx >= len(steps):
+    names = [f"  [{i}] {s.get('name')}" for i, s in enumerate(steps)]
+    die("Step {} out of range. Available steps:\n{}".format(step_idx, "\n".join(names)))
+selected = steps[step_idx]
+
+print(f"Selected step: {selected.get('name')}", file=sys.stderr)
+
+# Camera from task parameter definitions if present
+camera = ""
+pspace = selected.get("parameterSpace") or {}
+for pd in pspace.get("taskParameterDefinitions") or []:
+    if pd.get("name") == "Camera":
+        rng = pd.get("range") or []
+        if rng:
+            camera = rng[0]
+            break
+
+# Find the initData embedded file
+init_template = None
+for env in selected.get("stepEnvironments") or []:
+    script = env.get("script") or {}
+    for ef in script.get("embeddedFiles") or []:
+        if ef.get("name") == "initData":
+            init_template = ef.get("data")
+            break
+    if init_template:
+        break
+if init_template is None:
+    die("Could not find initData embedded file in selected step")
+
+# Substitute {{Param.X}} with parameter values; leave unknowns as empty strings
+def sub_placeholder(match):
+    name = match.group(1)
+    if name in param_values:
+        return str(param_values[name])
+    print(f"Warning: unresolved parameter Param.{name}; substituting empty string", file=sys.stderr)
+    return ""
+substituted = re.sub(r"\{\{\s*Param\.([A-Za-z0-9_]+)\s*\}\}", sub_placeholder, init_template)
+
+init_data = yaml.safe_load(substituted) or {}
+
+# Drop empty-string / None values so the adaptor schema doesn't reject them
+init_data = {k: v for k, v in init_data.items() if v not in ("", None)}
+
+# Pick first frame from the Frames parameter
+frames = str(param_values.get("Frames", "1")).strip() or "1"
+first_token = frames.split(",")[0].strip()
+first_num = first_token.split("-")[0].strip()
+try:
+    first_frame = int(first_num)
+except ValueError:
+    first_frame = 1
+
+run_data = {"frame": first_frame}
+if camera:
+    run_data["camera"] = camera
+
+with open(init_out, "w", encoding="utf-8") as f:
+    json.dump(init_data, f)
+with open(run_out, "w", encoding="utf-8") as f:
+    json.dump(run_data, f)
+PYEOF
+
+    local rc=$?
+    if [ $rc -ne 0 ]; then return $rc; fi
+
+    INIT_DATA_FILE="$init_file"
+    RUN_DATA_FILE="$run_file"
+    return 0
+}
+
+# ------------------------------------------------------------------
+# Build and run test
+# ------------------------------------------------------------------
+build_and_run() {
+    section "Building Test Command"
+
+    if ! build_json_via_python; then
+        err "Failed to prepare init/run data"
+        return 1
+    fi
+
+    info "Init Data JSON ($INIT_DATA_FILE):"
+    gray "$(cat "$INIT_DATA_FILE")"
+    info "Run Data JSON ($RUN_DATA_FILE):"
+    gray "$(cat "$RUN_DATA_FILE")"
+
+    local init_uri="file://${INIT_DATA_FILE//\\/\/}"
+    local run_uri="file://${RUN_DATA_FILE//\\/\/}"
+
+    local -a cmd=(
+        "$PYTHON_PATH" -m deadline.blender_adaptor.BlenderAdaptor
+        run
+        --init-data "$init_uri"
+        --run-data  "$run_uri"
+    )
+
+    if [ -n "$PATH_MAPPING_FILE" ]; then
+        if [ ! -f "$PATH_MAPPING_FILE" ]; then
+            err "Path mapping file not found: $PATH_MAPPING_FILE"
+            return 1
+        fi
+        local abs_pm
+        abs_pm="$("$PYTHON_PATH" -c "import os,sys; print(os.path.abspath(sys.argv[1]))" "$PATH_MAPPING_FILE")"
+        local pm_uri="file://${abs_pm//\\/\/}"
+        cmd+=(--path-mapping-rules "$pm_uri")
+        info "Path Mapping Rules File: $abs_pm"
+        gray "$(cat "$PATH_MAPPING_FILE")"
+    fi
+
+    info "Test Command: ${cmd[*]}"
+
+    section "Running Test"
+    local start_ts end_ts duration exit_code
+    start_ts=$(date +%s)
+
+    if [ $SHOW_OUTPUT -eq 1 ]; then
+        "${cmd[@]}"
+        exit_code=$?
+    else
+        local tmp_out
+        tmp_out="$(mktemp)"
+        "${cmd[@]}" >"$tmp_out" 2>&1
+        exit_code=$?
+        if [ $exit_code -ne 0 ]; then
+            err "Output:"
+            cat "$tmp_out"
+        fi
+        rm -f "$tmp_out"
+    fi
+
+    end_ts=$(date +%s)
+    duration=$((end_ts - start_ts))
+    gray "Test completed in ${duration}s (exit code: $exit_code)"
+
+    if [ $exit_code -eq 0 ]; then
+        ok "Test completed successfully!"
+        return 0
+    fi
+    err "Test failed"
+    return 1
+}
+
+# ------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------
+check_prereqs || exit 1
+setup_env || exit 1
+if [ $SKIP_INSTALL -eq 0 ]; then
+    install_adaptor || exit 1
+else
+    section "Skipping Installation"
+fi
+build_and_run

--- a/scripts/test-blender-openjd-run.ps1
+++ b/scripts/test-blender-openjd-run.ps1
@@ -1,0 +1,545 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Blender OpenJD Runner Testing Script (cross-platform PowerShell)
+# Tests the deadline-cloud-for-blender adaptor via `openjd-cli run` against a job bundle template.
+#
+# Works on Linux, macOS, and Windows using PowerShell 7+ (pwsh).
+
+param(
+    [string]$JobBundleDir,
+    [string]$WheelPath,
+    [string]$BlenderExecutable = "",
+    [string]$BlenderPython = "",
+    [int]$Step = -1,
+    [string]$PathMappingFile,
+    [switch]$SkipInstall,
+    [switch]$ShowOutput,
+    [switch]$Help
+)
+
+# ------------------------------------------------------------------
+# Interactive prompt helpers
+# ------------------------------------------------------------------
+function Prompt-ForValue {
+    param(
+        [string]$ParameterName,
+        [string]$Description,
+        [string]$DefaultValue = ""
+    )
+    $prompt = "$ParameterName"
+    if (-not [string]::IsNullOrEmpty($Description)) { $prompt += " ($Description)" }
+    if (-not [string]::IsNullOrEmpty($DefaultValue)) { $prompt += " [default: $DefaultValue]" }
+    $prompt += ": "
+    Write-Host $prompt -ForegroundColor Cyan -NoNewline
+    $value = Read-Host
+    if ([string]::IsNullOrEmpty($value) -and -not [string]::IsNullOrEmpty($DefaultValue)) {
+        return $DefaultValue
+    }
+    return $value
+}
+
+function Prompt-ForStep {
+    param([array]$Steps)
+    Write-Host "`nAvailable steps:" -ForegroundColor Yellow
+    for ($i = 0; $i -lt $Steps.Count; $i++) {
+        Write-Host "  [$i] $($Steps[$i].name)" -ForegroundColor Cyan
+    }
+    while ($true) {
+        Write-Host "Select step number [0-$($Steps.Count - 1)]: " -ForegroundColor Cyan -NoNewline
+        $inputValue = Read-Host
+        if ($inputValue -match '^\d+$') {
+            $stepNum = [int]$inputValue
+            if ($stepNum -ge 0 -and $stepNum -lt $Steps.Count) { return $stepNum }
+        }
+        Write-Host "Invalid selection. Enter a number between 0 and $($Steps.Count - 1)" -ForegroundColor Red
+    }
+}
+
+# ------------------------------------------------------------------
+# Help
+# ------------------------------------------------------------------
+if ($Help) {
+    Write-Host "=== Blender OpenJD Runner Testing Script Help ===" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "DESCRIPTION:" -ForegroundColor Yellow
+    Write-Host "  Tests the deadline-cloud-for-blender adaptor via 'openjd-cli run' against a job bundle template."
+    Write-Host "  Uses Blender's bundled Python. Parameters without values prompt interactively."
+    Write-Host "  Runs on Linux, macOS, and Windows (requires PowerShell 7+)."
+    Write-Host ""
+    Write-Host "USAGE:" -ForegroundColor Yellow
+    Write-Host "  pwsh ./scripts/test-blender-openjd-run.ps1" -ForegroundColor Cyan
+    Write-Host "  pwsh ./scripts/test-blender-openjd-run.ps1 -JobBundleDir test_bundle" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "PARAMETERS:" -ForegroundColor Yellow
+    Write-Host "  -JobBundleDir       Path to the job bundle directory (prompts if empty)" -ForegroundColor Cyan
+    Write-Host "  -WheelPath          Path to the wheel file (auto-detects from dist/ if empty)" -ForegroundColor Cyan
+    Write-Host "  -BlenderExecutable  Path to Blender (defaults to BLENDER_EXECUTABLE env or 'blender' on PATH)" -ForegroundColor Cyan
+    Write-Host "  -BlenderPython      Path to Blender's bundled Python (derived from Blender install if empty)" -ForegroundColor Cyan
+    Write-Host "  -Step               Step index to run (shows list if not provided)" -ForegroundColor Cyan
+    Write-Host "  -PathMappingFile    Path to JSON file with path mapping rules (optional)" -ForegroundColor Cyan
+    Write-Host "  -SkipInstall        Skip wheel installation" -ForegroundColor Cyan
+    Write-Host "  -ShowOutput         Show detailed output" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "PREREQUISITES:" -ForegroundColor Yellow
+    Write-Host "  - PowerShell 7+ (pwsh) for cross-platform use"
+    Write-Host "  - Blender installed (ships its own Python; no system Python required)"
+    Write-Host "  - PowerShell-Yaml module for YAML parsing:"
+    Write-Host "    Install-Module powershell-yaml -Scope CurrentUser -Force" -ForegroundColor Cyan
+    Write-Host ""
+    exit 0
+}
+
+# ------------------------------------------------------------------
+# Resolve Blender executable
+# ------------------------------------------------------------------
+function Resolve-BlenderExecutable {
+    param([string]$Override)
+    if (-not [string]::IsNullOrEmpty($Override)) { return $Override }
+    if (-not [string]::IsNullOrEmpty($env:BLENDER_EXECUTABLE)) { return $env:BLENDER_EXECUTABLE }
+
+    $cmd = Get-Command "blender" -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+
+    if ($IsWindows) {
+        $candidates = Get-ChildItem "C:\Program Files\Blender Foundation" -Directory -ErrorAction SilentlyContinue |
+                      Sort-Object Name -Descending
+        foreach ($dir in $candidates) {
+            $exe = Join-Path $dir.FullName "blender.exe"
+            if (Test-Path $exe) { return $exe }
+        }
+    } elseif ($IsMacOS) {
+        $mac = "/Applications/Blender.app/Contents/MacOS/Blender"
+        if (Test-Path $mac) { return $mac }
+    } else {
+        foreach ($p in @("/usr/bin/blender", "/usr/local/bin/blender", "/snap/bin/blender")) {
+            if (Test-Path $p) { return $p }
+        }
+    }
+    return ""
+}
+
+# ------------------------------------------------------------------
+# Resolve Blender's bundled Python from the Blender executable path.
+# Blender ships Python under <install>/<X.Y>/python/bin/... (Resources on macOS).
+# ------------------------------------------------------------------
+function Resolve-BlenderPython {
+    param(
+        [string]$Override,
+        [string]$BlenderExePath
+    )
+    if (-not [string]::IsNullOrEmpty($Override)) { return $Override }
+    if ([string]::IsNullOrEmpty($BlenderExePath) -or -not (Test-Path $BlenderExePath)) {
+        return ""
+    }
+
+    if ($IsMacOS -and $BlenderExePath -match "\.app/Contents/MacOS/") {
+        $appRoot = $BlenderExePath -replace "/Contents/MacOS/.*$", ""
+        $searchRoot = Join-Path $appRoot "Contents/Resources"
+    } else {
+        $searchRoot = Split-Path $BlenderExePath -Parent
+    }
+
+    if (-not (Test-Path $searchRoot)) { return "" }
+
+    $versionDirs = Get-ChildItem -Path $searchRoot -Directory -ErrorAction SilentlyContinue |
+                   Where-Object { $_.Name -match "^\d+\.\d+$" } |
+                   Sort-Object { [version]$_.Name } -Descending
+    foreach ($dir in $versionDirs) {
+        $pythonBin = Join-Path $dir.FullName "python/bin"
+        if (-not (Test-Path $pythonBin)) { continue }
+
+        if ($IsWindows) {
+            $exe = Join-Path $pythonBin "python.exe"
+            if (Test-Path $exe) { return $exe }
+        } else {
+            $candidates = Get-ChildItem -Path $pythonBin -File -ErrorAction SilentlyContinue |
+                          Where-Object { $_.Name -match "^python3\.\d+$" -or $_.Name -eq "python3" -or $_.Name -eq "python" } |
+                          Sort-Object {
+                              if ($_.Name -match "^python3\.(\d+)$") { [int]$Matches[1] }
+                              elseif ($_.Name -eq "python3") { -1 }
+                              else { -2 }
+                          } -Descending
+            if ($candidates) { return $candidates[0].FullName }
+        }
+    }
+    return ""
+}
+
+# ------------------------------------------------------------------
+# Interactive prompts for missing parameters
+# ------------------------------------------------------------------
+Write-Host "`n=== Parameter Configuration ===" -ForegroundColor Green
+
+if ([string]::IsNullOrEmpty($JobBundleDir)) {
+    $JobBundleDir = Prompt-ForValue -ParameterName "JobBundleDir" -Description "Path to job bundle directory"
+    if ([string]::IsNullOrEmpty($JobBundleDir)) {
+        Write-Error "JobBundleDir is required."; exit 1
+    }
+}
+if (-not (Test-Path $JobBundleDir)) {
+    Write-Error "Job bundle directory not found: $JobBundleDir"; exit 1
+}
+
+$BlenderExe = Resolve-BlenderExecutable -Override $BlenderExecutable
+if ([string]::IsNullOrEmpty($BlenderExe)) {
+    $BlenderExe = Prompt-ForValue -ParameterName "BlenderExecutable" -Description "Path to Blender"
+    if ([string]::IsNullOrEmpty($BlenderExe)) {
+        Write-Error "Blender executable is required."; exit 1
+    }
+}
+if (-not (Test-Path $BlenderExe)) {
+    Write-Error "Blender executable not found: $BlenderExe"; exit 1
+}
+
+$PythonPath = Resolve-BlenderPython -Override $BlenderPython -BlenderExePath $BlenderExe
+if ([string]::IsNullOrEmpty($PythonPath)) {
+    Write-Error "Could not locate Blender's bundled Python under '$BlenderExe'. Pass -BlenderPython to override."
+    exit 1
+}
+if (-not (Test-Path $PythonPath)) {
+    Write-Error "Blender Python not found: $PythonPath"; exit 1
+}
+
+# Wheel auto-detect
+if ([string]::IsNullOrEmpty($WheelPath)) {
+    $distDir = Join-Path (Get-Location) "dist"
+    $defaultWheel = ""
+    if (Test-Path $distDir) {
+        $wheelFiles = Get-ChildItem -Path $distDir -Filter "deadline_cloud_for_blender-*.whl" -ErrorAction SilentlyContinue |
+                      Sort-Object LastWriteTime -Descending
+        if ($wheelFiles) { $defaultWheel = $wheelFiles[0].FullName }
+    }
+    $WheelPath = Prompt-ForValue -ParameterName "WheelPath" -Description "Path to wheel file" -DefaultValue $defaultWheel
+    if ([string]::IsNullOrEmpty($WheelPath)) {
+        Write-Error "No wheel file specified and none found in dist/. Build with 'hatch build' first."
+        exit 1
+    }
+}
+
+if (-not $PSBoundParameters.ContainsKey('PathMappingFile')) {
+    $PathMappingFile = Prompt-ForValue -ParameterName "PathMappingFile" -Description "Optional path to JSON path mapping file"
+}
+
+# Template + step selection
+$templateFile = Join-Path $JobBundleDir "template.yaml"
+if (-not (Test-Path $templateFile)) {
+    Write-Error "Template file not found: $templateFile"; exit 1
+}
+
+try {
+    Import-Module powershell-yaml -ErrorAction Stop
+} catch {
+    Write-Error "powershell-yaml module is required. Install with: Install-Module powershell-yaml -Scope CurrentUser -Force"
+    exit 1
+}
+
+$templateData = ConvertFrom-Yaml (Get-Content $templateFile -Raw)
+if (-not $templateData.steps -or $templateData.steps.Count -eq 0) {
+    Write-Error "No steps found in template file"; exit 1
+}
+
+if ($Step -lt 0) {
+    $Step = Prompt-ForStep -Steps $templateData.steps
+}
+
+Write-Host "`n=== Blender OpenJD Runner Testing Script ===" -ForegroundColor Green
+Write-Host "Blender:        $BlenderExe" -ForegroundColor Cyan
+Write-Host "Blender Python: $PythonPath" -ForegroundColor Cyan
+Write-Host "Wheel:          $WheelPath" -ForegroundColor Cyan
+Write-Host "JobBundle:      $JobBundleDir" -ForegroundColor Cyan
+Write-Host "Step:           $Step" -ForegroundColor Cyan
+
+# ------------------------------------------------------------------
+# Prerequisites
+# ------------------------------------------------------------------
+function Test-Prerequisites {
+    Write-Host "`n--- Checking Prerequisites ---" -ForegroundColor Yellow
+
+    if (-not (Test-Path $WheelPath)) {
+        Write-Error "Wheel file not found: $WheelPath"; return $false
+    }
+    Write-Host "Wheel file found" -ForegroundColor Green
+
+    if (-not (Test-Path $JobBundleDir)) {
+        Write-Error "Job bundle directory not found: $JobBundleDir"; return $false
+    }
+    Write-Host "Job bundle directory found" -ForegroundColor Green
+
+    Write-Host "Checking openjd-cli installation..." -ForegroundColor Gray
+    & $PythonPath -c "import openjd.cli" 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "openjd-cli not found in Blender Python, installing..." -ForegroundColor Yellow
+        & $PythonPath -m pip install openjd-cli
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to install openjd-cli"; return $false
+        }
+    }
+    Write-Host "openjd-cli is installed in Blender Python" -ForegroundColor Green
+
+    return $true
+}
+
+# ------------------------------------------------------------------
+# Setup environment
+# ------------------------------------------------------------------
+function Setup-Environment {
+    Write-Host "`n--- Setting Up Environment ---" -ForegroundColor Yellow
+
+    $repoPath = (Get-Location).Path
+    $submitterPath = Join-Path $repoPath "src/deadline/blender_submitter"
+    $srcPath = Join-Path $repoPath "src"
+    $pathSep = [System.IO.Path]::PathSeparator
+
+    # Prioritize Blender's Python and exe on PATH
+    $blenderPythonDir = Split-Path $PythonPath -Parent
+    $blenderExeDir = Split-Path $BlenderExe -Parent
+    Write-Host "Prepending Blender directories to PATH..." -ForegroundColor Gray
+    $env:PATH = "$blenderPythonDir$pathSep$blenderExeDir$pathSep$env:PATH"
+    Write-Host "  - Blender Python dir: $blenderPythonDir" -ForegroundColor Green
+    Write-Host "  - Blender exe dir:    $blenderExeDir" -ForegroundColor Green
+
+    if ([string]::IsNullOrEmpty($env:PYTHONPATH)) {
+        $env:PYTHONPATH = "$srcPath$pathSep$submitterPath"
+    } else {
+        $env:PYTHONPATH = "$srcPath$pathSep$submitterPath$pathSep$env:PYTHONPATH"
+    }
+    Write-Host "PYTHONPATH: $env:PYTHONPATH" -ForegroundColor Green
+
+    $env:BLENDER_EXECUTABLE = $BlenderExe
+    Write-Host "BLENDER_EXECUTABLE: $env:BLENDER_EXECUTABLE" -ForegroundColor Green
+
+    Write-Host "Note: Environment changes are temporary for this session only" -ForegroundColor Yellow
+    return $true
+}
+
+# ------------------------------------------------------------------
+# Install adaptor
+# ------------------------------------------------------------------
+function Install-Adaptor {
+    Write-Host "`n--- Installing Adaptor ---" -ForegroundColor Yellow
+    Write-Host "Running: $PythonPath -m pip install `"$WheelPath`" --force-reinstall --no-deps" -ForegroundColor Cyan
+    & $PythonPath -m pip install $WheelPath --force-reinstall --no-deps
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to install adaptor (exit code: $LASTEXITCODE)"
+        return $false
+    }
+    Write-Host "Adaptor installed into Blender's Python environment" -ForegroundColor Green
+    return $true
+}
+
+# ------------------------------------------------------------------
+# Expand frame specification
+# ------------------------------------------------------------------
+function Expand-Frames {
+    param([string]$Frames)
+    $result = @()
+    foreach ($part in $Frames.Split(',')) {
+        $p = $part.Trim()
+        if ($p -match '^(\d+)-(\d+)$') {
+            for ($f = [int]$Matches[1]; $f -le [int]$Matches[2]; $f++) { $result += $f }
+        } elseif ($p -match '^\d+$') {
+            $result += [int]$p
+        } else {
+            Write-Host "Warning: Unrecognized frame spec '$p', skipping" -ForegroundColor Yellow
+        }
+    }
+    if ($result.Count -eq 0) { $result = @(1) }
+    return $result
+}
+
+# ------------------------------------------------------------------
+# Build test command
+# ------------------------------------------------------------------
+function Build-TestCommand {
+    param(
+        [object]$TemplateData,
+        [int]$StepNumber
+    )
+    Write-Host "`n--- Building Test Command ---" -ForegroundColor Yellow
+
+    $paramFile = Join-Path $JobBundleDir "parameter_values.yaml"
+    if (-not (Test-Path $paramFile)) {
+        Write-Error "Parameter values file not found: $paramFile"; return $null
+    }
+
+    $yamlData = ConvertFrom-Yaml (Get-Content $paramFile -Raw)
+    $selectedStep = $TemplateData.steps[$StepNumber]
+    $stepName = $selectedStep.name
+    Write-Host "Selected step: $stepName" -ForegroundColor Green
+
+    $getValue = {
+        param($name)
+        $p = $yamlData.parameterValues | Where-Object { $_.name -eq $name }
+        if ($p) { return $p.value } else { return "" }
+    }
+
+    $frames = & $getValue "Frames"
+    if ([string]::IsNullOrEmpty($frames)) { $frames = "1" }
+    Write-Host "Frames parameter: $frames" -ForegroundColor Green
+
+    $defaultCamera = ""
+    if ($selectedStep.parameterSpace -and $selectedStep.parameterSpace.taskParameterDefinitions) {
+        $cameraParam = $selectedStep.parameterSpace.taskParameterDefinitions | Where-Object { $_.name -eq "Camera" }
+        if ($cameraParam -and $cameraParam.range -and $cameraParam.range.Count -gt 0) {
+            $defaultCamera = $cameraParam.range[0]
+        }
+    }
+    if ([string]::IsNullOrEmpty($defaultCamera)) {
+        $defaultCamera = & $getValue "Camera"
+    }
+    Write-Host "Using camera: $defaultCamera" -ForegroundColor Green
+
+    $taskParamTypes = @{}
+    if ($selectedStep.parameterSpace -and $selectedStep.parameterSpace.taskParameterDefinitions) {
+        foreach ($pd in $selectedStep.parameterSpace.taskParameterDefinitions) {
+            $taskParamTypes[$pd.name] = $pd.type
+        }
+    }
+
+    $frameList = Expand-Frames -Frames $frames
+    Write-Host "Expanded frames: $($frameList -join ', ')" -ForegroundColor Green
+
+    $taskParamsArray = @()
+    foreach ($frame in $frameList) {
+        $taskParams = [ordered]@{}
+        if ($taskParamTypes["Frame"] -eq "INT") {
+            $taskParams["Frame"] = [int]$frame
+        } else {
+            $taskParams["Frame"] = [string]$frame
+        }
+        if (-not [string]::IsNullOrEmpty($defaultCamera)) {
+            $taskParams["Camera"] = $defaultCamera
+        }
+        $taskParamsArray += $taskParams
+    }
+
+    # Build the set of parameter names declared in the template so we can drop
+    # queue-environment extras (Conda*, deadline:*) that openjd-cli rejects.
+    $declaredParams = @{}
+    if ($TemplateData.parameterDefinitions) {
+        foreach ($pd in $TemplateData.parameterDefinitions) {
+            $declaredParams[$pd.name] = $true
+        }
+    }
+
+    $filteredJobParams = [ordered]@{}
+    foreach ($param in $yamlData.parameterValues) {
+        if ($param.name.StartsWith("deadline:")) { continue }
+        if (-not $declaredParams.ContainsKey($param.name)) { continue }
+        $filteredJobParams[$param.name] = $param.value
+    }
+
+    $tempDir = [System.IO.Path]::GetTempPath()
+    $jobParamsFile  = Join-Path $tempDir "blender-job-params.json"
+    $taskParamsFile = Join-Path $tempDir "blender-task-params.json"
+    $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+
+    $jobParamsJson = $filteredJobParams | ConvertTo-Json -Compress -Depth 10
+    [System.IO.File]::WriteAllText($jobParamsFile, $jobParamsJson, $utf8NoBom)
+
+    if ($taskParamsArray.Count -eq 1) {
+        $taskParamsJson = "[" + ($taskParamsArray[0] | ConvertTo-Json -Compress -Depth 10) + "]"
+    } else {
+        $taskParamsJson = $taskParamsArray | ConvertTo-Json -Compress -Depth 10
+    }
+    [System.IO.File]::WriteAllText($taskParamsFile, $taskParamsJson, $utf8NoBom)
+
+    $jobParamsUri  = "file://" + ($jobParamsFile  -replace '\\', '/')
+    $taskParamsUri = "file://" + ($taskParamsFile -replace '\\', '/')
+
+    $cmdArgs = @(
+        "-m", "openjd", "run", $templateFile,
+        "--step", $stepName,
+        "--job-param", $jobParamsUri,
+        "--tasks", $taskParamsUri
+    )
+
+    if (-not [string]::IsNullOrEmpty($PathMappingFile)) {
+        if (-not (Test-Path $PathMappingFile)) {
+            Write-Error "Path mapping file not found: $PathMappingFile"; return $null
+        }
+        $absPathMapping = (Resolve-Path $PathMappingFile).Path
+        $pmUri = "file://" + ($absPathMapping -replace '\\', '/')
+        $cmdArgs += @("--path-mapping-rules", $pmUri)
+        Write-Host "`nPath Mapping Rules File: $absPathMapping" -ForegroundColor Yellow
+        Write-Host (Get-Content $PathMappingFile -Raw) -ForegroundColor Gray
+    }
+
+    Write-Host "`nJob Parameters JSON ($jobParamsFile):" -ForegroundColor Yellow
+    Write-Host $jobParamsJson -ForegroundColor Gray
+    Write-Host "`nTask Parameters JSON ($taskParamsFile):" -ForegroundColor Yellow
+    Write-Host $taskParamsJson -ForegroundColor Gray
+    Write-Host "Frames: $($frameList -join ', ')" -ForegroundColor Cyan
+    Write-Host "Camera: $defaultCamera" -ForegroundColor Cyan
+    Write-Host "`nTest Command:" -ForegroundColor Yellow
+    Write-Host "$PythonPath $($cmdArgs -join ' ')" -ForegroundColor White
+
+    $fullCommand = @($PythonPath) + $cmdArgs
+    return , $fullCommand
+}
+
+# ------------------------------------------------------------------
+# Run
+# ------------------------------------------------------------------
+function Run-Test {
+    param([string[]]$TestCommand)
+
+    Write-Host "`n--- Running Test ---" -ForegroundColor Yellow
+    $startTime = Get-Date
+    Write-Host "Started at: $startTime" -ForegroundColor Gray
+
+    $exe  = $TestCommand[0]
+    $rest = $TestCommand[1..($TestCommand.Length - 1)]
+
+    $capturedOutput = $null
+    if ($ShowOutput) {
+        & $exe @rest
+    } else {
+        $capturedOutput = & $exe @rest 2>&1
+    }
+    $exitCode = $LASTEXITCODE
+
+    $duration = (Get-Date) - $startTime
+    Write-Host "`nTest completed in $($duration.TotalSeconds) seconds (exit code: $exitCode)" -ForegroundColor Gray
+
+    if ($exitCode -eq 0) {
+        Write-Host "Test completed successfully!" -ForegroundColor Green
+        return $true
+    } else {
+        Write-Host "Test failed (exit code: $exitCode)" -ForegroundColor Red
+        if (-not $ShowOutput -and $capturedOutput) {
+            Write-Host "`nOutput:" -ForegroundColor Gray
+            $capturedOutput | ForEach-Object { Write-Host $_ -ForegroundColor Red }
+        }
+        return $false
+    }
+}
+
+# ------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------
+try {
+    if (-not (Test-Prerequisites)) { exit 1 }
+    if (-not (Setup-Environment))  { exit 1 }
+
+    if (-not $SkipInstall) {
+        if (-not (Install-Adaptor)) { exit 1 }
+    } else {
+        Write-Host "`n--- Skipping Installation ---" -ForegroundColor Yellow
+    }
+
+    $testCommand = Build-TestCommand -TemplateData $templateData -StepNumber $Step
+    if (-not $testCommand) { exit 1 }
+
+    $success = Run-Test -TestCommand $testCommand
+    if ($success) {
+        Write-Host "`nTest completed successfully!" -ForegroundColor Green
+        exit 0
+    } else {
+        Write-Host "`nTest failed. Check the output above for details." -ForegroundColor Red
+        exit 1
+    }
+} catch {
+    Write-Error "Unexpected error: $($_.Exception.Message)"
+    exit 1
+}

--- a/scripts/test-blender-openjd-run.sh
+++ b/scripts/test-blender-openjd-run.sh
@@ -1,0 +1,546 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Blender OpenJD Runner Testing Script (Bash)
+# Tests the deadline-cloud-for-blender adaptor via `openjd-cli run` against a job bundle template.
+# Uses Blender's bundled Python.
+#
+# Works on Linux, macOS, and Windows (via Git Bash / WSL).
+
+set -u
+
+# ------------------------------------------------------------------
+# Color helpers
+# ------------------------------------------------------------------
+if [ -t 1 ]; then
+    C_RESET=$'\033[0m'
+    C_RED=$'\033[31m'
+    C_GREEN=$'\033[32m'
+    C_YELLOW=$'\033[33m'
+    C_CYAN=$'\033[36m'
+    C_GRAY=$'\033[90m'
+else
+    C_RESET="" C_RED="" C_GREEN="" C_YELLOW="" C_CYAN="" C_GRAY=""
+fi
+
+info()    { printf "%s%s%s\n" "$C_CYAN"   "$*" "$C_RESET"; }
+ok()      { printf "%s%s%s\n" "$C_GREEN"  "$*" "$C_RESET"; }
+warn()    { printf "%s%s%s\n" "$C_YELLOW" "$*" "$C_RESET"; }
+err()     { printf "%s%s%s\n" "$C_RED"    "$*" "$C_RESET" >&2; }
+section() { printf "\n%s--- %s ---%s\n" "$C_YELLOW" "$*" "$C_RESET"; }
+gray()    { printf "%s%s%s\n" "$C_GRAY"   "$*" "$C_RESET"; }
+
+# ------------------------------------------------------------------
+# Defaults
+# ------------------------------------------------------------------
+JOB_BUNDLE_DIR=""
+WHEEL_PATH=""
+BLENDER_EXE=""
+BLENDER_PYTHON=""
+STEP=-1
+PATH_MAPPING_FILE=""
+PATH_MAPPING_PROVIDED=0
+SKIP_INSTALL=0
+SHOW_OUTPUT=0
+
+usage() {
+    cat <<EOF
+=== Blender OpenJD Runner Testing Script Help ===
+
+DESCRIPTION:
+  Tests the deadline-cloud-for-blender adaptor via 'openjd-cli run' against a job bundle template.
+  Uses Blender's bundled Python. Prompts interactively for any parameter not provided.
+  Runs on Linux, macOS, and Windows (via Git Bash / WSL).
+
+USAGE:
+  ./scripts/test-blender-openjd-run.sh [options]
+  ./scripts/test-blender-openjd-run.sh --job-bundle-dir test_bundle
+
+OPTIONS:
+  -j, --job-bundle-dir <dir>    Path to the job bundle directory (prompts if empty)
+  -w, --wheel-path <path>       Path to the wheel file (auto-detects dist/*.whl if omitted)
+  -b, --blender <path>          Path to the Blender executable
+  -p, --blender-python <path>   Path to Blender's bundled Python (derived from Blender install if omitted)
+  -s, --step <n>                Step index to run (shows list if not provided)
+  -m, --path-mapping-file <p>   Path to JSON file with path mapping rules (optional)
+      --skip-install            Skip wheel installation
+      --show-output             Show detailed output
+  -h, --help                    Show this help and exit
+
+PREREQUISITES:
+  - Blender installed (ships its own Python; no system Python required)
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -j|--job-bundle-dir)     JOB_BUNDLE_DIR="$2"; shift 2 ;;
+        --job-bundle-dir=*)      JOB_BUNDLE_DIR="${1#*=}"; shift ;;
+        -w|--wheel-path)         WHEEL_PATH="$2"; shift 2 ;;
+        --wheel-path=*)          WHEEL_PATH="${1#*=}"; shift ;;
+        -b|--blender|--blender-executable) BLENDER_EXE="$2"; shift 2 ;;
+        --blender=*|--blender-executable=*) BLENDER_EXE="${1#*=}"; shift ;;
+        -p|--blender-python)     BLENDER_PYTHON="$2"; shift 2 ;;
+        --blender-python=*)      BLENDER_PYTHON="${1#*=}"; shift ;;
+        -s|--step)               STEP="$2"; shift 2 ;;
+        --step=*)                STEP="${1#*=}"; shift ;;
+        -m|--path-mapping-file)  PATH_MAPPING_FILE="$2"; PATH_MAPPING_PROVIDED=1; shift 2 ;;
+        --path-mapping-file=*)   PATH_MAPPING_FILE="${1#*=}"; PATH_MAPPING_PROVIDED=1; shift ;;
+        --skip-install)          SKIP_INSTALL=1; shift ;;
+        --show-output)           SHOW_OUTPUT=1; shift ;;
+        -h|--help)               usage; exit 0 ;;
+        *) err "Unknown argument: $1"; usage; exit 1 ;;
+    esac
+done
+
+# ------------------------------------------------------------------
+# Interactive prompt helper
+# ------------------------------------------------------------------
+prompt_for_value() {
+    local name="$1" desc="$2" default="${3:-}"
+    local prompt="$name"
+    [ -n "$desc" ] && prompt="$prompt ($desc)"
+    [ -n "$default" ] && prompt="$prompt [default: $default]"
+    prompt="$prompt: "
+    printf "%s%s%s" "$C_CYAN" "$prompt" "$C_RESET" >&2
+    local val
+    IFS= read -r val
+    if [ -z "$val" ] && [ -n "$default" ]; then echo "$default"; else echo "$val"; fi
+}
+
+# ------------------------------------------------------------------
+# Resolve Blender executable
+# ------------------------------------------------------------------
+resolve_blender() {
+    if [ -n "$BLENDER_EXE" ]; then echo "$BLENDER_EXE"; return; fi
+    if [ -n "${BLENDER_EXECUTABLE:-}" ]; then echo "$BLENDER_EXECUTABLE"; return; fi
+    if command -v blender >/dev/null 2>&1; then command -v blender; return; fi
+    case "$(uname -s)" in
+        Darwin)
+            [ -x "/Applications/Blender.app/Contents/MacOS/Blender" ] \
+                && echo "/Applications/Blender.app/Contents/MacOS/Blender" && return ;;
+        Linux|*)
+            for p in /usr/bin/blender /usr/local/bin/blender /snap/bin/blender; do
+                [ -x "$p" ] && echo "$p" && return
+            done ;;
+    esac
+    if [ -d "/c/Program Files/Blender Foundation" ]; then
+        for dir in $(ls -1d "/c/Program Files/Blender Foundation"/* 2>/dev/null | sort -r); do
+            [ -x "$dir/blender.exe" ] && echo "$dir/blender.exe" && return
+        done
+    fi
+    echo ""
+}
+
+resolve_blender_python() {
+    local blender_exe="$1"
+    if [ -n "$BLENDER_PYTHON" ]; then echo "$BLENDER_PYTHON"; return; fi
+    if [ -z "$blender_exe" ] || [ ! -e "$blender_exe" ]; then echo ""; return; fi
+
+    local search_root
+    case "$(uname -s)" in
+        Darwin)
+            if [[ "$blender_exe" == *".app/Contents/MacOS/"* ]]; then
+                local app_root="${blender_exe%/Contents/MacOS/*}"
+                search_root="$app_root/Contents/Resources"
+            else
+                search_root="$(dirname "$blender_exe")"
+            fi
+            ;;
+        *)
+            search_root="$(dirname "$blender_exe")"
+            ;;
+    esac
+
+    if [ ! -d "$search_root" ]; then echo ""; return; fi
+
+    local dir python_bin exe
+    for dir in $(ls -1d "$search_root"/[0-9]*.[0-9]* 2>/dev/null | sort -rV); do
+        python_bin="$dir/python/bin"
+        if [ ! -d "$python_bin" ]; then continue; fi
+
+        case "$(uname -s)" in
+            CYGWIN*|MINGW*|MSYS*)
+                exe="$python_bin/python.exe"
+                [ -x "$exe" ] && { echo "$exe"; return; }
+                ;;
+            *)
+                exe="$(ls -1 "$python_bin"/python3.* 2>/dev/null | grep -E '/python3\.[0-9]+$' | sort -V | tail -n 1)"
+                if [ -n "$exe" ] && [ -x "$exe" ]; then echo "$exe"; return; fi
+                [ -x "$python_bin/python3" ] && { echo "$python_bin/python3"; return; }
+                [ -x "$python_bin/python" ] && { echo "$python_bin/python"; return; }
+                ;;
+        esac
+    done
+    echo ""
+}
+
+# ------------------------------------------------------------------
+# Interactive prompts
+# ------------------------------------------------------------------
+echo
+ok "=== Parameter Configuration ==="
+
+if [ -z "$JOB_BUNDLE_DIR" ]; then
+    JOB_BUNDLE_DIR="$(prompt_for_value "JobBundleDir" "Path to job bundle directory")"
+    [ -z "$JOB_BUNDLE_DIR" ] && { err "JobBundleDir is required."; exit 1; }
+fi
+[ -d "$JOB_BUNDLE_DIR" ] || { err "Job bundle directory not found: $JOB_BUNDLE_DIR"; exit 1; }
+
+BLENDER_EXE="$(resolve_blender)"
+if [ -z "$BLENDER_EXE" ]; then
+    BLENDER_EXE="$(prompt_for_value "BlenderExecutable" "Path to Blender")"
+    [ -z "$BLENDER_EXE" ] && { err "Blender executable is required."; exit 1; }
+fi
+[ -e "$BLENDER_EXE" ] || { err "Blender executable not found: $BLENDER_EXE"; exit 1; }
+
+PYTHON_PATH="$(resolve_blender_python "$BLENDER_EXE")"
+if [ -z "$PYTHON_PATH" ]; then
+    err "Could not locate Blender's bundled Python under '$BLENDER_EXE'. Pass --blender-python to override."
+    exit 1
+fi
+[ -x "$PYTHON_PATH" ] || { err "Blender Python not executable: $PYTHON_PATH"; exit 1; }
+
+# Ensure PyYAML is available in Blender Python
+if ! "$PYTHON_PATH" -c "import yaml" >/dev/null 2>&1; then
+    warn "PyYAML is not installed in Blender's Python. Installing..."
+    "$PYTHON_PATH" -m pip install pyyaml || { err "Failed to install PyYAML into Blender Python"; exit 1; }
+fi
+
+if [ -z "$WHEEL_PATH" ]; then
+    default_wheel="$(ls -t dist/deadline_cloud_for_blender-*.whl 2>/dev/null | head -n 1 || true)"
+    WHEEL_PATH="$(prompt_for_value "WheelPath" "Path to wheel file" "$default_wheel")"
+    if [ -z "$WHEEL_PATH" ]; then
+        err "No wheel file specified and none found in dist/. Build with 'hatch build' first."
+        exit 1
+    fi
+fi
+
+if [ "$PATH_MAPPING_PROVIDED" -eq 0 ]; then
+    PATH_MAPPING_FILE="$(prompt_for_value "PathMappingFile" "Optional path to JSON path mapping file")"
+fi
+
+# ------------------------------------------------------------------
+# Parse template to list steps (via Blender Python)
+# ------------------------------------------------------------------
+TEMPLATE_FILE="$JOB_BUNDLE_DIR/template.yaml"
+[ -f "$TEMPLATE_FILE" ] || { err "Template file not found: $TEMPLATE_FILE"; exit 1; }
+
+list_step_names() {
+    "$PYTHON_PATH" - "$TEMPLATE_FILE" <<'PYEOF'
+import sys, yaml
+with open(sys.argv[1]) as f:
+    t = yaml.safe_load(f) or {}
+for i, s in enumerate(t.get("steps") or []):
+    print(f"{i}\t{s.get('name')}")
+PYEOF
+}
+
+# Portable array population (works on bash 3.2 without mapfile)
+STEP_LINES=()
+while IFS= read -r line; do
+    STEP_LINES+=("$line")
+done < <(list_step_names)
+
+if [ ${#STEP_LINES[@]} -eq 0 ]; then
+    err "No steps found in template file"
+    exit 1
+fi
+
+if [ "$STEP" -lt 0 ]; then
+    section "Available steps"
+    for line in "${STEP_LINES[@]}"; do
+        idx="${line%%$'\t'*}"
+        name="${line#*$'\t'}"
+        info "  [$idx] $name"
+    done
+    max_idx=$((${#STEP_LINES[@]} - 1))
+    while true; do
+        printf "%sSelect step number [0-%d]: %s" "$C_CYAN" "$max_idx" "$C_RESET" >&2
+        IFS= read -r step_input
+        if [[ "$step_input" =~ ^[0-9]+$ ]] && [ "$step_input" -ge 0 ] && [ "$step_input" -le "$max_idx" ]; then
+            STEP="$step_input"
+            break
+        fi
+        err "Invalid selection."
+    done
+fi
+
+echo
+ok "=== Blender OpenJD Runner Testing Script ==="
+info "Blender:        $BLENDER_EXE"
+info "Blender Python: $PYTHON_PATH"
+info "Wheel:          $WHEEL_PATH"
+info "JobBundle:      $JOB_BUNDLE_DIR"
+info "Step:           $STEP"
+
+# ------------------------------------------------------------------
+# Prerequisites
+# ------------------------------------------------------------------
+check_prereqs() {
+    section "Checking Prerequisites"
+    [ -f "$WHEEL_PATH" ] || { err "Wheel file not found: $WHEEL_PATH"; return 1; }
+    ok "Wheel file found"
+    [ -d "$JOB_BUNDLE_DIR" ] || { err "Job bundle directory not found: $JOB_BUNDLE_DIR"; return 1; }
+    ok "Job bundle directory found"
+
+    gray "Checking openjd-cli installation..."
+    if ! "$PYTHON_PATH" -c "import openjd.cli" >/dev/null 2>&1; then
+        warn "openjd-cli not found in Blender Python, installing..."
+        "$PYTHON_PATH" -m pip install openjd-cli || { err "Failed to install openjd-cli"; return 1; }
+    fi
+    ok "openjd-cli is installed in Blender Python"
+
+    return 0
+}
+
+# ------------------------------------------------------------------
+# Setup environment
+# ------------------------------------------------------------------
+setup_env() {
+    section "Setting Up Environment"
+    local repo_path submitter_path src_path sep
+    repo_path="$(pwd)"
+    submitter_path="$repo_path/src/deadline/blender_submitter"
+    src_path="$repo_path/src"
+    sep=":"
+    case "$(uname -s)" in CYGWIN*|MINGW*|MSYS*) sep=";" ;; esac
+
+    local blender_python_dir blender_exe_dir
+    blender_python_dir="$(dirname "$PYTHON_PATH")"
+    blender_exe_dir="$(dirname "$BLENDER_EXE")"
+    gray "Prepending Blender directories to PATH..."
+    export PATH="$blender_python_dir:$blender_exe_dir:$PATH"
+    ok "  - Blender Python dir: $blender_python_dir"
+    ok "  - Blender exe dir:    $blender_exe_dir"
+
+    if [ -z "${PYTHONPATH:-}" ]; then
+        export PYTHONPATH="$src_path$sep$submitter_path"
+    else
+        export PYTHONPATH="$src_path$sep$submitter_path$sep$PYTHONPATH"
+    fi
+    ok "PYTHONPATH: $PYTHONPATH"
+
+    export BLENDER_EXECUTABLE="$BLENDER_EXE"
+    ok "BLENDER_EXECUTABLE: $BLENDER_EXECUTABLE"
+
+    warn "Note: Environment changes are temporary for this session only"
+    return 0
+}
+
+# ------------------------------------------------------------------
+# Install adaptor
+# ------------------------------------------------------------------
+install_adaptor() {
+    section "Installing Adaptor"
+    info "Running: $PYTHON_PATH -m pip install \"$WHEEL_PATH\" --force-reinstall --no-deps"
+    if "$PYTHON_PATH" -m pip install "$WHEEL_PATH" --force-reinstall --no-deps; then
+        ok "Adaptor installed into Blender's Python environment"
+        return 0
+    fi
+    err "Failed to install adaptor"
+    return 1
+}
+
+# ------------------------------------------------------------------
+# Build job-param / task-param JSON via Blender Python
+# ------------------------------------------------------------------
+build_params_via_python() {
+    local temp_dir
+    temp_dir="$(mktemp -d)"
+    local job_file="$temp_dir/blender-job-params.json"
+    local task_file="$temp_dir/blender-task-params.json"
+    local meta_file="$temp_dir/blender-meta.env"
+
+    "$PYTHON_PATH" - "$JOB_BUNDLE_DIR" "$STEP" "$job_file" "$task_file" "$meta_file" <<'PYEOF'
+import json, os, sys
+import yaml
+
+bundle_dir, step_str, job_out, task_out, meta_out = sys.argv[1:6]
+step_idx = int(step_str)
+
+def die(msg):
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+param_file = os.path.join(bundle_dir, "parameter_values.yaml")
+template_file = os.path.join(bundle_dir, "template.yaml")
+if not os.path.isfile(param_file):
+    die(f"parameter_values.yaml not found: {param_file}")
+if not os.path.isfile(template_file):
+    die(f"template.yaml not found: {template_file}")
+
+with open(param_file) as f:
+    params = yaml.safe_load(f) or {}
+with open(template_file) as f:
+    template = yaml.safe_load(f) or {}
+
+steps = template.get("steps") or []
+if step_idx < 0 or step_idx >= len(steps):
+    die(f"Step {step_idx} out of range (0..{len(steps)-1})")
+selected = steps[step_idx]
+
+pv = {p["name"]: p["value"] for p in (params.get("parameterValues") or [])}
+frames = str(pv.get("Frames", "1")).strip() or "1"
+
+# Set of parameter names actually declared in the template — used to filter out
+# queue-environment extras (Conda*, deadline:*) that the openjd CLI rejects.
+declared_params = {pd["name"] for pd in (template.get("parameterDefinitions") or [])}
+
+camera = ""
+pspace = selected.get("parameterSpace") or {}
+task_defs = pspace.get("taskParameterDefinitions") or []
+task_param_types = {pd["name"]: pd.get("type") for pd in task_defs}
+for pd in task_defs:
+    if pd.get("name") == "Camera":
+        rng = pd.get("range") or []
+        if rng:
+            camera = rng[0]
+            break
+if not camera:
+    camera = pv.get("Camera", "") or ""
+
+def expand(f):
+    out = []
+    for part in f.split(","):
+        part = part.strip()
+        if "-" in part:
+            try:
+                a, b = part.split("-", 1)
+                out.extend(range(int(a), int(b) + 1))
+            except ValueError:
+                pass
+        elif part.isdigit():
+            out.append(int(part))
+    return out or [1]
+
+frame_list = expand(frames)
+
+tasks = []
+for fr in frame_list:
+    t = {}
+    if task_param_types.get("Frame") == "INT":
+        t["Frame"] = int(fr)
+    else:
+        t["Frame"] = str(fr)
+    if camera:
+        t["Camera"] = camera
+    tasks.append(t)
+
+# Only pass parameters declared in the template; drops 'deadline:' and any
+# queue-environment-only values (e.g. Conda* from the Conda queue env).
+filtered = {
+    k: v for k, v in pv.items()
+    if k in declared_params and not str(k).startswith("deadline:")
+}
+
+with open(job_out, "w", encoding="utf-8") as f:
+    json.dump(filtered, f)
+with open(task_out, "w", encoding="utf-8") as f:
+    json.dump(tasks, f)
+
+step_name = selected.get("name") or ""
+with open(meta_out, "w", encoding="utf-8") as f:
+    f.write(f"STEP_NAME={step_name}\n")
+    f.write(f"CAMERA={camera}\n")
+    f.write(f"FRAME_LIST={','.join(str(x) for x in frame_list)}\n")
+PYEOF
+
+    local rc=$?
+    if [ $rc -ne 0 ]; then return $rc; fi
+
+    STEP_NAME="$(grep '^STEP_NAME=' "$meta_file" | head -n 1 | cut -d= -f2-)"
+    CAMERA="$(grep '^CAMERA=' "$meta_file" | head -n 1 | cut -d= -f2-)"
+    FRAME_LIST="$(grep '^FRAME_LIST=' "$meta_file" | head -n 1 | cut -d= -f2-)"
+
+    JOB_PARAMS_FILE="$job_file"
+    TASK_PARAMS_FILE="$task_file"
+    return 0
+}
+
+# ------------------------------------------------------------------
+# Build and run test
+# ------------------------------------------------------------------
+build_and_run() {
+    section "Building Test Command"
+
+    if ! build_params_via_python; then
+        err "Failed to prepare job/task parameters"
+        return 1
+    fi
+
+    info "Selected step: $STEP_NAME"
+    info "Camera: $CAMERA"
+    info "Frames: $FRAME_LIST"
+    info "Job Parameters JSON ($JOB_PARAMS_FILE):"
+    gray "$(cat "$JOB_PARAMS_FILE")"
+    info "Task Parameters JSON ($TASK_PARAMS_FILE):"
+    gray "$(cat "$TASK_PARAMS_FILE")"
+
+    local job_uri="file://${JOB_PARAMS_FILE//\\/\/}"
+    local task_uri="file://${TASK_PARAMS_FILE//\\/\/}"
+
+    local -a cmd=(
+        "$PYTHON_PATH" -m openjd run "$TEMPLATE_FILE"
+        --step "$STEP_NAME"
+        --job-param "$job_uri"
+        --tasks "$task_uri"
+    )
+
+    if [ -n "$PATH_MAPPING_FILE" ]; then
+        if [ ! -f "$PATH_MAPPING_FILE" ]; then
+            err "Path mapping file not found: $PATH_MAPPING_FILE"
+            return 1
+        fi
+        local abs_pm
+        abs_pm="$("$PYTHON_PATH" -c "import os,sys; print(os.path.abspath(sys.argv[1]))" "$PATH_MAPPING_FILE")"
+        local pm_uri="file://${abs_pm//\\/\/}"
+        cmd+=(--path-mapping-rules "$pm_uri")
+        info "Path Mapping Rules File: $abs_pm"
+        gray "$(cat "$PATH_MAPPING_FILE")"
+    fi
+
+    info "Test Command: ${cmd[*]}"
+
+    section "Running Test"
+    local start_ts end_ts duration exit_code
+    start_ts=$(date +%s)
+
+    if [ $SHOW_OUTPUT -eq 1 ]; then
+        "${cmd[@]}"
+        exit_code=$?
+    else
+        local tmp_out
+        tmp_out="$(mktemp)"
+        "${cmd[@]}" >"$tmp_out" 2>&1
+        exit_code=$?
+        if [ $exit_code -ne 0 ]; then
+            err "Output:"
+            cat "$tmp_out"
+        fi
+        rm -f "$tmp_out"
+    fi
+
+    end_ts=$(date +%s)
+    duration=$((end_ts - start_ts))
+    gray "Test completed in ${duration}s (exit code: $exit_code)"
+
+    if [ $exit_code -eq 0 ]; then
+        ok "Test completed successfully!"
+        return 0
+    fi
+    err "Test failed"
+    return 1
+}
+
+# ------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------
+check_prereqs || exit 1
+setup_env || exit 1
+if [ $SKIP_INSTALL -eq 0 ]; then
+    install_adaptor || exit 1
+else
+    section "Skipping Installation"
+fi
+build_and_run


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When iterating on the Blender adaptor or a job template, there is no quick way to test an adaptor build against a job bundle without running a full worker agent setup. The 3ds Max repository has two PowerShell scripts for this purpose (`test-3dsmax-adapter-run.ps1` and `test-3dsmax-openjd-run.ps1`), but they are Windows-only and there is no equivalent for Blender. This forces Blender adaptor developers to either spin up a worker agent for every test or hand-craft the init-data / run-data / openjd invocations manually.

### What was the solution? (How)

Port the two 3ds Max testing scripts to the Blender repository with cross-platform support. Each flow is provided as both a PowerShell (`.ps1`) script and a Bash (`.sh`) script so users can run on any of Linux, macOS, or Windows.

 - scripts/test-blender-adapter-run.{sh,ps1}
    Invokes the adaptor directly via `blender-openjd run` with init-data and run-data derived from the job bundle. Renders only the first frame; useful as a quick smoke test of the init/run/stop flow.

- scripts/test-blender-openjd-run.{sh,ps1}
    Invokes `openjd run` against the job bundle template with the full frame list expanded into per-task parameters; exercises the daemon-mode start/run/stop sequence end-to-end through the real template.

Both scripts:
- Resolve the Blender executable from `--blender`, `BLENDER_EXECUTABLE`, the PATH, or platform-specific default install locations.
- Derive Blender's bundled Python from the Blender install (`<install>/<X.Y>/python/bin/...`) and install the adaptor wheel into it, mirroring the 3ds Max pattern of targeting the DCC's own Python.
- Parse `parameter_values.yaml` and `template.yaml` (PyYAML for bash, powershell-yaml for pwsh), merging template `parameterDefinitions` defaults with explicit values so sparse bundles still produce valid init data.
- Strip `deadline:` scoped parameters and any queue-environment parameters (e.g. `CondaPackages`, `CondaChannels`, `NamedCondaEnv*`) that are not declared in the template's `parameterDefinitions`, avoiding `openjd run` rejection for unknown job parameters.
- Honour declared task parameter types (INT Frame vs STRING Frame).
- Support `--path-mapping-file` for path mapping rules.

### What is the impact of this change?

Blender adaptor developers can now smoke-test an adaptor build against any job bundle in under two minutes, on any platform, without a worker agent. No production code paths are affected.

### How was this change tested?

Verified end-to-end on macOS against a real customer bundle (BMW27.blend, Cycles + Metal, 1280x720):

- `test-blender-adapter-run.sh` rendered frame 1 in 67s (exit 0).
- `test-blender-openjd-run.sh` rendered frames 1-2 in 93s through a full OpenJD session (`Chunks run: 2`, exit 0).

#### Please run the integration tests and paste the results below

N/A — the existing integration suite is unaffected. The new scripts are developer tooling under `scripts/` and are not imported by the adaptor or submitter.

### Was this change documented?

No

### Is this a breaking change?

No. Pure addition of new developer-tooling scripts.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
