### PR TITLE
chore: refresh GPU submitter test fixture

### DIFF
--- a/test/integ/test_scripts/gpu_test/expected_job_bundle/template.yaml
+++ b/test/integ/test_scripts/gpu_test/expected_job_bundle/template.yaml
@@ -1,5 +1,5 @@
 specificationVersion: jobtemplate-2023-09
-name: test
+name: car-gpu-test
 description: host_test
 parameterDefinitions:
 - name: BlenderFile
@@ -118,7 +118,7 @@ parameterDefinitions:
   minValue: 1
   description: The image height.
 steps:
-- name: ViewLayer_001
+- name: RenderLayer
   parameterSpace:
     taskParameterDefinitions:
     - name: Frame


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The `expected_job_bundle/template.yaml` fixture in `test/integ/test_scripts/gpu_test/` was committed in #327 with placeholder values (`name: test`, step `name: ViewLayer_001`) that never matched what the submitter actually generates. This was hidden because `test_gpu_scene_submitter` only ran schema validation. When PR XYZ added strict template comparison, the mismatch surfaced as a test failure.


### What was the solution? (How)
Regenerated the fixture from the actual submitter output for `car-gpu-test.blend`. The submitter now generates identical templates across all Blender versions, so a single fixture works for all supported versions.


### What is the impact of this change?
GPU submitter integration test now passes. No production behavior change.


### How was this change tested?
Ran `hatch run integ:test_gpu` locally and passed
```
wyongzhi@842f5739fe21 deadline-cloud-for-blender % hatch run integ:test_gpu
================================================================================ test session starts ================================================================================
platform darwin -- Python 3.12.12, pytest-8.4.2, pluggy-1.6.0 -- /Users/wyongzhi/Library/Application Support/hatch/env/virtual/deadline-cloud-for-blender/8yFr5ikC/integ/bin/python
cachedir: .pytest_cache
rootdir: /Volumes/workplace/test/deadline-cloud-for-blender
configfile: pyproject.toml
plugins: cov-7.1.0, xdist-3.8.0
1 worker [2 items]     
scheduling tests via LoadScheduling

test/integ/test_blender_adaptors.py::TestAdaptors::test_gpu_scene_adaptor 
[gw0] [ 50%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_gpu_scene_adaptor 
test/integ/test_blender_submitters.py::TestSubmitters::test_gpu_scene_submitter 
[gw0] [100%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_gpu_scene_submitter 

================================================================================ slowest 5 durations ================================================================================
193.81s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_gpu_scene_adaptor
2.30s call     test/integ/test_blender_submitters.py::TestSubmitters::test_gpu_scene_submitter
0.46s setup    test/integ/test_blender_adaptors.py::TestAdaptors::test_gpu_scene_adaptor
0.00s setup    test/integ/test_blender_submitters.py::TestSubmitters::test_gpu_scene_submitter
0.00s teardown test/integ/test_blender_adaptors.py::TestAdaptors::test_gpu_scene_adaptor
=========================================================================== 2 passed in 197.23s (0:03:17) ===========================================================================
```


#### Please run the integration tests and paste the results below
```
wyongzhi@842f5739fe21 deadline-cloud-for-blender % hatch run integ:test
================================================================================ test session starts ================================================================================
platform darwin -- Python 3.12.12, pytest-8.4.2, pluggy-1.6.0 -- /Users/wyongzhi/Library/Application Support/hatch/env/virtual/deadline-cloud-for-blender/8yFr5ikC/integ/bin/python
cachedir: .pytest_cache
rootdir: /Volumes/workplace/test/deadline-cloud-for-blender
configfile: pyproject.toml
plugins: cov-7.1.0, xdist-3.8.0
1 worker [8 items]     
scheduling tests via LoadScheduling

test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_start_and_close_blender 
[gw0] [ 12%] PASSED test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_start_and_close_blender 
test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_cancel_closes_blender 
[gw0] [ 25%] PASSED test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_cancel_closes_blender 
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
[gw0] [ 37%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor 
[gw0] [ 50%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor 
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter 
[gw0] [ 62%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter 
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter 
[gw0] [ 75%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter 
test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_start_and_stop 
[gw0] [ 87%] PASSED test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_start_and_stop 
test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_run_command 
[gw0] [100%] PASSED test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_run_command 

================================================================================ slowest 5 durations ================================================================================
27.81s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
10.57s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
9.15s call     test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_run_command
8.09s call     test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_start_and_stop
4.21s call     test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_start_and_close_blender
=========================================================================== 8 passed in 76.16s (0:01:16) ============================================================================

```

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below
Nothing changed under this folder

### Was this change documented?
Not applicable — internal test fixture only.

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*