### PR TITLE
ci: add Security Scan stub (zizmor via reusable org workflow)

### DIFF
--- a/.github/actions/bump_precommit_hook/action.yml
+++ b/.github/actions/bump_precommit_hook/action.yml
@@ -8,9 +8,12 @@ runs:
   steps:
   - name: Update plugin Version
     shell: bash
+    env:
+      # Pass context via env, not inline ${{ }}, to avoid template injection.
+      SEMVER: ${{ inputs.semver }}
     run: |
-      major=$(printf ${{inputs.semver}} | cut -d '.' -f1)
-      minor=$(printf ${{inputs.semver}} | cut -d '.' -f2)
-      patch=$(printf ${{inputs.semver}} | cut -d '.' -f3)
+      major=$(printf "%s" "$SEMVER" | cut -d '.' -f1)
+      minor=$(printf "%s" "$SEMVER" | cut -d '.' -f2)
+      patch=$(printf "%s" "$SEMVER" | cut -d '.' -f3)
       sed -i "s/\"version\": ([0-9]*, [0-9]*, [0-9]*)/\"version\": ($major, $minor, $patch)/" ./src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py
       git add ./src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py

--- a/.github/actions/prepush_release_hook/action.yml
+++ b/.github/actions/prepush_release_hook/action.yml
@@ -11,13 +11,18 @@ runs:
   steps:
     - name: Zip submitter plugin
       shell: bash
+      env:
+        # Pass context via env, not inline ${{ }}, to avoid template injection.
+        SEMVER: ${{ inputs.semver }}
       run: |
         mkdir -p dist_extras
         cd src/deadline/blender_submitter/addons
-        zip -r  ../../../../dist_extras/blender_submitter_plugin_${{inputs.semver}}.zip .
+        zip -r  "../../../../dist_extras/blender_submitter_plugin_$SEMVER.zip" .
         cd ../../../../
 
     - name: Build Blender add-on and extension respository index
       shell: bash
+      env:
+        SEMVER: ${{ inputs.semver }}
       run: |
-        hatch run build-addon --version ${{ inputs.semver }}
+        hatch run build-addon --version "$SEMVER"

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -7,11 +7,12 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    # canonical dependabot auto-approve pattern; the job only has pull-requests: write and runs Dependabot's own metadata action
+    if: ${{ github.actor == 'dependabot[bot]' }} # zizmor: ignore[bot-conditions]
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR

--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -11,7 +11,7 @@
 # workflow_run identifiers and the role-ARN secret.
 name: Claude PR Review
 
-on:
+on: # zizmor: ignore[dangerous-triggers] -- workflow_run is intentional and safe here; see the header comment above (runs from default branch, fork PRs cannot alter behavior/secrets)
   workflow_run:
     workflows: ["Claude PR Review (collect)"]
     types:

--- a/.github/workflows/on_opened_pr.yml
+++ b/.github/workflows/on_opened_pr.yml
@@ -1,6 +1,9 @@
 name: On Opened PR
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
+  # workflow_run is intentional: it runs from the default branch with this
+  # repo's context (never a fork's copy), and only consumes the PR artifact via
+  # the reusable extract-PR-details workflow. A fork PR cannot alter behavior.
   workflow_run:
     workflows: ["Record PR"]
     types:

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -131,12 +131,12 @@ jobs:
         id-token: write
       steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.TagRelease.outputs.tag }}
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ needs.TagRelease.outputs.build-python-version }}
       - name: Install dependencies
@@ -146,5 +146,5 @@ jobs:
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -1,0 +1,21 @@
+name: "Security Scan"
+
+on:
+  push:
+    branches: [ "mainline", "feature_*", "patch_*" ]
+  pull_request:
+    branches: [ "mainline", "feature_*", "patch_*" ]
+  schedule:
+    - cron: '0 8 * * MON'
+
+jobs:
+  Scan:
+    name: Scan
+    # Central, extensible security-scan workflow (currently zizmor). New checks
+    # added there apply here automatically — no change needed to this stub.
+    uses: aws-deadline/.github/.github/workflows/reusable_security_scan.yml@mainline
+    permissions:
+      # The reusable workflow checks out this repo and fetches the central
+      # zizmor config, and reports findings to the run log / PR annotations
+      # (not the Security tab), so it only needs read access.
+      contents: read


### PR DESCRIPTION
## What

Adds a thin `.github/workflows/security_scan.yml` stub that calls the central reusable Security Scan workflow (`aws-deadline/.github/.github/workflows/reusable_security_scan.yml@mainline`, zizmor today). The gate fails PRs on **high**-severity zizmor findings; new checks added centrally apply here automatically.

## Prerequisite fixes

To make CI green under the new gate, this PR first fixes all **12 high-severity** zizmor findings (central config, `--min-severity high`):

- **template-injection (5)** — moved `${{ inputs.semver }}` out of composite-action `run:` blocks into `env:` vars referenced as shell `$SEMVER` (`bump_precommit_hook`, `prepush_release_hook`).
- **unpinned-uses (4)** — pinned third-party actions to full commit SHAs with version comments: `actions/checkout@v7.0.0`, `actions/setup-python@v6.3.0`, `pypa/gh-action-pypi-publish@v1.14.0` (release_publish.yml), `dependabot/fetch-metadata@v3.1.0` (auto_approve.yml).
- **bot-conditions (1)** — suppressed on the dependabot actor check (canonical auto-approve pattern; job only has `pull-requests: write`).
- **dangerous-triggers (2)** — suppressed the intentional `workflow_run` triggers that run from the default branch with this repo's context (fork PRs cannot alter behavior/secrets): `claude_pr_review.yml`, `on_opened_pr.yml`.

Internal `aws-deadline/*@mainline` reusable-workflow refs left as-is (central config allows ref-pin). `uvx zizmor --min-severity high` now reports **0 findings**.

Replicates aws-deadline/deadline-cloud#1256.