### PR TITLE
feat: implement BlenderSubmitter on the unified BaseSubmitter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,13 +35,16 @@ classifiers = [
 # Blender 5.1+ uses Python version 3.13
 
 dependencies = [
-    "deadline >= 0.60.1,< 0.61",
+    # BaseSubmitter/BaseSubmitterSettings (the unified submitter contract this
+    # package builds on) first ship in deadline 0.60.2; 0.60.0/0.60.1 lack them
+    # and would fail at import. Floor must be 0.60.2.
+    "deadline >= 0.60.2,< 0.61",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
 ]
 
 [project.optional-dependencies]
 gui = [
-    "deadline[gui] >= 0.60.1,< 0.61",
+    "deadline[gui] >= 0.60.2,< 0.61",
 ]
 
 [project.urls]

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/blender_utils.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/blender_utils.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 
 import bpy
+from deadline.client.exceptions import DeadlineOperationError
 
 _logger = logging.getLogger(__name__)
 
@@ -17,21 +18,20 @@ def get_renderable_view_layers(saved_scene_name) -> list[str]:
     during rendering.
 
     Args:
-        saved_scene_name: The name of the scene.
+        saved_scene_name: The name of the scene (a key in ``bpy.data.scenes``).
     """
-    scene_name = bpy.data.scenes[saved_scene_name].name
-    layers = [layer.name for layer in bpy.data.scenes[scene_name].view_layers if layer.use]
-    return layers
+    scene = bpy.data.scenes[saved_scene_name]
+    return [layer.name for layer in scene.view_layers if layer.use]
 
 
 def get_renderable_cameras(saved_scene_name) -> list[str]:
     """Returns a list of all camera objects in the scene that are marked as renderable.
 
     Args:
-        saved_scene_name: The name of the scene.
+        saved_scene_name: The name of the scene (a key in ``bpy.data.scenes``).
     """
-    scene_name = bpy.data.scenes[saved_scene_name].name
-    camera_names = [cam.name for cam in bpy.data.scenes[scene_name].objects if cam.type == "CAMERA"]
+    scene = bpy.data.scenes[saved_scene_name]
+    camera_names = [obj.name for obj in scene.objects if obj.type == "CAMERA"]
     return [cam for cam in camera_names if not bpy.data.objects[cam].hide_render]
 
 
@@ -53,9 +53,29 @@ def get_scene_resolution(saved_scene_name):
 
 
 def get_scene_name() -> str:
-    """Construct and return a name for the current scene based on the currently opened `.blend` file."""
+    """Construct and return a name for the current scene based on the currently opened `.blend` file.
+
+    The dialog submitter uses this as the default *job* name
+    (``open_deadline_cloud_dialog.py``), so it must stay derived from the
+    ``.blend`` file name. Callers that need the active scene's name as a
+    ``bpy.data.scenes`` key (e.g. the unified ``BlenderSubmitter`` path) must
+    use ``get_active_scene_name()`` instead.
+    """
     scene_name = bpy.path.basename(bpy.context.blend_data.filepath).replace(".blend", "")
     return scene_name
+
+
+def get_active_scene_name() -> str:
+    """Return the name of the active Blender scene.
+
+    This is an actual key in ``bpy.data.scenes`` (unlike ``get_scene_name()``,
+    which derives a label from the ``.blend`` file name). Callers that index
+    ``bpy.data.scenes`` — e.g. ``get_renderable_view_layers`` /
+    ``get_renderable_cameras`` — must use this, since the active scene is not
+    necessarily named identically to the file (the default scene is ``"Scene"``),
+    which would otherwise raise a KeyError during job-template construction.
+    """
+    return bpy.context.scene.name
 
 
 def get_frames() -> str:
@@ -63,6 +83,117 @@ def get_frames() -> str:
     start = bpy.context.scene.frame_start
     end = bpy.context.scene.frame_end
     return str(start) + "-" + str(end)
+
+
+# Maps Blender's internal engine id (e.g. "BLENDER_EEVEE", "CYCLES") to the
+# render-engine names the job template's RenderEngine parameter allows
+# ("eevee"/"cycles"/"workbench"). Emitting the raw "blender_eevee" id fails
+# CreateJob with a ValidationException.
+_RENDER_ENGINE_MAP = {
+    "BLENDER_EEVEE": "eevee",
+    "BLENDER_EEVEE_NEXT": "eevee",
+    "CYCLES": "cycles",
+    "BLENDER_WORKBENCH": "workbench",
+}
+
+
+def get_render_engine() -> str:
+    """Return the active scene's render engine as a template RenderEngine value.
+
+    Shared by the GUI submitter and the unified API path so both map Blender's
+    internal engine id to the template's allowed values identically.
+
+    Raises:
+        DeadlineOperationError: If the active engine is not one of the built-in
+            engines the job template supports (Cycles / EEVEE / Workbench).
+            Third-party engines (V-Ray, Octane, Redshift, …) would otherwise be
+            forwarded as an out-of-range ``RenderEngine`` value that CreateJob
+            rejects with an opaque ValidationException, so fail early with an
+            actionable message instead.
+    """
+    engine = bpy.context.scene.render.engine
+    if engine not in _RENDER_ENGINE_MAP:
+        raise DeadlineOperationError(
+            f"Render engine '{engine}' is not supported. Switch the scene's render "
+            "engine to Cycles, EEVEE, or Workbench before submitting."
+        )
+    return _RENDER_ENGINE_MAP[engine]
+
+
+def resolve_output_path() -> str:
+    """Return the render output *directory* for the active scene.
+
+    The OutputDir job parameter is type PATH / objectType DIRECTORY, so this
+    must be a directory (``scene.render.filepath`` is a directory + filename
+    prefix, e.g. ``//render/frame_``). Falls back, in order, to:
+
+    1. the directory of ``scene.render.filepath`` (if it has a directory part),
+    2. the Preferences "render output directory", then
+    3. the directory containing the ``.blend`` file.
+
+    Shared by the GUI submitter and the unified API path so both resolve the
+    output directory (and its fallbacks) identically.
+    """
+    render_filepath = bpy.context.scene.render.filepath
+    if os.path.dirname(render_filepath):
+        return os.path.dirname(bpy.path.abspath(render_filepath))
+    if bpy.context.preferences.filepaths.render_output_directory:
+        return bpy.context.preferences.filepaths.render_output_directory
+    return os.path.dirname(bpy.context.blend_data.filepath)
+
+
+def resolve_output_file_prefix() -> str:
+    """Return the output filename prefix from ``scene.render.filepath``.
+
+    Empty when the scene's render filepath has no filename part (the caller
+    keeps its own default in that case). Shared by both submission flows.
+    """
+    return bpy.path.basename(bpy.context.scene.render.filepath)
+
+
+def resolve_gpu_settings() -> tuple[bool, str]:
+    """Return ``(enable_gpu, gpu_device)`` read from the scene/preferences.
+
+    ``gpu_device`` defaults to the ``"NONE"`` sentinel (uppercase) — matching
+    ``default_blender_template.yaml`` and the adaptor's ``CyclesHandler`` check
+    — and is set to the Cycles ``compute_device_type`` only when the scene is
+    actually rendering on GPU (``scene.cycles.device == "GPU"``).
+
+    The ``compute_device_type`` preference persists independently of the scene's
+    render device, so gating on ``enable_gpu`` here keeps ``gpu_device`` at
+    ``"NONE"`` for a CPU scene even when a GPU device type is selected in
+    Preferences — mirroring ``scene_settings_widget.update_settings`` so the GUI
+    and unified API paths enable GPU rendering identically.
+    """
+    enable_gpu = bpy.context.scene.cycles.device == "GPU"
+    gpu_device = "NONE"
+    if enable_gpu:
+        compute_device_type = bpy.context.preferences.addons[
+            "cycles"
+        ].preferences.compute_device_type
+        if compute_device_type != "NONE":
+            gpu_device = compute_device_type
+    return enable_gpu, gpu_device
+
+
+def classify_auto_detected_paths(project_path) -> tuple[set[str], set[str]]:
+    """Auto-detect external dependencies and split them into files/directories.
+
+    Runs :func:`find_files` for ``project_path`` and classifies each result as
+    an input filename or input directory. Shared by the GUI submitter and the
+    unified API path so both attach the same auto-detected assets.
+
+    Returns:
+        A ``(input_filenames, input_directories)`` tuple of string sets.
+    """
+    input_filenames: set[str] = set()
+    input_directories: set[str] = set()
+    for f in find_files(project_path):
+        if f.is_dir():
+            input_directories.add(str(f))
+        else:
+            input_filenames.add(str(f))
+    return input_filenames, input_directories
 
 
 def find_files(project_path, skip_temp=True, skip_nonexistent=True) -> list[Path]:

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/ocio_utils.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/ocio_utils.py
@@ -14,19 +14,43 @@ def get_ocio_config(filename: str) -> ocio.Config:
     return ocio.Config.CreateFromFile(filename)
 
 
-def get_ocio_referenced_dirs(config: ocio.Config) -> list[str]:
+def get_ocio_referenced_dirs(config: ocio.Config, config_path: str = "") -> list[str]:
     """
     Given an OCIO Config object, parse its `search_path` attribute and
     return a list of referenced directories.
+
+    Relative search paths are resolved against ``config_path``'s directory (the
+    directory of the config file the search paths belong to), falling back to
+    the active ``$OCIO`` config directory when ``config_path`` is not given.
     """
+    base_dir = os.path.dirname(config_path or get_ocio_path())
 
     path_list = []
     if config.getSearchPath():
         for path in config.getSearchPaths():
             # Paths may be absolute or relative to the config file.
             if not Path(path).is_absolute():
-                path = Path.joinpath(Path(os.path.dirname(get_ocio_path())), path)
+                path = Path.joinpath(Path(base_dir), path)
 
             path_list.append(path)
 
     return path_list
+
+
+def get_current_ocio_referenced_dirs(ocio_path: str = "") -> list[str]:
+    """Return the directories referenced by an OCIO config, if any.
+
+    Reads the OCIO config at ``ocio_path`` (defaulting to the active config via
+    the ``OCIO`` env var when not given) and returns the directories it
+    references, so they can be added as job input attachments. Empty when no
+    OCIO config is set. Shared by the GUI submitter and the unified API path so
+    both attach the same OCIO-referenced directories.
+    """
+    ocio_path = ocio_path or get_ocio_path()
+    if not ocio_path:
+        return []
+    config = get_ocio_config(ocio_path)
+    # Resolve relative search paths against this config's own directory, not
+    # necessarily the $OCIO one (they can differ when a caller passes an
+    # explicit ocio_path).
+    return [str(path) for path in get_ocio_referenced_dirs(config, ocio_path)]

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py
@@ -1,8 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-import os
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import bpy
 from qtpy.QtCore import Qt  # type: ignore
@@ -29,6 +28,7 @@ from . import sanity_checks as sc
 from . import scene_settings_widget as ssw
 from . import template_filling as tf
 from . import ocio_utils as ocio
+from .submitter import BlenderSubmitter, BlenderSubmitterSettings
 from ._version import version
 from ._version import version_tuple as adaptor_version_tuple
 
@@ -75,26 +75,14 @@ def create_deadline_dialog(parent=None) -> SubmitJobToDeadlineDialog:
     settings.project_path = bpy.context.blend_data.filepath
     settings.frame_list = bu.get_frames()
 
-    # For the output path, first check for a value in the Scene settings
-    if os.path.dirname(bpy.context.scene.render.filepath):
-        settings.output_path = os.path.dirname(bpy.path.abspath(bpy.context.scene.render.filepath))
-    # If none, use the one in Preferences
-    elif bpy.context.preferences.filepaths.render_output_directory:
-        settings.output_path = bpy.context.preferences.filepaths.render_output_directory
-    # If neither of these are set, use the job bundle directory by default
-    else:
-        settings.output_path = os.path.dirname(bpy.context.blend_data.filepath)
+    # Resolve the output directory + filename prefix via the shared helpers so
+    # the GUI and the unified API path stay in lock-step.
+    settings.output_path = bu.resolve_output_path()
+    if bu.resolve_output_file_prefix():
+        settings.output_file_prefix = bu.resolve_output_file_prefix()
 
-    if bpy.path.basename(bpy.context.scene.render.filepath):
-        settings.output_file_prefix = bpy.path.basename(bpy.context.scene.render.filepath)
-
-    # Read the user's preferences to set GPU settings.
-    settings.enable_gpu = bpy.context.scene.cycles.device == "GPU"
-
-    if bpy.context.preferences.addons["cycles"].preferences.compute_device_type != "NONE":
-        settings.gpu_device = bpy.context.preferences.addons[
-            "cycles"
-        ].preferences.compute_device_type
+    # Read GPU settings from the scene/preferences (shared helper).
+    settings.enable_gpu, settings.gpu_device = bu.resolve_gpu_settings()
 
     # Load and set sticky settings, if any.
     settings.load_sticky_settings(settings.project_path)
@@ -105,11 +93,10 @@ def create_deadline_dialog(parent=None) -> SubmitJobToDeadlineDialog:
     # Set auto-detected attachments.
     auto_detected_attachments = _get_auto_detected_assets(settings.project_path)
 
-    # If the user has an OCIO config file set, we will have to upload any directories referenced by that file as job attachments.
-    if ocio.get_ocio_path():
-        ocio_config = ocio.get_ocio_config(ocio.get_ocio_path())
-        for path in ocio.get_ocio_referenced_dirs(ocio_config):
-            auto_detected_attachments.input_directories.add(str(path))
+    # Add the directories referenced by a custom OCIO config (shared helper) as
+    # job attachments, so custom color management resolves on the farm.
+    for path in ocio.get_current_ocio_referenced_dirs():
+        auto_detected_attachments.input_directories.add(path)
 
     # Set regular attachments.
     attachments = AssetReferences(
@@ -210,6 +197,47 @@ def _create_bundle(
     )
 
 
+def _ui_settings_to_submitter_settings(
+    settings: tf.BlenderSubmitterUISettings,
+) -> BlenderSubmitterSettings:
+    """Adapt the GUI's BlenderSubmitterUISettings to the headless BlenderSubmitterSettings.
+
+    The GUI binds its Qt widgets to BlenderSubmitterUISettings, while the
+    builders now consume BlenderSubmitterSettings (the unified engine's shape),
+    so we convert at the submission boundary — the mirror of the old
+    ``_to_native_settings``. This is the single adaptation point; both the GUI
+    and the unified API path then run the same BlenderSubmitter builders.
+
+    The effective frame range is resolved here (override -> the user's range,
+    otherwise the scene range) so the engine sees a ready-to-use ``frame_list``.
+    """
+    frame_list = settings.frame_list if settings.override_frame_range else bu.get_frames()
+    width, height = bpy.context.scene.render.resolution_x, bpy.context.scene.render.resolution_y
+
+    return BlenderSubmitterSettings(
+        job_name=settings.name,
+        description=settings.description,
+        frame_list=frame_list,
+        project_path=settings.project_path,
+        output_path=settings.output_path,
+        override_frame_range=settings.override_frame_range,
+        input_filenames=list(settings.input_filenames),
+        input_directories=list(settings.input_directories),
+        output_directories=list(settings.output_directories),
+        renderer_name=settings.renderer_name,
+        scene_name=settings.scene_name,
+        view_layer_selection=settings.view_layer_selection,
+        camera_selection=settings.camera_selection,
+        image_width=width,
+        image_height=height,
+        output_file_prefix=settings.output_file_prefix,
+        enable_gpu=settings.enable_gpu,
+        gpu_device=settings.gpu_device,
+        ocio_config_path=settings.ocio_config_path,
+        include_adaptor_wheels=settings.include_adaptor_wheels,
+    )
+
+
 def _create_bundle_internal(
     widget: SubmitJobToDeadlineDialog,
     job_bundle_dir: str,
@@ -222,6 +250,11 @@ def _create_bundle_internal(
 ) -> dict[str, Any]:
     """Create and write Deadline job bundle files to the given directory. Also save sticky settings.
     The internal variation exists so that the functionality can be accessed without a UI.
+
+    The bundle itself is built by the unified :class:`BlenderSubmitter` (the
+    single source of truth shared with the AYON/headless path); this callback
+    only owns the GUI-specific concerns — sanity checks, adapting the UI
+    settings, writing the files, and saving sticky settings.
 
     Args:
         widget: The submitter dialog widget.
@@ -238,41 +271,16 @@ def _create_bundle_internal(
     # Run sanity checks on submission
     sc.run_sanity_checks(settings, prompt_for_saving)
 
-    renderable_cameras = bu.get_renderable_cameras(settings.scene_name)
-
-    common_layer_settings = tf.CommonLayerSettings(
-        renderer_name=settings.renderer_name,
-        frame_range=bu.get_frames(),
-        renderable_camera_names=renderable_cameras,
-        output_directories=settings.output_path,
-        output_file_prefix=settings.output_file_prefix,
-        image_resolution=(
-            bpy.context.scene.render.resolution_x,
-            bpy.context.scene.render.resolution_y,
-        ),
-        ui_group_label=settings.ui_group_label,
-        frames_parameter_name=settings.frames_parameter_name,
-        output_file_prefix_parameter_name=settings.output_file_prefix_parameter_name,
-        image_width_parameter_name=settings.image_width_parameter_name,
-        image_height_parameter_name=settings.image_height_parameter_name,
-        scene_name=settings.scene_name,
+    # Delegate bundle construction to the unified submitter so the GUI and the
+    # headless/AYON path build identical templates and parameter values.
+    submitter = BlenderSubmitter()
+    submitter_settings = _ui_settings_to_submitter_settings(settings)
+    job_template = submitter.get_job_template(submitter_settings, host_requirements)
+    # queue_parameters is list[JobParameter] (a TypedDict); the unified builder
+    # types it as list[dict] — same shape at runtime, so cast to bridge.
+    parameter_values = submitter.get_parameter_values(
+        submitter_settings, cast("list[dict[str, Any]]", queue_parameters)
     )
-
-    # Add selected layers to the list of layers to render.
-    layer_names: list[str] = []
-    if settings.view_layer_selection == ssw.COMBO_DEFAULT_ALL_RENDERABLE_LAYERS:
-        for layer in bu.get_renderable_view_layers(settings.scene_name):
-            layer_names.append(layer)
-    else:
-        layer_names.append(settings.view_layer_selection)
-
-    if settings.override_frame_range:
-        common_layer_settings.frame_range = settings.frame_list
-
-    job_template = tf.fill_job_template(
-        settings, layer_names, common_layer_settings, host_requirements
-    )
-    parameter_values = tf.get_parameter_values(settings, common_layer_settings, queue_parameters)
 
     # Write the job bundle files.
     job_bundle_path = Path(job_bundle_dir)
@@ -298,17 +306,9 @@ def _create_bundle_internal(
 
 
 def _get_auto_detected_assets(project_path: str) -> AssetReferences:
-    files = bu.find_files(project_path)
-
-    # Sort auto-detected attachments to classify files and directories correctly.
-    input_filenames = set()
-    input_directories = set()
-    for f in files:
-        if f.is_dir():
-            input_directories.add(str(f))
-        else:
-            input_filenames.add(str(f))
-
+    # Classify auto-detected dependencies via the shared helper so the GUI and
+    # the unified API path attach identical assets.
+    input_filenames, input_directories = bu.classify_auto_detected_paths(project_path)
     return AssetReferences(input_filenames=input_filenames, input_directories=input_directories)
 
 

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/submitter.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/submitter.py
@@ -1,0 +1,244 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional, cast
+
+from deadline.client.api import BaseSubmitter, BaseSubmitterSettings
+from deadline.client.exceptions import DeadlineOperationError
+
+import bpy  # type: ignore[import]
+
+from deadline.client.job_bundle.parameters import JobParameter
+from deadline.client.job_bundle.submission import AssetReferences
+
+from . import ocio_utils as ocio
+from .blender_utils import (
+    classify_auto_detected_paths,
+    get_active_scene_name,
+    get_frames,
+    get_render_engine,
+    get_renderable_cameras,
+    get_renderable_view_layers,
+    resolve_gpu_settings,
+    resolve_output_file_prefix,
+    resolve_output_path,
+)
+from .template_filling import (
+    BlenderSubmitterSettings,
+    CommonLayerSettings,
+    fill_job_template,
+    get_parameter_values as _fill_parameter_values,
+)
+
+_logger = logging.getLogger(__name__)
+
+# Re-exported for callers that import it from this module (e.g. the GUI dialog
+# and tests). The definition lives in ``template_filling`` so the module
+# dependency flows one way and avoids an import cycle.
+__all__ = ["BlenderSubmitter", "BlenderSubmitterSettings"]
+
+# Sentinel for "render every renderable view layer". Duplicated from
+# scene_settings_widget.COMBO_DEFAULT_ALL_RENDERABLE_LAYERS to avoid importing
+# the Qt-heavy widget module into this headless engine (the same pattern
+# template_filling uses for the camera sentinels).
+_ALL_RENDERABLE_LAYERS = "All Renderable Layers"
+
+
+class BlenderSubmitter(BaseSubmitter):
+    """BaseSubmitter implementation for Blender submissions."""
+
+    def get_settings(self) -> BlenderSubmitterSettings:
+        settings = BlenderSubmitterSettings()
+        scene = bpy.context.scene
+
+        settings.job_name = bpy.path.basename(bpy.data.filepath) or "Untitled"
+        settings.project_path = bpy.data.filepath or ""
+        # scene_name must be a key in bpy.data.scenes (indexed downstream by
+        # get_renderable_view_layers/cameras), so use the active scene name
+        # rather than the .blend-derived label.
+        settings.scene_name = get_active_scene_name()
+        settings.frame_list = get_frames()
+        # Shared with the GUI flow: maps Blender's internal engine id to the
+        # template's allowed RenderEngine values (eevee/cycles/workbench).
+        settings.renderer_name = get_render_engine()
+
+        settings.image_width = scene.render.resolution_x
+        settings.image_height = scene.render.resolution_y
+        # Shared with the GUI flow: resolve the output *directory* (with the
+        # scene/prefs/blend-dir fallbacks) and the filename prefix identically.
+        settings.output_path = resolve_output_path()
+        settings.output_file_prefix = resolve_output_file_prefix() or settings.output_file_prefix
+
+        settings.input_filenames = [bpy.data.filepath] if bpy.data.filepath else []
+        settings.output_directories = [settings.output_path] if settings.output_path else []
+
+        # Default to rendering all renderable view layers (empty selection),
+        # matching the dialog's default. _resolve_view_layer_names expands this.
+        settings.view_layer_selection = ""
+
+        # An empty camera_selection flows into _fill_step_template's else branch
+        # and produces a bogus [""] camera dimension. Fall back to the scene's
+        # default camera (mirrors the dialog) when none is resolved.
+        if scene.camera:
+            settings.camera_selection = scene.camera.name
+        else:
+            settings.camera_selection = "Use Default Camera"
+
+        # Read GPU settings from the scene/preferences (shared helper), so API
+        # submissions honor the user's GPU choice and default to the "NONE"
+        # sentinel (not "None") that the template/adaptor expect.
+        settings.enable_gpu, settings.gpu_device = resolve_gpu_settings()
+
+        # Mirror the dialog flow: pick up a custom OCIO config from the
+        # environment so jobs render with the correct color management. The
+        # OCIO-referenced directories are attached in get_asset_references().
+        settings.ocio_config_path = ocio.get_ocio_path()
+
+        return settings
+
+    def get_job_template(
+        self,
+        settings: BaseSubmitterSettings,
+        host_requirements: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        # The builders read BlenderSubmitterSettings directly (no UISettings
+        # translation); at runtime this is always that concrete type.
+        blender_settings = cast("BlenderSubmitterSettings", settings)
+        view_layers = self._resolve_view_layer_names(settings)
+        common_layer_settings = self._build_common_layer_settings(settings)
+
+        return fill_job_template(
+            blender_settings, view_layers, common_layer_settings, host_requirements
+        )
+
+    def get_parameter_values(
+        self,
+        settings: BaseSubmitterSettings,
+        queue_parameters: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        blender_settings = cast("BlenderSubmitterSettings", settings)
+        common_layer_settings = self._build_common_layer_settings(settings)
+
+        # The unified ABC types queue_parameters as list[dict]; the native
+        # filler expects list[JobParameter] (a TypedDict). They are the same
+        # shape at runtime, so cast to bridge the static types.
+        return _fill_parameter_values(
+            blender_settings,
+            common_layer_settings,
+            cast(list[JobParameter], queue_parameters),
+        )
+
+    def _build_common_layer_settings(self, settings: BaseSubmitterSettings):
+        """Construct CommonLayerSettings from the unified settings."""
+        renderer_name = "cycles"
+        scene_name = "Scene"
+        output_file_prefix = "output_####"
+        image_resolution = (1920, 1080)
+        if isinstance(settings, BlenderSubmitterSettings):
+            renderer_name = settings.renderer_name
+            scene_name = settings.scene_name
+            output_file_prefix = settings.output_file_prefix
+            image_resolution = (settings.image_width, settings.image_height)
+
+        # Populate the renderable cameras so the "All Renderable Cameras"
+        # selection produces a real Camera task dimension (mirrors the dialog).
+        # A scene with no renderable cameras returns []; an invalid scene_name
+        # raises KeyError here (same as _resolve_view_layer_names), which should
+        # surface as a submission error rather than be silently swallowed.
+        renderable_camera_names = get_renderable_cameras(scene_name)
+
+        return CommonLayerSettings(
+            renderer_name=renderer_name,
+            frame_range=settings.frame_list,
+            frames_parameter_name="Frames",
+            renderable_camera_names=renderable_camera_names,
+            output_directories=settings.output_path,
+            output_file_prefix=output_file_prefix,
+            output_file_prefix_parameter_name="OutputFileName",
+            ui_group_label="Blender Settings",
+            image_width_parameter_name="ResolutionX",
+            image_height_parameter_name="ResolutionY",
+            image_resolution=image_resolution,
+            scene_name=scene_name,
+        )
+
+    def _resolve_view_layer_names(self, settings: BaseSubmitterSettings) -> list[str]:
+        """Return the view layers to render, honoring view_layer_selection.
+
+        An empty selection (or the "All Renderable Layers" sentinel) renders
+        every renderable view layer; any other value renders that single layer.
+        Mirrors the dialog flow so the GUI and unified API paths agree.
+        """
+        # scene_name must be a key in bpy.data.scenes. Fail fast on an empty
+        # scene_name with an actionable message rather than falling back to
+        # job_name (the .blend file name, which is NOT a scenes key and would
+        # only produce a more confusing KeyError deep in get_renderable_view_layers).
+        scene_name = getattr(settings, "scene_name", "")
+        if not scene_name:
+            raise DeadlineOperationError(
+                "settings.scene_name is empty; set it to a valid scene name "
+                "(a key in bpy.data.scenes) before submitting."
+            )
+        selection = getattr(settings, "view_layer_selection", "")
+
+        if not selection or selection == _ALL_RENDERABLE_LAYERS:
+            return get_renderable_view_layers(scene_name)
+        return [selection]
+
+    def get_asset_references(self, settings: BaseSubmitterSettings) -> AssetReferences:
+        # Seed from any caller-supplied inputs so they are honored (not dropped).
+        input_filenames: set[str] = set(settings.input_filenames)
+        input_directories: set[str] = set(settings.input_directories)
+
+        # The .blend file itself.
+        if bpy.data.filepath:
+            input_filenames.add(bpy.data.filepath)
+
+        # Auto-detect external dependencies (textures, linked libraries, UDIM
+        # tiles, OCIO configs, …) via the shared helper, so jobs submitted
+        # through this API attach the same assets the dialog flow does.
+        # Best-effort: never let a scan failure block the submission (the .blend
+        # + explicit directories are still attached), but log rather than
+        # swallow so a scan bug is diagnosable.
+        try:
+            files, dirs = classify_auto_detected_paths(bpy.data.filepath)
+        except Exception:
+            _logger.warning(
+                "Auto-detection of external dependencies failed; only the .blend "
+                "file and explicitly-provided paths will be attached.",
+                exc_info=True,
+            )
+        else:
+            input_filenames |= files
+            input_directories |= dirs
+
+        # Attach the directories referenced by the OCIO config (shared with the
+        # dialog flow) so custom color management resolves on the farm. Honor an
+        # explicitly-set ocio_config_path (defaults to "" -> the active $OCIO
+        # config). get_current_ocio_referenced_dirs returns [] when no config is
+        # set; a malformed/unreadable config raises inside PyOpenColorIO — log
+        # and continue rather than block submission, but don't swallow silently.
+        blender_settings = cast(BlenderSubmitterSettings, settings)
+        try:
+            referenced_dirs = ocio.get_current_ocio_referenced_dirs(
+                blender_settings.ocio_config_path
+            )
+        except Exception:
+            _logger.warning(
+                "Failed to read OCIO config %r; its referenced directories will "
+                "not be attached as job inputs.",
+                blender_settings.ocio_config_path,
+                exc_info=True,
+            )
+        else:
+            input_directories.update(referenced_dirs)
+
+        # Return the typed AssetReferences per the unified BaseSubmitter
+        # contract (deadline-cloud #1245); callers call .to_dict() at the
+        # job-bundle serialization boundary.
+        return AssetReferences(
+            input_filenames=input_filenames,
+            input_directories=input_directories,
+            output_directories=set(settings.output_directories),
+        )

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/template_filling.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/template_filling.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import yaml
+from deadline.client.api import BaseSubmitterSettings
 from deadline.client.exceptions import DeadlineOperationError
 from deadline.client.job_bundle.parameters import JobParameter
 
@@ -35,7 +36,11 @@ class BlenderSubmitterUISettings:
     renderer_name: str = field(default="cycles", metadata={"sticky": True})
     scene_name: str = field(default="Scene", metadata={"sticky": True})
     enable_gpu: bool = field(default=False, metadata={"sticky": True})
-    gpu_device: str = field(default="None", metadata={"sticky": True})
+    # "NONE" sentinel (uppercase) — matches default_blender_template.yaml and the
+    # adaptor's CyclesHandler check. Legacy sticky files may hold "None"; those
+    # are normalized on load (see load_sticky_settings) so they can't resurrect
+    # the GPU-path bug on a CPU scene.
+    gpu_device: str = field(default="NONE", metadata={"sticky": True})
 
     ui_group_label: str = field(default="Blender Settings")
 
@@ -114,6 +119,12 @@ class BlenderSubmitterUISettings:
             for name, value in sticky_settings.items():
                 if name in sticky_fields:
                     setattr(self, name, value)
+            # Normalize a legacy "None" gpu_device (written by older addon
+            # versions for CPU scenes) to the "NONE" sentinel the template and
+            # adaptor expect, so a stale sticky file can't re-enable the GPU
+            # path on a CPU scene.
+            if self.gpu_device == "None":
+                self.gpu_device = "NONE"
         except (OSError, json.JSONDecodeError) as e:
             warn(str(e))
 
@@ -153,8 +164,40 @@ class CommonLayerSettings:
     scene_name: str
 
 
+@dataclass
+class BlenderSubmitterSettings(BaseSubmitterSettings):
+    """Blender-specific submission settings.
+
+    Extends the DCC-agnostic :class:`BaseSubmitterSettings` with the fields the
+    Blender job-template/parameter builders consume, so the GUI submitter and
+    the unified API path share one settings shape and one set of builders.
+
+    Defined here (alongside the builders that read it) rather than in
+    ``submitter`` so the module dependency flows one way — ``submitter`` imports
+    the builders, not the reverse — avoiding a module-level import cycle.
+    """
+
+    renderer_name: str = "cycles"
+    scene_name: str = "Scene"
+    # Empty means "all renderable view layers"; otherwise a single layer name.
+    view_layer_selection: str = ""
+    camera_selection: str = ""
+    image_width: int = 1920
+    image_height: int = 1080
+    output_file_prefix: str = "output_####"
+    enable_gpu: bool = False
+    # "NONE" sentinel (uppercase) — matches default_blender_template.yaml and the
+    # adaptor's CyclesHandler check; "None" would slip past both onto the GPU path.
+    gpu_device: str = "NONE"
+    ocio_config_path: str = ""
+    description: str = ""
+
+    # developer option
+    include_adaptor_wheels: bool = False
+
+
 def fill_job_template(
-    settings: BlenderSubmitterUISettings,
+    settings: BlenderSubmitterSettings,
     view_layer_names: list[str],
     common_layer_settings: CommonLayerSettings,
     host_requirements: Optional[dict],
@@ -165,7 +208,7 @@ def fill_job_template(
     with open(Path(__file__).parent / "default_blender_template.yaml") as fh:
         job_template = yaml.safe_load(fh)
 
-    job_template["name"] = settings.name
+    job_template["name"] = settings.job_name
     if settings.description:
         job_template["description"] = settings.description
 
@@ -280,7 +323,7 @@ def _add_ocio_template_data(job_template: dict):
 def _fill_step_template(
     view_layer_name: str,
     default_step_template: dict,
-    settings: BlenderSubmitterUISettings,
+    settings: BlenderSubmitterSettings,
     common_layer_settings: CommonLayerSettings,
     host_requirements: Optional[dict],
 ):
@@ -375,7 +418,7 @@ def _fill_step_template(
 
 
 def get_parameter_values(
-    settings: BlenderSubmitterUISettings,
+    settings: BlenderSubmitterSettings,
     layer_settings: CommonLayerSettings,
     queue_params: list[JobParameter],
 ) -> list[dict[str, Any]]:

--- a/test/unit/deadline_submitter_for_blender/test_blender_utils.py
+++ b/test/unit/deadline_submitter_for_blender/test_blender_utils.py
@@ -4,6 +4,8 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 # Ensure the submitter can be imported.
 SUBMITTER_DIR = (
     Path(__file__).parent.parent.parent.parent
@@ -205,3 +207,162 @@ class TestFindFiles:
             assert tile_u1_v1 in found_files
             assert tile_u2_v1 in found_files
             assert len(found_files) == 3  # project + 2 tiles
+
+
+class TestSceneName:
+    """get_scene_name (dialog job name) vs get_active_scene_name (bpy.data.scenes key)."""
+
+    def test_get_scene_name_is_derived_from_blend_filename(self):
+        """The dialog uses get_scene_name() as the default job name, so it must
+        stay derived from the .blend file name (not the active scene name)."""
+        with (
+            patch("blender_utils.bpy.context.blend_data.filepath", "/proj/my_shot.blend"),
+            patch("blender_utils.bpy.path.basename", side_effect=lambda p: p.rsplit("/", 1)[-1]),
+        ):
+            assert bu.get_scene_name() == "my_shot"
+
+    def test_get_active_scene_name_returns_active_scene(self):
+        """The API path indexes bpy.data.scenes, so it needs the real scene name."""
+        with patch("blender_utils.bpy.context.scene.name", "Scene.001"):
+            assert bu.get_active_scene_name() == "Scene.001"
+
+
+class TestGetRenderEngine:
+    """get_render_engine maps Blender engine ids to template RenderEngine values."""
+
+    def test_maps_known_engine_ids(self):
+        for engine_id, expected in [
+            ("BLENDER_EEVEE", "eevee"),
+            ("BLENDER_EEVEE_NEXT", "eevee"),
+            ("CYCLES", "cycles"),
+            ("BLENDER_WORKBENCH", "workbench"),
+        ]:
+            with patch("blender_utils.bpy.context.scene.render.engine", engine_id):
+                assert bu.get_render_engine() == expected
+
+    def test_unsupported_engine_raises(self):
+        """A third-party engine (V-Ray/Octane/…) must fail early, not forward an
+        out-of-range RenderEngine value that CreateJob rejects opaquely."""
+        from deadline.client.exceptions import DeadlineOperationError
+
+        with patch("blender_utils.bpy.context.scene.render.engine", "VRAY"):
+            with pytest.raises(DeadlineOperationError, match="not supported"):
+                bu.get_render_engine()
+
+
+class TestResolveOutputPath:
+    """resolve_output_path returns a directory, with scene/prefs/blend fallbacks."""
+
+    def test_uses_render_filepath_directory_when_set(self):
+        with (
+            patch("blender_utils.bpy.context.scene.render.filepath", "/render/frame_"),
+            patch("blender_utils.bpy.path.abspath", side_effect=lambda p: p),
+        ):
+            assert bu.resolve_output_path() == "/render"
+
+    def test_falls_back_to_preferences_render_output_dir(self):
+        with (
+            # No directory part -> skip tier 1.
+            patch("blender_utils.bpy.context.scene.render.filepath", "frame_"),
+            patch(
+                "blender_utils.bpy.context.preferences.filepaths.render_output_directory",
+                "/prefs/out",
+            ),
+        ):
+            assert bu.resolve_output_path() == "/prefs/out"
+
+    def test_falls_back_to_blend_file_directory(self):
+        with (
+            patch("blender_utils.bpy.context.scene.render.filepath", "frame_"),
+            patch(
+                "blender_utils.bpy.context.preferences.filepaths.render_output_directory",
+                "",
+            ),
+            patch("blender_utils.bpy.context.blend_data.filepath", "/proj/scene.blend"),
+        ):
+            assert bu.resolve_output_path() == "/proj"
+
+
+class TestResolveOutputFilePrefix:
+    def test_returns_basename_of_render_filepath(self):
+        with patch(
+            "blender_utils.bpy.path.basename",
+            side_effect=lambda p: p.rsplit("/", 1)[-1],
+        ):
+            with patch("blender_utils.bpy.context.scene.render.filepath", "/render/frame_"):
+                assert bu.resolve_output_file_prefix() == "frame_"
+
+    def test_empty_when_render_filepath_has_no_filename(self):
+        with patch("blender_utils.bpy.path.basename", side_effect=lambda p: ""):
+            with patch("blender_utils.bpy.context.scene.render.filepath", "/render/"):
+                assert bu.resolve_output_file_prefix() == ""
+
+
+class TestClassifyAutoDetectedPaths:
+    """classify_auto_detected_paths splits find_files results into files/dirs."""
+
+    def test_splits_files_and_directories(self, tmp_path):
+        tex = tmp_path / "tex.png"
+        tex.write_text("x")
+        cache = tmp_path / "cache"
+        cache.mkdir()
+
+        with patch("blender_utils.find_files", return_value=[tex, cache]):
+            files, dirs = bu.classify_auto_detected_paths("/proj/scene.blend")
+
+        assert files == {str(tex)}
+        assert dirs == {str(cache)}
+
+
+class TestResolveGpuSettings:
+    """resolve_gpu_settings reads scene/prefs and defaults the device to NONE."""
+
+    def test_gpu_enabled_with_configured_device(self):
+        with (
+            patch("blender_utils.bpy.context.scene.cycles.device", "GPU"),
+            patch(
+                "blender_utils.bpy.context.preferences.addons",
+                {
+                    "cycles": type(
+                        "P", (), {"preferences": type("Q", (), {"compute_device_type": "CUDA"})()}
+                    )()
+                },
+            ),
+        ):
+            enable_gpu, gpu_device = bu.resolve_gpu_settings()
+        assert enable_gpu is True
+        assert gpu_device == "CUDA"
+
+    def test_defaults_to_none_sentinel_when_no_device(self):
+        with (
+            patch("blender_utils.bpy.context.scene.cycles.device", "CPU"),
+            patch(
+                "blender_utils.bpy.context.preferences.addons",
+                {
+                    "cycles": type(
+                        "P", (), {"preferences": type("Q", (), {"compute_device_type": "NONE"})()}
+                    )()
+                },
+            ),
+        ):
+            enable_gpu, gpu_device = bu.resolve_gpu_settings()
+        assert enable_gpu is False
+        assert gpu_device == "NONE"
+
+    def test_cpu_scene_with_configured_gpu_device_stays_none(self):
+        """A CPU scene must yield gpu_device "NONE" even when Preferences have a
+        GPU compute device selected (mirrors the widget's enable_gpu gating)."""
+        with (
+            patch("blender_utils.bpy.context.scene.cycles.device", "CPU"),
+            patch(
+                "blender_utils.bpy.context.preferences.addons",
+                {
+                    "cycles": type(
+                        "P", (), {"preferences": type("Q", (), {"compute_device_type": "CUDA"})()}
+                    )()
+                },
+            ),
+        ):
+            enable_gpu, gpu_device = bu.resolve_gpu_settings()
+        assert enable_gpu is False
+        assert gpu_device == "NONE"

--- a/test/unit/deadline_submitter_for_blender/test_gui_submitter.py
+++ b/test/unit/deadline_submitter_for_blender/test_gui_submitter.py
@@ -1,0 +1,657 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Tests for the GUI submitter (open_deadline_cloud_dialog + template_filling).
+
+Covers the dialog flow's template/param builders, asset classification, and the
+adapter that delegates to the unified BlenderSubmitter. The headless
+BlenderSubmitter engine itself is tested in test_submitter.py.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from unittest.mock import Mock, patch
+
+from deadline.blender_submitter.addons.deadline_cloud_blender_submitter.open_deadline_cloud_dialog import (
+    _get_auto_detected_assets,
+)
+from deadline.blender_submitter.addons.deadline_cloud_blender_submitter.submitter import (
+    BlenderSubmitterSettings,
+)
+
+
+from deadline.client.exceptions import DeadlineOperationError
+
+# Ensure the submitter can be imported.
+SUBMITTER_DIR = (
+    Path(__file__).parent.parent.parent.parent
+    / "src"
+    / "deadline"
+    / "blender_submitter"
+    / "addons"
+    / "deadline_cloud_blender_submitter"
+)
+sys.path.append(str(SUBMITTER_DIR))
+import template_filling  # noqa: E402
+
+
+@pytest.fixture
+def submitter_settings():
+    """Return a submitter settings object.
+
+    The builders now consume the unified BlenderSubmitterSettings directly (no
+    BlenderSubmitterUISettings translation). job_name is set to the old
+    UISettings default so the template-name assertion below is unchanged.
+    """
+    # camera_selection="Camera" mirrors the old BlenderSubmitterUISettings
+    # default (a specific named camera), keeping the template assertions stable.
+    return BlenderSubmitterSettings(job_name="Blender Submission", camera_selection="Camera")
+
+
+@pytest.fixture
+def common_layer_settings():
+    """Return a common layer settings object."""
+    settings = template_filling.CommonLayerSettings(
+        renderer_name="dummy_renderer",
+        frame_range="1-10",
+        frames_parameter_name=None,
+        renderable_camera_names=["dummy_camera"],
+        output_directories=["/dummy/output/directory"],
+        output_file_prefix="dummy_prefix",
+        output_file_prefix_parameter_name=None,
+        ui_group_label="dummy_group_label",
+        image_width_parameter_name=None,
+        image_height_parameter_name=None,
+        image_resolution=(1920, 1080),
+        scene_name="dummy_scene_name",
+    )
+    print(settings)
+    return settings
+
+
+LAYER_NAMES = ["layer_1", "layer_2"]
+
+
+def test_fill_job_template(submitter_settings, common_layer_settings):
+    """Test filling the job template."""
+
+    # NOTE This is not the most elegant way to test this; brittle to changes in the template.
+
+    expected = {
+        "specificationVersion": "jobtemplate-2023-09",
+        "name": "Blender Submission",
+        "description": None,
+        "parameterDefinitions": [
+            {
+                "name": "BlenderFile",
+                "type": "PATH",
+                "objectType": "FILE",
+                "dataFlow": "IN",
+                "userInterface": {
+                    "control": "CHOOSE_INPUT_FILE",
+                    "label": "Blender File",
+                    "fileFilters": [
+                        {"label": "Blender Files", "patterns": ["*.blend"]},
+                        {"label": "All Files", "patterns": ["*"]},
+                    ],
+                },
+                "description": "The Blender scene file you want to render.",
+            },
+            {
+                "name": "RenderEngine",
+                "type": "STRING",
+                "default": "cycles",
+                "allowedValues": ["eevee", "workbench", "cycles"],
+            },
+            {
+                "name": "RenderScene",
+                "type": "STRING",
+                "userInterface": {
+                    "control": "LINE_EDIT",
+                    "label": "Scene",
+                    "groupLabel": "Blender Settings",
+                },
+                "default": "Scene",
+                "description": "The scene you want to render (scene name).",
+            },
+            {
+                "name": "ViewLayer",
+                "type": "STRING",
+                "userInterface": {"control": "LINE_EDIT", "label": "view_layer"},
+                "description": "The layer to render.",
+                "default": "ViewLayer",
+            },
+            {
+                "name": "Frames",
+                "type": "STRING",
+                "userInterface": {
+                    "control": "LINE_EDIT",
+                    "label": "Frames",
+                    "groupLabel": "Blender Settings",
+                },
+                "default": "1-1",
+                "description": "The frames to render. E.g. 1-3,8,11-15",
+            },
+            {
+                "name": "OutputDir",
+                "type": "PATH",
+                "objectType": "DIRECTORY",
+                "dataFlow": "OUT",
+                "userInterface": {"control": "CHOOSE_DIRECTORY", "label": "Output Directory"},
+                "description": "The render output directory.",
+            },
+            {
+                "name": "OutputFileName",
+                "type": "STRING",
+                "userInterface": {"control": "LINE_EDIT", "label": "Output File Name"},
+                "default": "output_####",
+                "description": "The output filename (without extension).",
+            },
+            {
+                "name": "OutputFormat",
+                "type": "STRING",
+                "userInterface": {"control": "DROPDOWN_LIST", "label": "Output File Format"},
+                "description": "The file format to render as.",
+                "default": "PNG",
+                "allowedValues": [
+                    "TARGA",
+                    "TARGA_RAW",
+                    "JPEG",
+                    "IRIS",
+                    "PNG",
+                    "HDR",
+                    "TIFF",
+                    "OPEN_EXR",
+                    "OPEN_EXR_MULTILAYER",
+                    "CINEON",
+                    "DPX",
+                    "JPEG2000",
+                    "WEBP",
+                ],
+            },
+            {
+                "name": "GPUDevice",
+                "type": "STRING",
+                "userInterface": {
+                    "control": "LINE_EDIT",
+                    "label": "GPU Device",
+                },
+                "description": "The GPU device type to render with when using the cycles engine.",
+                "default": "NONE",
+            },
+            {
+                "name": "StrictErrorChecking",
+                "type": "STRING",
+                "userInterface": {
+                    "control": "CHECK_BOX",
+                    "label": "Strict Error Checking",
+                    "groupLabel": "Blender Settings",
+                },
+                "description": "Fail when errors occur.",
+                "default": "false",
+                "allowedValues": ["true", "false"],
+            },
+            {
+                "name": None,
+                "type": "INT",
+                "userInterface": {
+                    "control": "SPIN_BOX",
+                    "label": "Image Width",
+                    "groupLabel": "dummy_group_label",
+                },
+                "minValue": 1,
+                "description": "The image width.",
+            },
+            {
+                "name": None,
+                "type": "INT",
+                "userInterface": {
+                    "control": "SPIN_BOX",
+                    "label": "Image Height",
+                    "groupLabel": "dummy_group_label",
+                },
+                "minValue": 1,
+                "description": "The image height.",
+            },
+        ],
+        "steps": [
+            {
+                "name": "layer_1",
+                "parameterSpace": {
+                    "taskParameterDefinitions": [
+                        {"name": "Frame", "type": "INT", "range": "{{Param.Frames}}"},
+                        {"name": "Camera", "type": "STRING", "range": ["Camera"]},
+                    ]
+                },
+                "stepEnvironments": [
+                    {
+                        "name": "Blender",
+                        "description": "Runs Blender in the background.",
+                        "script": {
+                            "embeddedFiles": [
+                                {
+                                    "name": "initData",
+                                    "filename": "init-data.yaml",
+                                    "type": "TEXT",
+                                    "data": "scene_file: {{Param.BlenderFile}}\nrender_engine: {{Param.RenderEngine}}\ngpu_device: {{Param.GPUDevice}}\nrender_scene: {{Param.RenderScene}}\nview_layer: layer_1\noutput_dir: {{Param.OutputDir}}\noutput_file_name: {{Param.OutputFileName}}\noutput_format: {{Param.OutputFormat}}\nrenderer: dummy_renderer\noutput_file_prefix: {{Param.OutputFilePrefix}}\nimage_width: {{Param.ImageWidth}}\nimage_height: {{Param.ImageHeight}}",
+                                }
+                            ],
+                            "actions": {
+                                "onEnter": {
+                                    "command": "blender-openjd",
+                                    "args": [
+                                        "daemon",
+                                        "start",
+                                        "--connection-file",
+                                        "{{Session.WorkingDirectory}}/connection.json",
+                                        "--init-data",
+                                        "file://{{Env.File.initData}}",
+                                    ],
+                                    "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
+                                    "timeout": 3720,
+                                },
+                                "onExit": {
+                                    "command": "blender-openjd",
+                                    "args": [
+                                        "daemon",
+                                        "stop",
+                                        "--connection-file",
+                                        "{{ Session.WorkingDirectory }}/connection.json",
+                                    ],
+                                    "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
+                                    "timeout": 120,
+                                },
+                            },
+                        },
+                    }
+                ],
+                "script": {
+                    "embeddedFiles": [
+                        {
+                            "name": "runData",
+                            "filename": "run-data.yaml",
+                            "type": "TEXT",
+                            "data": "frame: {{Task.Param.Frame}}\ncamera: '{{Task.Param.Camera}}'\n",
+                        }
+                    ],
+                    "actions": {
+                        "onRun": {
+                            "command": "blender-openjd",
+                            "args": [
+                                "daemon",
+                                "run",
+                                "--connection-file",
+                                "{{ Session.WorkingDirectory }}/connection.json",
+                                "--run-data",
+                                "file://{{ Task.File.runData }}",
+                            ],
+                            "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
+                        }
+                    },
+                },
+            },
+            {
+                "name": "layer_2",
+                "parameterSpace": {
+                    "taskParameterDefinitions": [
+                        {"name": "Frame", "type": "INT", "range": "{{Param.Frames}}"},
+                        {"name": "Camera", "type": "STRING", "range": ["Camera"]},
+                    ]
+                },
+                "stepEnvironments": [
+                    {
+                        "name": "Blender",
+                        "description": "Runs Blender in the background.",
+                        "script": {
+                            "embeddedFiles": [
+                                {
+                                    "name": "initData",
+                                    "filename": "init-data.yaml",
+                                    "type": "TEXT",
+                                    "data": "scene_file: {{Param.BlenderFile}}\nrender_engine: {{Param.RenderEngine}}\ngpu_device: {{Param.GPUDevice}}\nrender_scene: {{Param.RenderScene}}\nview_layer: layer_2\noutput_dir: {{Param.OutputDir}}\noutput_file_name: {{Param.OutputFileName}}\noutput_format: {{Param.OutputFormat}}\nrenderer: dummy_renderer\noutput_file_prefix: {{Param.OutputFilePrefix}}\nimage_width: {{Param.ImageWidth}}\nimage_height: {{Param.ImageHeight}}",
+                                }
+                            ],
+                            "actions": {
+                                "onEnter": {
+                                    "command": "blender-openjd",
+                                    "args": [
+                                        "daemon",
+                                        "start",
+                                        "--connection-file",
+                                        "{{Session.WorkingDirectory}}/connection.json",
+                                        "--init-data",
+                                        "file://{{Env.File.initData}}",
+                                    ],
+                                    "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
+                                    "timeout": 3720,
+                                },
+                                "onExit": {
+                                    "command": "blender-openjd",
+                                    "args": [
+                                        "daemon",
+                                        "stop",
+                                        "--connection-file",
+                                        "{{ Session.WorkingDirectory }}/connection.json",
+                                    ],
+                                    "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
+                                    "timeout": 120,
+                                },
+                            },
+                        },
+                    }
+                ],
+                "script": {
+                    "embeddedFiles": [
+                        {
+                            "name": "runData",
+                            "filename": "run-data.yaml",
+                            "type": "TEXT",
+                            "data": "frame: {{Task.Param.Frame}}\ncamera: '{{Task.Param.Camera}}'\n",
+                        }
+                    ],
+                    "actions": {
+                        "onRun": {
+                            "command": "blender-openjd",
+                            "args": [
+                                "daemon",
+                                "run",
+                                "--connection-file",
+                                "{{ Session.WorkingDirectory }}/connection.json",
+                                "--run-data",
+                                "file://{{ Task.File.runData }}",
+                            ],
+                            "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
+                        }
+                    },
+                },
+            },
+        ],
+    }
+
+    filled = template_filling.fill_job_template(
+        submitter_settings, LAYER_NAMES, common_layer_settings, host_requirements=None
+    )
+    assert filled == expected
+
+    # Adding host requirements to the call adds them to each step.
+    host_reqs = {"GPU": "1"}
+    filled = template_filling.fill_job_template(
+        submitter_settings, LAYER_NAMES, common_layer_settings, host_requirements=host_reqs
+    )
+    for step in filled["steps"]:
+        assert step["hostRequirements"] == host_reqs
+
+
+def test_get_param_values(submitter_settings, common_layer_settings):
+    """Test getting param values."""
+    expected_settings = {
+        "BlenderFile": submitter_settings.project_path,
+        "OutputFileName": common_layer_settings.output_file_prefix,
+        "OutputDir": common_layer_settings.output_directories,
+        "RenderScene": common_layer_settings.scene_name,
+        "RenderEngine": common_layer_settings.renderer_name,
+        "GPUDevice": submitter_settings.gpu_device,
+    }
+    expected = [{"name": k, "value": v} for k, v in expected_settings.items()]
+
+    # Patching this scene setting causes GPUDevice to use the default value
+    with patch("bpy.context.scene.cycles.device", "CPU"):
+        filled = template_filling.get_parameter_values(
+            submitter_settings, common_layer_settings, queue_params=[]
+        )
+        assert filled == expected
+
+
+def test_conflicting_queue_params_error(submitter_settings, common_layer_settings):
+    # If queue params are passed, their keys should not conflict with existing keys. Expect an error if they do.
+    queue_params = [
+        {"name": "RenderScene", "value": common_layer_settings.scene_name + "_some_value"}
+    ]
+    with pytest.raises(DeadlineOperationError):
+        template_filling.get_parameter_values(
+            submitter_settings, common_layer_settings, queue_params=queue_params
+        )
+
+
+def test_get_queue_params(submitter_settings, common_layer_settings):
+    # If queue params are passed, and they don't conflict with existing keys, they should be added.
+    queue_params = [{"name": "SomeParam", "value": "some_value"}]
+    filled = template_filling.get_parameter_values(
+        submitter_settings, common_layer_settings, queue_params=queue_params
+    )
+    assert filled[-1] == queue_params[0]
+
+
+@pytest.mark.parametrize(
+    "queue_param_name,package_name",
+    [
+        pytest.param("RezPackages", "deadline_cloud_for_blender"),
+        pytest.param("CondaPackages", "blender-openjd"),
+    ],
+)
+def test_use_adaptor_wheels(
+    submitter_settings, common_layer_settings, queue_param_name, package_name
+):
+    """
+    Tests that default packages are excluded from CondaPackages and RezPackages if `include_adaptor_wheels` is true.
+    """
+
+    # GIVEN
+    queue_params = [
+        {
+            "name": queue_param_name,
+            "value": f"some_other_package {package_name} another_package",
+        }
+    ]
+
+    # WHEN
+    submitter_settings.include_adaptor_wheels = True
+    filled = template_filling.get_parameter_values(
+        submitter_settings, common_layer_settings, queue_params=queue_params
+    )
+
+    # THEN
+    assert filled[-1]["value"] == "some_other_package another_package"
+
+
+def test_add_ocio_template_data(submitter_settings, common_layer_settings):
+    """
+    Certain information should only be added to the template if an OCIO environment variable is set.
+    There should be an extra job environment and corresponding parameter.
+    """
+
+    expected_ocio_env = {"name": "Set OCIO Path", "variables": {"OCIO": "{{Param.OCIOConfigPath}}"}}
+    expected_ocio_param = {"name": "OCIOConfigPath", "value": "my_ocio_config.ocio"}
+
+    # GIVEN
+    submitter_settings.ocio_config_path = "my_ocio_config.ocio"
+
+    # WHEN
+    filled_template = template_filling.fill_job_template(
+        submitter_settings, LAYER_NAMES, common_layer_settings, host_requirements=None
+    )
+    params = template_filling.get_parameter_values(submitter_settings, common_layer_settings, [])
+
+    # THEN
+    assert expected_ocio_env in filled_template["jobEnvironments"]
+    assert expected_ocio_param in params
+
+
+def test_sort_auto_detected_assets():
+    """Test that auto-detected assets are properly classified."""
+    expected_input_filenames = set(["file_1.blend", "file_2.abc"])
+    expected_input_dirs = set(["dir_1", "dir_2"])
+
+    # WHEN find_files returns a mix of files and directories, classify them before adding them to the dialog.
+    with (
+        patch(
+            "deadline.blender_submitter.addons.deadline_cloud_blender_submitter.open_deadline_cloud_dialog.bu.find_files",
+            Mock(
+                return_value=[
+                    Path("dir_1"),
+                    Path("file_1.blend"),
+                    Path("dir_2"),
+                    Path("file_2.abc"),
+                ]
+            ),
+        ),
+        patch.object(Path, "is_dir", side_effect=[True, False, True, False]),
+    ):
+
+        auto_detected_assets = _get_auto_detected_assets("test_project_path.blend")
+
+        assert auto_detected_assets.input_filenames == expected_input_filenames
+        assert auto_detected_assets.input_directories == expected_input_dirs
+
+
+def test_fill_job_template_use_default_camera(submitter_settings, common_layer_settings):
+    """Test filling the job template when camera_selection is 'Use Default Camera'."""
+
+    # Set camera_selection to "Use Default Camera"
+    submitter_settings.camera_selection = "Use Default Camera"
+
+    filled = template_filling.fill_job_template(
+        submitter_settings, ["layer_1"], common_layer_settings, host_requirements=None
+    )
+
+    # Check that Camera parameter is NOT in taskParameterDefinitions
+    task_param_defs = filled["steps"][0]["parameterSpace"]["taskParameterDefinitions"]
+    camera_params = [param for param in task_param_defs if param.get("name") == "Camera"]
+    assert (
+        len(camera_params) == 0
+    ), "Camera parameter should not be defined when using default camera"
+
+    # Check that camera is NOT set in the embedded RunData file
+    run_data = filled["steps"][0]["script"]["embeddedFiles"][0]["data"]
+    assert (
+        "camera:" not in run_data
+    ), "Camera should not be set in RunData when using default camera"
+
+
+# ---------------------------------------------------------------------------
+# GUI -> unified submitter delegation
+#
+# The dialog no longer builds the bundle itself; it adapts its UI settings to
+# BlenderSubmitterSettings and delegates to BlenderSubmitter (the single source
+# of truth shared with the AYON/headless path). These cover the adapter.
+# ---------------------------------------------------------------------------
+
+
+def _dialog_module():
+    from deadline.blender_submitter.addons.deadline_cloud_blender_submitter import (
+        open_deadline_cloud_dialog as dlg,
+    )
+
+    return dlg
+
+
+def test_ui_settings_adapter_maps_fields_and_scene_resolution():
+    """UI settings map onto BlenderSubmitterSettings; resolution comes from the scene."""
+    dlg = _dialog_module()
+
+    ui = template_filling.BlenderSubmitterUISettings()
+    ui.name = "my_shot"
+    ui.scene_name = "Scene"
+    ui.renderer_name = "cycles"
+    ui.view_layer_selection = "Beauty"
+    ui.camera_selection = "Use Default Camera"
+    ui.output_file_prefix = "frame_"
+    ui.output_path = "/out"
+    ui.override_frame_range = False
+
+    render = dlg.bpy.context.scene.render
+    render.resolution_x = 640
+    render.resolution_y = 480
+
+    with patch.object(dlg.bu, "get_frames", return_value="1-10"):
+        result = dlg._ui_settings_to_submitter_settings(ui)
+
+    assert result.job_name == "my_shot"  # name -> job_name
+    assert result.scene_name == "Scene"
+    assert result.view_layer_selection == "Beauty"
+    assert result.camera_selection == "Use Default Camera"
+    assert (result.image_width, result.image_height) == (640, 480)
+    # override off -> the scene frame range is used
+    assert result.frame_list == "1-10"
+
+
+def test_ui_settings_adapter_uses_override_frame_range_when_set():
+    """When override is on, the user's explicit frame range wins over the scene range."""
+    dlg = _dialog_module()
+
+    ui = template_filling.BlenderSubmitterUISettings()
+    ui.override_frame_range = True
+    ui.frame_list = "5-8"
+
+    with patch.object(dlg.bu, "get_frames", return_value="1-10"):
+        result = dlg._ui_settings_to_submitter_settings(ui)
+
+    assert result.frame_list == "5-8"
+
+
+def test_create_bundle_delegates_to_blender_submitter(tmp_path):
+    """_create_bundle_internal builds the bundle via BlenderSubmitter, not its own path."""
+    from unittest.mock import MagicMock
+
+    from deadline.client.job_bundle.submission import AssetReferences
+
+    dlg = _dialog_module()
+
+    ui = template_filling.BlenderSubmitterUISettings()
+    # project_path must be writable — sticky settings are saved next to it.
+    ui.project_path = str(tmp_path / "scene.blend")
+    ui.output_path = "/out"
+
+    widget = MagicMock()
+    widget.job_attachments.attachments = AssetReferences()
+
+    fake_template = {"name": "job"}
+    fake_param_values = [{"name": "Frames", "value": "1-10"}]
+
+    with (
+        patch.object(dlg.bpy.path, "abspath", side_effect=lambda p: p),
+        patch.object(dlg.sc, "run_sanity_checks"),
+        patch.object(dlg, "BlenderSubmitter") as submitter_cls,
+    ):
+        submitter = submitter_cls.return_value
+        submitter.get_job_template.return_value = fake_template
+        submitter.get_parameter_values.return_value = fake_param_values
+
+        result = dlg._create_bundle_internal(
+            widget,
+            str(tmp_path),
+            ui,
+            [],
+            AssetReferences(),
+            host_requirements=None,
+            prompt_for_saving=False,
+        )
+
+    # The bundle came from the unified submitter, and the files were written.
+    submitter.get_job_template.assert_called_once()
+    submitter.get_parameter_values.assert_called_once()
+    assert result == {"job_parameters": fake_param_values}
+    assert (tmp_path / "template.yaml").exists()
+    assert (tmp_path / "parameter_values.yaml").exists()
+    assert (tmp_path / "asset_references.yaml").exists()
+
+
+def test_ui_settings_gpu_device_defaults_to_none_sentinel():
+    """UISettings default must be the "NONE" sentinel, not "None"."""
+    assert template_filling.BlenderSubmitterUISettings().gpu_device == "NONE"
+
+
+def test_load_sticky_settings_normalizes_legacy_none_gpu_device(tmp_path):
+    """A legacy sticky file with gpu_device "None" is normalized to "NONE" on
+    load, so it can't resurrect the adaptor GPU-path bug on a CPU scene."""
+    import json
+
+    scene = tmp_path / "scene.blend"
+    sticky = scene.with_suffix(".deadline_render_settings.json")
+    sticky.write_text(json.dumps({"gpu_device": "None"}))
+
+    ui = template_filling.BlenderSubmitterUISettings()
+    ui.load_sticky_settings(str(scene))
+
+    assert ui.gpu_device == "NONE"

--- a/test/unit/deadline_submitter_for_blender/test_submitter.py
+++ b/test/unit/deadline_submitter_for_blender/test_submitter.py
@@ -1,515 +1,398 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-"""Test the Deadline Cloud Blender Submitter."""
+"""Tests for the unified BlenderSubmitter (…deadline_cloud_blender_submitter.submitter).
 
-import sys
-from pathlib import Path
+`bpy` and the UI dialog are mocked in this package's __init__.py.
+
+The unified BaseSubmitter base class lives in deadline-cloud (PR #1245). This
+module imports it at load, so — matching the Maya submitter's convention — it is
+NOT guarded with a skip: it fails until a `deadline` release carrying
+BaseSubmitter is installed, and passes once it is.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
 
 import pytest
-from unittest.mock import Mock, patch
 
-from deadline.blender_submitter.addons.deadline_cloud_blender_submitter.open_deadline_cloud_dialog import (
-    _get_auto_detected_assets,
-)
+_API = "deadline.blender_submitter.addons.deadline_cloud_blender_submitter.submitter"
 
 
-from deadline.client.exceptions import DeadlineOperationError
+def _import_api():
+    import importlib
 
-# Ensure the submitter can be imported.
-SUBMITTER_DIR = (
-    Path(__file__).parent.parent.parent.parent
-    / "src"
-    / "deadline"
-    / "blender_submitter"
-    / "addons"
-    / "deadline_cloud_blender_submitter"
-)
-sys.path.append(str(SUBMITTER_DIR))
-import template_filling  # noqa: E402
+    return importlib.import_module(_API)
 
 
-@pytest.fixture
-def submitter_settings():
-    """Return a submitter settings object."""
-    settings = template_filling.BlenderSubmitterUISettings()
-    return settings
+def _inputs(refs) -> tuple[set[str], set[str]]:
+    """Return (input_filenames, input_directories) from an AssetReferences."""
+    return set(refs.input_filenames), set(refs.input_directories)
 
 
-@pytest.fixture
-def common_layer_settings():
-    """Return a common layer settings object."""
-    settings = template_filling.CommonLayerSettings(
-        renderer_name="dummy_renderer",
-        frame_range="1-10",
-        frames_parameter_name=None,
-        renderable_camera_names=["dummy_camera"],
-        output_directories=["/dummy/output/directory"],
-        output_file_prefix="dummy_prefix",
-        output_file_prefix_parameter_name=None,
-        ui_group_label="dummy_group_label",
-        image_width_parameter_name=None,
-        image_height_parameter_name=None,
-        image_resolution=(1920, 1080),
-        scene_name="dummy_scene_name",
-    )
-    print(settings)
-    return settings
+def _outputs(refs) -> set[str]:
+    return set(refs.output_directories)
 
 
-LAYER_NAMES = ["layer_1", "layer_2"]
+def test_get_asset_references_includes_auto_detected(tmp_path):
+    api_mod = _import_api()
 
+    tex = tmp_path / "tex.png"
+    sub = tmp_path / "cache"
 
-def test_fill_job_template(submitter_settings, common_layer_settings):
-    """Test filling the job template."""
+    settings = api_mod.BlenderSubmitterSettings()
+    settings.input_directories = []
+    settings.output_directories = ["/out"]
 
-    # NOTE This is not the most elegant way to test this; brittle to changes in the template.
-
-    expected = {
-        "specificationVersion": "jobtemplate-2023-09",
-        "name": "Blender Submission",
-        "description": None,
-        "parameterDefinitions": [
-            {
-                "name": "BlenderFile",
-                "type": "PATH",
-                "objectType": "FILE",
-                "dataFlow": "IN",
-                "userInterface": {
-                    "control": "CHOOSE_INPUT_FILE",
-                    "label": "Blender File",
-                    "fileFilters": [
-                        {"label": "Blender Files", "patterns": ["*.blend"]},
-                        {"label": "All Files", "patterns": ["*"]},
-                    ],
-                },
-                "description": "The Blender scene file you want to render.",
-            },
-            {
-                "name": "RenderEngine",
-                "type": "STRING",
-                "default": "cycles",
-                "allowedValues": ["eevee", "workbench", "cycles"],
-            },
-            {
-                "name": "RenderScene",
-                "type": "STRING",
-                "userInterface": {
-                    "control": "LINE_EDIT",
-                    "label": "Scene",
-                    "groupLabel": "Blender Settings",
-                },
-                "default": "Scene",
-                "description": "The scene you want to render (scene name).",
-            },
-            {
-                "name": "ViewLayer",
-                "type": "STRING",
-                "userInterface": {"control": "LINE_EDIT", "label": "view_layer"},
-                "description": "The layer to render.",
-                "default": "ViewLayer",
-            },
-            {
-                "name": "Frames",
-                "type": "STRING",
-                "userInterface": {
-                    "control": "LINE_EDIT",
-                    "label": "Frames",
-                    "groupLabel": "Blender Settings",
-                },
-                "default": "1-1",
-                "description": "The frames to render. E.g. 1-3,8,11-15",
-            },
-            {
-                "name": "OutputDir",
-                "type": "PATH",
-                "objectType": "DIRECTORY",
-                "dataFlow": "OUT",
-                "userInterface": {"control": "CHOOSE_DIRECTORY", "label": "Output Directory"},
-                "description": "The render output directory.",
-            },
-            {
-                "name": "OutputFileName",
-                "type": "STRING",
-                "userInterface": {"control": "LINE_EDIT", "label": "Output File Name"},
-                "default": "output_####",
-                "description": "The output filename (without extension).",
-            },
-            {
-                "name": "OutputFormat",
-                "type": "STRING",
-                "userInterface": {"control": "DROPDOWN_LIST", "label": "Output File Format"},
-                "description": "The file format to render as.",
-                "default": "PNG",
-                "allowedValues": [
-                    "TARGA",
-                    "TARGA_RAW",
-                    "JPEG",
-                    "IRIS",
-                    "PNG",
-                    "HDR",
-                    "TIFF",
-                    "OPEN_EXR",
-                    "OPEN_EXR_MULTILAYER",
-                    "CINEON",
-                    "DPX",
-                    "JPEG2000",
-                    "WEBP",
-                ],
-            },
-            {
-                "name": "GPUDevice",
-                "type": "STRING",
-                "userInterface": {
-                    "control": "LINE_EDIT",
-                    "label": "GPU Device",
-                },
-                "description": "The GPU device type to render with when using the cycles engine.",
-                "default": "NONE",
-            },
-            {
-                "name": "StrictErrorChecking",
-                "type": "STRING",
-                "userInterface": {
-                    "control": "CHECK_BOX",
-                    "label": "Strict Error Checking",
-                    "groupLabel": "Blender Settings",
-                },
-                "description": "Fail when errors occur.",
-                "default": "false",
-                "allowedValues": ["true", "false"],
-            },
-            {
-                "name": None,
-                "type": "INT",
-                "userInterface": {
-                    "control": "SPIN_BOX",
-                    "label": "Image Width",
-                    "groupLabel": "dummy_group_label",
-                },
-                "minValue": 1,
-                "description": "The image width.",
-            },
-            {
-                "name": None,
-                "type": "INT",
-                "userInterface": {
-                    "control": "SPIN_BOX",
-                    "label": "Image Height",
-                    "groupLabel": "dummy_group_label",
-                },
-                "minValue": 1,
-                "description": "The image height.",
-            },
-        ],
-        "steps": [
-            {
-                "name": "layer_1",
-                "parameterSpace": {
-                    "taskParameterDefinitions": [
-                        {"name": "Frame", "type": "INT", "range": "{{Param.Frames}}"},
-                        {"name": "Camera", "type": "STRING", "range": ["Camera"]},
-                    ]
-                },
-                "stepEnvironments": [
-                    {
-                        "name": "Blender",
-                        "description": "Runs Blender in the background.",
-                        "script": {
-                            "embeddedFiles": [
-                                {
-                                    "name": "initData",
-                                    "filename": "init-data.yaml",
-                                    "type": "TEXT",
-                                    "data": "scene_file: {{Param.BlenderFile}}\nrender_engine: {{Param.RenderEngine}}\ngpu_device: {{Param.GPUDevice}}\nrender_scene: {{Param.RenderScene}}\nview_layer: layer_1\noutput_dir: {{Param.OutputDir}}\noutput_file_name: {{Param.OutputFileName}}\noutput_format: {{Param.OutputFormat}}\nrenderer: dummy_renderer\noutput_file_prefix: {{Param.OutputFilePrefix}}\nimage_width: {{Param.ImageWidth}}\nimage_height: {{Param.ImageHeight}}",
-                                }
-                            ],
-                            "actions": {
-                                "onEnter": {
-                                    "command": "blender-openjd",
-                                    "args": [
-                                        "daemon",
-                                        "start",
-                                        "--connection-file",
-                                        "{{Session.WorkingDirectory}}/connection.json",
-                                        "--init-data",
-                                        "file://{{Env.File.initData}}",
-                                    ],
-                                    "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
-                                    "timeout": 3720,
-                                },
-                                "onExit": {
-                                    "command": "blender-openjd",
-                                    "args": [
-                                        "daemon",
-                                        "stop",
-                                        "--connection-file",
-                                        "{{ Session.WorkingDirectory }}/connection.json",
-                                    ],
-                                    "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
-                                    "timeout": 120,
-                                },
-                            },
-                        },
-                    }
-                ],
-                "script": {
-                    "embeddedFiles": [
-                        {
-                            "name": "runData",
-                            "filename": "run-data.yaml",
-                            "type": "TEXT",
-                            "data": "frame: {{Task.Param.Frame}}\ncamera: '{{Task.Param.Camera}}'\n",
-                        }
-                    ],
-                    "actions": {
-                        "onRun": {
-                            "command": "blender-openjd",
-                            "args": [
-                                "daemon",
-                                "run",
-                                "--connection-file",
-                                "{{ Session.WorkingDirectory }}/connection.json",
-                                "--run-data",
-                                "file://{{ Task.File.runData }}",
-                            ],
-                            "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
-                        }
-                    },
-                },
-            },
-            {
-                "name": "layer_2",
-                "parameterSpace": {
-                    "taskParameterDefinitions": [
-                        {"name": "Frame", "type": "INT", "range": "{{Param.Frames}}"},
-                        {"name": "Camera", "type": "STRING", "range": ["Camera"]},
-                    ]
-                },
-                "stepEnvironments": [
-                    {
-                        "name": "Blender",
-                        "description": "Runs Blender in the background.",
-                        "script": {
-                            "embeddedFiles": [
-                                {
-                                    "name": "initData",
-                                    "filename": "init-data.yaml",
-                                    "type": "TEXT",
-                                    "data": "scene_file: {{Param.BlenderFile}}\nrender_engine: {{Param.RenderEngine}}\ngpu_device: {{Param.GPUDevice}}\nrender_scene: {{Param.RenderScene}}\nview_layer: layer_2\noutput_dir: {{Param.OutputDir}}\noutput_file_name: {{Param.OutputFileName}}\noutput_format: {{Param.OutputFormat}}\nrenderer: dummy_renderer\noutput_file_prefix: {{Param.OutputFilePrefix}}\nimage_width: {{Param.ImageWidth}}\nimage_height: {{Param.ImageHeight}}",
-                                }
-                            ],
-                            "actions": {
-                                "onEnter": {
-                                    "command": "blender-openjd",
-                                    "args": [
-                                        "daemon",
-                                        "start",
-                                        "--connection-file",
-                                        "{{Session.WorkingDirectory}}/connection.json",
-                                        "--init-data",
-                                        "file://{{Env.File.initData}}",
-                                    ],
-                                    "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
-                                    "timeout": 3720,
-                                },
-                                "onExit": {
-                                    "command": "blender-openjd",
-                                    "args": [
-                                        "daemon",
-                                        "stop",
-                                        "--connection-file",
-                                        "{{ Session.WorkingDirectory }}/connection.json",
-                                    ],
-                                    "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
-                                    "timeout": 120,
-                                },
-                            },
-                        },
-                    }
-                ],
-                "script": {
-                    "embeddedFiles": [
-                        {
-                            "name": "runData",
-                            "filename": "run-data.yaml",
-                            "type": "TEXT",
-                            "data": "frame: {{Task.Param.Frame}}\ncamera: '{{Task.Param.Camera}}'\n",
-                        }
-                    ],
-                    "actions": {
-                        "onRun": {
-                            "command": "blender-openjd",
-                            "args": [
-                                "daemon",
-                                "run",
-                                "--connection-file",
-                                "{{ Session.WorkingDirectory }}/connection.json",
-                                "--run-data",
-                                "file://{{ Task.File.runData }}",
-                            ],
-                            "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
-                        }
-                    },
-                },
-            },
-        ],
-    }
-
-    filled = template_filling.fill_job_template(
-        submitter_settings, LAYER_NAMES, common_layer_settings, host_requirements=None
-    )
-    assert filled == expected
-
-    # Adding host requirements to the call adds them to each step.
-    host_reqs = {"GPU": "1"}
-    filled = template_filling.fill_job_template(
-        submitter_settings, LAYER_NAMES, common_layer_settings, host_requirements=host_reqs
-    )
-    for step in filled["steps"]:
-        assert step["hostRequirements"] == host_reqs
-
-
-def test_get_param_values(submitter_settings, common_layer_settings):
-    """Test getting param values."""
-    expected_settings = {
-        "BlenderFile": submitter_settings.project_path,
-        "OutputFileName": common_layer_settings.output_file_prefix,
-        "OutputDir": common_layer_settings.output_directories,
-        "RenderScene": common_layer_settings.scene_name,
-        "RenderEngine": common_layer_settings.renderer_name,
-        "GPUDevice": submitter_settings.gpu_device,
-    }
-    expected = [{"name": k, "value": v} for k, v in expected_settings.items()]
-
-    # Patching this scene setting causes GPUDevice to use the default value
-    with patch("bpy.context.scene.cycles.device", "CPU"):
-        filled = template_filling.get_parameter_values(
-            submitter_settings, common_layer_settings, queue_params=[]
-        )
-        assert filled == expected
-
-
-def test_conflicting_queue_params_error(submitter_settings, common_layer_settings):
-    # If queue params are passed, their keys should not conflict with existing keys. Expect an error if they do.
-    queue_params = [
-        {"name": "RenderScene", "value": common_layer_settings.scene_name + "_some_value"}
-    ]
-    with pytest.raises(DeadlineOperationError):
-        template_filling.get_parameter_values(
-            submitter_settings, common_layer_settings, queue_params=queue_params
-        )
-
-
-def test_get_queue_params(submitter_settings, common_layer_settings):
-    # If queue params are passed, and they don't conflict with existing keys, they should be added.
-    queue_params = [{"name": "SomeParam", "value": "some_value"}]
-    filled = template_filling.get_parameter_values(
-        submitter_settings, common_layer_settings, queue_params=queue_params
-    )
-    assert filled[-1] == queue_params[0]
-
-
-@pytest.mark.parametrize(
-    "queue_param_name,package_name",
-    [
-        pytest.param("RezPackages", "deadline_cloud_for_blender"),
-        pytest.param("CondaPackages", "blender-openjd"),
-    ],
-)
-def test_use_adaptor_wheels(
-    submitter_settings, common_layer_settings, queue_param_name, package_name
-):
-    """
-    Tests that default packages are excluded from CondaPackages and RezPackages if `include_adaptor_wheels` is true.
-    """
-
-    # GIVEN
-    queue_params = [
-        {
-            "name": queue_param_name,
-            "value": f"some_other_package {package_name} another_package",
-        }
-    ]
-
-    # WHEN
-    submitter_settings.include_adaptor_wheels = True
-    filled = template_filling.get_parameter_values(
-        submitter_settings, common_layer_settings, queue_params=queue_params
-    )
-
-    # THEN
-    assert filled[-1]["value"] == "some_other_package another_package"
-
-
-def test_add_ocio_template_data(submitter_settings, common_layer_settings):
-    """
-    Certain information should only be added to the template if an OCIO environment variable is set.
-    There should be an extra job environment and corresponding parameter.
-    """
-
-    expected_ocio_env = {"name": "Set OCIO Path", "variables": {"OCIO": "{{Param.OCIOConfigPath}}"}}
-    expected_ocio_param = {"name": "OCIOConfigPath", "value": "my_ocio_config.ocio"}
-
-    # GIVEN
-    submitter_settings.ocio_config_path = "my_ocio_config.ocio"
-
-    # WHEN
-    filled_template = template_filling.fill_job_template(
-        submitter_settings, LAYER_NAMES, common_layer_settings, host_requirements=None
-    )
-    params = template_filling.get_parameter_values(submitter_settings, common_layer_settings, [])
-
-    # THEN
-    assert expected_ocio_env in filled_template["jobEnvironments"]
-    assert expected_ocio_param in params
-
-
-def test_sort_auto_detected_assets():
-    """Test that auto-detected assets are properly classified."""
-    expected_input_filenames = set(["file_1.blend", "file_2.abc"])
-    expected_input_dirs = set(["dir_1", "dir_2"])
-
-    # WHEN find_files returns a mix of files and directories, classify them before adding them to the dialog.
     with (
-        patch(
-            "deadline.blender_submitter.addons.deadline_cloud_blender_submitter.open_deadline_cloud_dialog.bu.find_files",
-            Mock(
-                return_value=[
-                    Path("dir_1"),
-                    Path("file_1.blend"),
-                    Path("dir_2"),
-                    Path("file_2.abc"),
-                ]
-            ),
+        mock.patch.object(api_mod.bpy, "data") as bpy_data,
+        # classify_auto_detected_paths is the shared helper (blender_utils);
+        # it returns (files, dirs) already split.
+        mock.patch.object(
+            api_mod,
+            "classify_auto_detected_paths",
+            return_value=({str(tex)}, {str(sub)}),
         ),
-        patch.object(Path, "is_dir", side_effect=[True, False, True, False]),
+        mock.patch.object(api_mod.ocio, "get_current_ocio_referenced_dirs", return_value=[]),
     ):
+        bpy_data.filepath = "/proj/scene.blend"
+        api = api_mod.BlenderSubmitter()
+        refs = api.get_asset_references(settings)
 
-        auto_detected_assets = _get_auto_detected_assets("test_project_path.blend")
+    input_filenames, input_directories = _inputs(refs)
+    # the .blend itself plus the auto-detected texture are attached as inputs,
+    # and the auto-detected directory is attached as an input directory.
+    assert "/proj/scene.blend" in input_filenames
+    assert str(tex) in input_filenames
+    assert str(sub) in input_directories
+    assert _outputs(refs) == {"/out"}
 
-        assert auto_detected_assets.input_filenames == expected_input_filenames
-        assert auto_detected_assets.input_directories == expected_input_dirs
+
+def test_get_asset_references_survives_scan_failure():
+    api_mod = _import_api()
+    settings = api_mod.BlenderSubmitterSettings()
+    settings.input_directories = []
+    settings.output_directories = []
+
+    with (
+        mock.patch.object(api_mod.bpy, "data") as bpy_data,
+        mock.patch.object(
+            api_mod,
+            "classify_auto_detected_paths",
+            side_effect=RuntimeError("scan boom"),
+        ),
+        mock.patch.object(api_mod.ocio, "get_current_ocio_referenced_dirs", return_value=[]),
+    ):
+        bpy_data.filepath = "/proj/scene.blend"
+        api = api_mod.BlenderSubmitter()
+        # a scan failure must not blow up the submission; the .blend is still there
+        refs = api.get_asset_references(settings)
+
+    input_filenames, _ = _inputs(refs)
+    assert "/proj/scene.blend" in input_filenames
 
 
-def test_fill_job_template_use_default_camera(submitter_settings, common_layer_settings):
-    """Test filling the job template when camera_selection is 'Use Default Camera'."""
+def test_get_asset_references_honors_caller_input_filenames(tmp_path):
+    """Caller-supplied input_filenames must be preserved, not dropped."""
+    api_mod = _import_api()
 
-    # Set camera_selection to "Use Default Camera"
-    submitter_settings.camera_selection = "Use Default Camera"
+    settings = api_mod.BlenderSubmitterSettings()
+    settings.input_filenames = ["/extra/asset.abc"]
+    settings.input_directories = ["/extra/dir"]
+    settings.output_directories = []
 
-    filled = template_filling.fill_job_template(
-        submitter_settings, ["layer_1"], common_layer_settings, host_requirements=None
-    )
+    with (
+        mock.patch.object(api_mod.bpy, "data") as bpy_data,
+        mock.patch.object(api_mod, "classify_auto_detected_paths", return_value=(set(), set())),
+        mock.patch.object(api_mod.ocio, "get_current_ocio_referenced_dirs", return_value=[]),
+    ):
+        bpy_data.filepath = "/proj/scene.blend"
+        api = api_mod.BlenderSubmitter()
+        refs = api.get_asset_references(settings)
 
-    # Check that Camera parameter is NOT in taskParameterDefinitions
-    task_param_defs = filled["steps"][0]["parameterSpace"]["taskParameterDefinitions"]
-    camera_params = [param for param in task_param_defs if param.get("name") == "Camera"]
-    assert (
-        len(camera_params) == 0
-    ), "Camera parameter should not be defined when using default camera"
+    input_filenames, input_directories = _inputs(refs)
+    assert "/extra/asset.abc" in input_filenames
+    assert "/extra/dir" in input_directories
+    assert "/proj/scene.blend" in input_filenames
 
-    # Check that camera is NOT set in the embedded RunData file
-    run_data = filled["steps"][0]["script"]["embeddedFiles"][0]["data"]
-    assert (
-        "camera:" not in run_data
-    ), "Camera should not be set in RunData when using default camera"
+
+def test_get_asset_references_attaches_ocio_dirs(tmp_path):
+    """Directories referenced by a custom OCIO config are attached as inputs."""
+    api_mod = _import_api()
+
+    settings = api_mod.BlenderSubmitterSettings()
+    settings.input_directories = []
+    settings.output_directories = []
+    settings.ocio_config_path = "/color/config.ocio"
+
+    with (
+        mock.patch.object(api_mod.bpy, "data") as bpy_data,
+        mock.patch.object(api_mod, "classify_auto_detected_paths", return_value=(set(), set())),
+        mock.patch.object(
+            api_mod.ocio, "get_current_ocio_referenced_dirs", return_value=["/color/luts"]
+        ) as get_ocio_dirs,
+    ):
+        bpy_data.filepath = "/proj/scene.blend"
+        api = api_mod.BlenderSubmitter()
+        refs = api.get_asset_references(settings)
+
+    _, input_directories = _inputs(refs)
+    assert "/color/luts" in input_directories
+    # the explicitly-set ocio_config_path is honored (passed to the helper)
+    get_ocio_dirs.assert_called_once_with("/color/config.ocio")
+
+
+def test_get_asset_references_survives_bad_ocio_config():
+    """A broken OCIO config must not block submission."""
+    api_mod = _import_api()
+
+    settings = api_mod.BlenderSubmitterSettings()
+    settings.input_directories = []
+    settings.output_directories = []
+    settings.ocio_config_path = "/color/config.ocio"
+
+    with (
+        mock.patch.object(api_mod.bpy, "data") as bpy_data,
+        mock.patch.object(api_mod, "classify_auto_detected_paths", return_value=(set(), set())),
+        mock.patch.object(
+            api_mod.ocio,
+            "get_current_ocio_referenced_dirs",
+            side_effect=RuntimeError("bad config"),
+        ),
+    ):
+        bpy_data.filepath = "/proj/scene.blend"
+        api = api_mod.BlenderSubmitter()
+        refs = api.get_asset_references(settings)
+
+    input_filenames, _ = _inputs(refs)
+    assert "/proj/scene.blend" in input_filenames
+
+
+def test_get_settings_defaults_camera_when_none():
+    """When the active scene has no camera, fall back to 'Use Default Camera'."""
+    api_mod = _import_api()
+
+    scene = mock.MagicMock()
+    scene.camera = None
+    scene.render.engine = "CYCLES"
+    scene.render.filepath = ""
+    scene.view_layers = []
+
+    with (
+        mock.patch.object(api_mod.bpy, "context") as ctx,
+        mock.patch.object(api_mod.bpy, "data") as bpy_data,
+        mock.patch.object(api_mod, "get_active_scene_name", return_value="Scene"),
+        mock.patch.object(api_mod, "get_frames", return_value="1-1"),
+        mock.patch.object(api_mod.ocio, "get_ocio_path", return_value=""),
+    ):
+        ctx.scene = scene
+        bpy_data.filepath = "/proj/scene.blend"
+        api_mod.bpy.path.basename.return_value = "scene.blend"
+        api = api_mod.BlenderSubmitter()
+        settings = api.get_settings()
+
+    assert settings.camera_selection == "Use Default Camera"
+
+
+def test_get_settings_populates_gpu_from_helper():
+    """get_settings reads GPU settings via resolve_gpu_settings."""
+    api_mod = _import_api()
+
+    scene = mock.MagicMock()
+    scene.camera = None
+    scene.render.engine = "CYCLES"
+    scene.render.filepath = ""
+    scene.view_layers = []
+
+    with (
+        mock.patch.object(api_mod.bpy, "context") as ctx,
+        mock.patch.object(api_mod.bpy, "data") as bpy_data,
+        mock.patch.object(api_mod, "get_active_scene_name", return_value="Scene"),
+        mock.patch.object(api_mod, "get_frames", return_value="1-1"),
+        mock.patch.object(api_mod, "resolve_gpu_settings", return_value=(True, "CUDA")),
+        mock.patch.object(api_mod.ocio, "get_ocio_path", return_value=""),
+    ):
+        ctx.scene = scene
+        bpy_data.filepath = "/proj/scene.blend"
+        api_mod.bpy.path.basename.return_value = "scene.blend"
+        api = api_mod.BlenderSubmitter()
+        settings = api.get_settings()
+
+    assert settings.enable_gpu is True
+    assert settings.gpu_device == "CUDA"
+
+
+def test_blender_submitter_settings_gpu_device_defaults_to_none_sentinel():
+    """The default gpu_device must be the "NONE" sentinel, not "None"."""
+    api_mod = _import_api()
+    assert api_mod.BlenderSubmitterSettings().gpu_device == "NONE"
+
+
+def test_get_settings_uses_scene_camera_when_present():
+    api_mod = _import_api()
+
+    scene = mock.MagicMock()
+    scene.camera.name = "RenderCam"
+    scene.render.engine = "CYCLES"
+    scene.render.filepath = ""
+    scene.view_layers = []
+
+    with (
+        mock.patch.object(api_mod.bpy, "context") as ctx,
+        mock.patch.object(api_mod.bpy, "data") as bpy_data,
+        mock.patch.object(api_mod, "get_active_scene_name", return_value="Scene"),
+        mock.patch.object(api_mod, "get_frames", return_value="1-1"),
+        mock.patch.object(api_mod.ocio, "get_ocio_path", return_value=""),
+    ):
+        ctx.scene = scene
+        bpy_data.filepath = "/proj/scene.blend"
+        api_mod.bpy.path.basename.return_value = "scene.blend"
+        api = api_mod.BlenderSubmitter()
+        settings = api.get_settings()
+
+    assert settings.camera_selection == "RenderCam"
+
+
+def test_get_settings_populates_ocio_config_path():
+    api_mod = _import_api()
+
+    scene = mock.MagicMock()
+    scene.camera = None
+    scene.render.engine = "CYCLES"
+    scene.render.filepath = ""
+    scene.view_layers = []
+
+    with (
+        mock.patch.object(api_mod.bpy, "context") as ctx,
+        mock.patch.object(api_mod.bpy, "data") as bpy_data,
+        mock.patch.object(api_mod, "get_active_scene_name", return_value="Scene"),
+        mock.patch.object(api_mod, "get_frames", return_value="1-1"),
+        mock.patch.object(api_mod.ocio, "get_ocio_path", return_value="/color/config.ocio"),
+    ):
+        ctx.scene = scene
+        bpy_data.filepath = "/proj/scene.blend"
+        api_mod.bpy.path.basename.return_value = "scene.blend"
+        api = api_mod.BlenderSubmitter()
+        settings = api.get_settings()
+
+    assert settings.ocio_config_path == "/color/config.ocio"
+
+
+def test_build_common_layer_settings_populates_renderable_cameras():
+    """renderable_camera_names must be populated so 'All Renderable Cameras' works."""
+    api_mod = _import_api()
+
+    settings = api_mod.BlenderSubmitterSettings()
+    settings.scene_name = "Scene"
+    settings.frame_list = "1-1"
+
+    with mock.patch.object(
+        api_mod, "get_renderable_cameras", return_value=["CamA", "CamB"]
+    ) as get_cams:
+        api = api_mod.BlenderSubmitter()
+        common = api._build_common_layer_settings(settings)
+
+    get_cams.assert_called_once_with("Scene")
+    assert common.renderable_camera_names == ["CamA", "CamB"]
+
+
+def test_build_common_layer_settings_propagates_bad_scene_name():
+    """An unresolvable scene name must surface (KeyError), not be swallowed —
+    a silent [] would hide a real misconfiguration."""
+    api_mod = _import_api()
+
+    settings = api_mod.BlenderSubmitterSettings()
+    settings.scene_name = "Nonexistent"
+    settings.frame_list = "1-1"
+
+    with mock.patch.object(api_mod, "get_renderable_cameras", side_effect=KeyError("Nonexistent")):
+        api = api_mod.BlenderSubmitter()
+        with pytest.raises(KeyError):
+            api._build_common_layer_settings(settings)
+
+
+def test_build_common_layer_settings_empty_when_no_cameras():
+    """A scene with no renderable cameras yields an empty camera dimension."""
+    api_mod = _import_api()
+
+    settings = api_mod.BlenderSubmitterSettings()
+    settings.scene_name = "Scene"
+    settings.frame_list = "1-1"
+
+    with mock.patch.object(api_mod, "get_renderable_cameras", return_value=[]):
+        api = api_mod.BlenderSubmitter()
+        common = api._build_common_layer_settings(settings)
+
+    assert common.renderable_camera_names == []
+
+
+# ---------------------------------------------------------------------------
+# _resolve_view_layer_names — shared by the GUI and the unified API path so
+# both honor view_layer_selection identically (the reviewer's dedup concern).
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_view_layers_empty_selection_renders_all():
+    """Empty selection expands to every renderable view layer."""
+    api_mod = _import_api()
+
+    settings = api_mod.BlenderSubmitterSettings()
+    settings.scene_name = "Scene"
+    settings.view_layer_selection = ""
+
+    with mock.patch.object(
+        api_mod, "get_renderable_view_layers", return_value=["View Layer", "Extra"]
+    ) as get_layers:
+        api = api_mod.BlenderSubmitter()
+        layers = api._resolve_view_layer_names(settings)
+
+    get_layers.assert_called_once_with("Scene")
+    assert layers == ["View Layer", "Extra"]
+
+
+def test_resolve_view_layers_all_sentinel_renders_all():
+    """The 'All Renderable Layers' sentinel expands to every renderable layer."""
+    api_mod = _import_api()
+
+    settings = api_mod.BlenderSubmitterSettings()
+    settings.scene_name = "Scene"
+    settings.view_layer_selection = "All Renderable Layers"
+
+    with mock.patch.object(api_mod, "get_renderable_view_layers", return_value=["A", "B"]):
+        api = api_mod.BlenderSubmitter()
+        layers = api._resolve_view_layer_names(settings)
+
+    assert layers == ["A", "B"]
+
+
+def test_resolve_view_layers_single_selection_renders_only_it():
+    """A specific selection renders only that layer, without scanning all layers."""
+    api_mod = _import_api()
+
+    settings = api_mod.BlenderSubmitterSettings()
+    settings.scene_name = "Scene"
+    settings.view_layer_selection = "Beauty"
+
+    with mock.patch.object(
+        api_mod, "get_renderable_view_layers", side_effect=AssertionError("must not scan")
+    ):
+        api = api_mod.BlenderSubmitter()
+        layers = api._resolve_view_layer_names(settings)
+
+    assert layers == ["Beauty"]
+
+
+def test_resolve_view_layers_empty_scene_name_raises():
+    """An empty scene_name fails fast with an actionable error rather than
+    falling back to job_name and producing a confusing KeyError downstream."""
+    from deadline.client.exceptions import DeadlineOperationError
+
+    api_mod = _import_api()
+
+    settings = api_mod.BlenderSubmitterSettings()
+    settings.job_name = "myfile.blend"  # a .blend name, NOT a scenes key
+    settings.scene_name = ""
+
+    api = api_mod.BlenderSubmitter()
+    with pytest.raises(DeadlineOperationError, match="scene_name"):
+        api._resolve_view_layer_names(settings)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Blender could only be driven through its native GUI submitter. The unified `BaseSubmitter` ABC (aws-deadline/deadline-cloud#1245) defines a shared, DCC-agnostic submission contract so hosts can be driven programmatically (e.g. the AYON/headless path) using one common interface. Blender needed an implementation of that contract, without regressing the existing GUI submit flow.

### What was the solution? (How)

Implement `BlenderSubmitter(BaseSubmitter)` and route the GUI through it so both paths build identical job bundles.

- **New `deadline_cloud_blender_submitter/submitter.py`** — `BlenderSubmitter` implements `get_settings` / `get_job_template` / `get_parameter_values` / `get_asset_references` (+ inherited `get_submission_context`). Imports `BaseSubmitter` / `BaseSubmitterSettings` from `deadline.client.api`; the settings field is `job_name`.
- **`BlenderSubmitterSettings` lives in `template_filling.py`** (alongside the builders that consume it) and is re-exported from `submitter.py`. The builders read it directly, so the module dependency flows one way (`submitter` → `template_filling`, no import cycle). The GUI adapts its `BlenderSubmitterUISettings` → `BlenderSubmitterSettings` at the submission boundary via `_ui_settings_to_submitter_settings` in `open_deadline_cloud_dialog.py`. Blender stays **stateless** (Maya's stateful scene-context refactor is Maya-specific and not mirrored here).
- **`blender_utils` shared helpers** (used by both the GUI and API paths so they resolve identically):
  - `get_active_scene_name()` returns the real active scene (a valid `bpy.data.scenes` key) for the API path; `get_scene_name()` stays `.blend`-filename-derived so the dialog's default **job name** is unchanged.
  - `get_render_engine()` maps Blender engine ids (`BLENDER_EEVEE` / `BLENDER_EEVEE_NEXT` / `CYCLES` / `BLENDER_WORKBENCH`) to the template's `RenderEngine` allowed values (`eevee` / `cycles` / `workbench`), and raises a clear `DeadlineOperationError` for unsupported (third-party) engines rather than forwarding an out-of-range value that CreateJob rejects opaquely.
  - `resolve_output_path()` / `resolve_output_file_prefix()` resolve the output **directory** (with scene → prefs → blend-dir fallbacks) and filename prefix.
  - `resolve_gpu_settings()` reads `enable_gpu` / `gpu_device` from the scene, gating `gpu_device` to the `"NONE"` sentinel unless the scene actually renders on GPU (mirrors the widget).
  - `classify_auto_detected_paths()` auto-detects external dependencies (textures / linked libs / UDIM tiles / OCIO) and attaches them as job inputs.

Naming tracks aws-deadline/deadline-cloud#1245 + aws-deadline/deadline-cloud-for-maya#435: `SubmitterAPI` → `BaseSubmitter`, `SubmitterSettings` → `BaseSubmitterSettings` (re-exported from `deadline.client.api`); settings field `name` → `job_name`; module `submitter_api.py` → `submitter.py`; class `BlenderSubmitterAPI` → `BlenderSubmitter` (matches Maya's `MayaSubmitter`).

### What is the impact of this change?

- Blender can now be driven through the unified `BaseSubmitter` contract (enables the AYON/headless submission path) **in addition to** the existing native GUI submitter.
- The GUI submit flow is preserved: it now delegates bundle construction to `BlenderSubmitter`, so the GUI and API paths produce identical templates and parameter values from one set of builders.
- One intentional behavior change in the GUI flow: `GPUDevice` now emits the `"NONE"` sentinel (uppercase) for CPU scenes instead of `"None"`, matching `default_blender_template.yaml` and the adaptor's case-sensitive `CyclesHandler` check (previously `"None"` could slip onto the GPU path on a GPU-equipped worker).
- **Depends on** aws-deadline/deadline-cloud#1245 — shipped in `deadline` **0.60.2**; `pyproject.toml` pins `deadline >= 0.60.2, < 0.61` (0.60.0/0.60.1 do not export the base classes).

### How was this change tested?

- **Unit suite** against `deadline` 0.60.2: **60 passed, 0 skipped**; `ruff` + `black` + `mypy` clean. CI (full Python matrix + CodeQL) is green on the current head.
- **GUI publish → BlenderSubmitter → CreateJob → 10/10 SUCCEEDED** render (10 PNGs) on a live farm.

#### Please run the integration tests and paste the results below

Submitter integration suite (`test/integ/test_blender_submitters.py`, `-m submitter`) — Blender 5.1.2, `deadline` 0.60.2, Rocky Linux 9, `QT_QPA_PLATFORM=offscreen`. Each test launches Blender headless, drives `BlenderSubmitter` via `_create_bundle_internal` to export a job bundle, and validates the generated `template.yaml` with `openjd check`:

```
$ pytest --no-cov test/integ -vvv --numprocesses=1 -m submitter
platform linux -- Python 3.11.13, pytest-9.1.1, pluggy-1.6.0
configfile: pyproject.toml
1 worker [3 items]

test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_submitter PASSED                    [ 33%]
test/integ/test_blender_submitters.py::TestSubmitters::test_minimal_scene_with_host_requirements_submitter PASSED [ 66%]
test/integ/test_blender_submitters.py::TestSubmitters::test_gpu_scene_submitter PASSED                         [100%]

============================== 3 passed in 6.70s ==============================
```

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

`installer/` is **not** modified. One file is **added** to `src/` (`.../deadline_cloud_blender_submitter/submitter.py`); no files removed. The addon is packaged as a directory tree (the installer copies `src/deadline/blender_submitter/addons/` wholesale), so adding a module within the existing package does not change the installer's file list or require installer-test updates.

### Was this change documented?

No user-facing docs change. The new module, shared helpers, and the settings-shape/naming changes are documented via docstrings and this PR description; the naming migration tracks aws-deadline/deadline-cloud#1245 and aws-deadline/deadline-cloud-for-maya#435.

### Is this a breaking change?

No. The native GUI submit flow is preserved (it now delegates to `BlenderSubmitter` but produces identical bundles), and `BlenderSubmitter` is an additive API. It does raise the minimum `deadline` dependency to `>= 0.60.2` (for the `BaseSubmitter` base classes).

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
