### PR TITLE
feat: enable deadline-cloud-v2 conda channel in submitter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,13 +35,13 @@ classifiers = [
 # Blender 5.1+ uses Python version 3.13
 
 dependencies = [
-    "deadline >= 0.55.1,< 0.58",
+    "deadline >= 0.59.0,< 0.60",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
 ]
 
 [project.optional-dependencies]
 gui = [
-    "deadline[gui] >= 0.54,< 0.58",
+    "deadline[gui] >= 0.59.0,< 0.60",
 ]
 
 [project.urls]

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
@@ -131,6 +131,7 @@ def create_deadline_dialog(parent=None) -> SubmitJobToDeadlineDialog:
         f=Qt.WindowType.Tool,
         show_host_requirements_tab=True,
         submitter_info=submitter_info,
+        use_deadline_cloud_v2_channel=True,
     )
     dialog.setWindowFlags(Qt.WindowType.WindowStaysOnTopHint)
     return dialog


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Deadline Cloud is migrating its service-managed Conda channel from `deadline-cloud` to `deadline-cloud-v2`. The Blender submitter should adopt the `v2` channel so that jobs resolve packages from `deadline-cloud-v2` (while still falling back to `deadline-cloud` for anything not yet hosted on `v2`). The actual channel rewrite is shared logic that belongs in the `deadline-cloud` library, not in this submitter; this change is the Blender side that opts into it.

Related changes: https://github.com/aws-deadline/deadline-cloud/pull/1211


### What was the solution? (How)
- Pass `use_deadline_cloud_v2_channel=True` when constructing `SubmitJobToDeadlineDialog` in `_show_submitter`. This is a new opt-in flag added to the `deadline-cloud` library: when enabled, the library prepends `deadline-cloud-v2` ahead of `deadline-cloud` in the `CondaChannels` queue parameter as it loads (token-level, order-preserving, idempotent). The submitter itself contains no channel-name logic.
- Bump the `deadline[gui]` dependency from `>= 0.55.1, < 0.59` to `>= 0.59, < 0.60`, since the `use_deadline_cloud_v2_channel` argument is only available in deadline-cloud `0.59+`.

### What is the impact of this change?
- GUI submissions from the Blender submitter now prepend `deadline-cloud-v2` ahead of `deadline-cloud` in the `CondaChannels` queue parameter, with `deadline-cloud` retained as a fallback. Customized channels on the queue are left untouched.
- Requires `deadline-cloud` 0.59 or newer. The dependency bump is the only thing that gates upgrades.
- No change to the adaptor, its init-data/run-data, or the job template structure.

### How was this change tested?

<img width="541" height="679" alt="Screenshot 2026-06-18 at 2 30 23 PM" src="https://github.com/user-attachments/assets/9ab7b35a-09db-4d52-b505-dca3ea650fb8" />


#### Please run the integration tests and paste the results below
```
scheduling tests via LoadScheduling

test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_start_and_close_blender 
[gw0] [ 10%] PASSED test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_start_and_close_blender 
test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_cancel_closes_blender 
[gw0] [ 20%] PASSED test/integ/test_adaptor_lifecycle.py::TestAdaptorLifecycle::test_adaptor_cancel_closes_blender 
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
[gw0] [ 30%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor 
[gw0] [ 40%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor 
test/integ/test_blender_adaptors.py::TestAdaptors::test_gpu_scene_adaptor 
[gw0] [ 50%] PASSED test/integ/test_blender_adaptors.py::TestAdaptors::test_gpu_scene_adaptor 
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter 
[gw0] [ 60%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter 
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter 
[gw0] [ 70%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter 
test/integ/test_blender_submitters.py::TestSubmitters::test_gpu_scene_submitter 
[gw0] [ 80%] PASSED test/integ/test_blender_submitters.py::TestSubmitters::test_gpu_scene_submitter 
test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_start_and_stop 
[gw0] [ 90%] PASSED test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_start_and_stop 
test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_run_command 
[gw0] [100%] PASSED test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_run_command 

================================================================================ slowest 5 durations ================================================================================
34.24s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
11.72s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_gpu_scene_adaptor
11.22s call     test/integ/test_blender_adaptors.py::TestAdaptors::test_minimal_scene_with_host_requirements_adaptor
10.06s call     test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_run_command
8.34s call     test/integ/test_daemon_mode.py::TestDaemonMode::test_daemon_start_and_stop
========================================================================== 10 passed in 101.43s (0:01:41) ===========================================================================

```

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below
N/A

### Was this change documented?
No documentation changes are required. No Python function signatures in this repository changed (only a call-site argument was added), the adaptor init-data/run-data schemas are unaffected, and there are no user-facing CLI or README changes.

### Is this a breaking change?
No. This is a backward-compatible change: it adds an opt-in argument at a call site and raises the minimum `deadline-cloud` version. The adaptor interface, init-data, and run-data are unchanged, so jobs submitted by older submitter versions continue to work with the adaptor.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*