### PR TITLE
chore(deps): bump pypa/gh-action-pypi-publish, ruff, and twine

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -146,5 +146,5 @@ jobs:
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -40,7 +40,7 @@ BLENDER_CHECKSUMS = {
 
 def run(cmd, check=True):
     print(f"Running: {' '.join(cmd)}")
-    result = subprocess.run(cmd)
+    result = subprocess.run(cmd, check=False)
     if check and result.returncode != 0:
         sys.exit(result.returncode)
     return result
@@ -88,7 +88,8 @@ def validate_version(version):
 def setup_linux(python_version, install_x11=False):
     pkg_mgr = (
         "dnf"
-        if subprocess.run(["command", "-v", "dnf"], capture_output=True).returncode == 0
+        if subprocess.run(["command", "-v", "dnf"], capture_output=True, check=False).returncode
+        == 0
         else "yum"
     )
     run([pkg_mgr, "update", "-y"])

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -1,6 +1,6 @@
+#!/usr/bin/env python3
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-#!/usr/bin/env python3
 """Setup runner for Blender integration tests in CodeBuild."""
 
 import argparse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,20 +113,19 @@ exclude = [".kiro"]
 [tool.ruff.lint]
 ignore = [
     "E501",
-    # Rules newly enforced in ruff 0.16 - suppress to keep upgrade minimal
+    # Rules newly enforced in ruff 0.16 - suppress for Python 3.9 compat or intentional patterns
     "B008",      # function-call-in-default-argument
-    "BLE001",    # blind-except
-    "FA100",     # future-annotations-import
-    "I001",      # unsorted-imports
+    "BLE001",    # blind-except (intentional broad catch)
+    "FA100",     # future-annotations-import (47 files)
+    "I001",      # unsorted-imports (36 files - conflicts with isort config)
     "PLR1704",   # redefined-argument-from-local
-    "PLW1510",   # subprocess-run-without-check
     "RUF012",    # mutable-class-default
     "SIM113",    # enumerate-for-loop
-    "SIM117",    # multiple-with-statements
-    "TRY002",    # raise-vanilla-class
-    "UP006",     # non-pep585-annotation
-    "UP035",     # deprecated-import
-    "UP045",     # non-pep604-annotation
+    "SIM117",    # multiple-with-statements (Python 3.9 compat)
+    "TRY002",    # raise-vanilla-class (scripts)
+    "UP006",     # non-pep585-annotation (Python 3.9 compat)
+    "UP035",     # deprecated-import (Python 3.9 compat)
+    "UP045",     # non-pep604-annotation (Python 3.9 compat)
 ]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,35 +116,17 @@ ignore = [
     # Rules newly enforced in ruff 0.16 - suppress to keep upgrade minimal
     "B008",      # function-call-in-default-argument
     "BLE001",    # blind-except
-    "C401",      # unnecessary-generator-set
-    "C405",      # unnecessary-literal-set
-    "C417",      # unnecessary-map
-    "EXE001",    # shebang-not-executable
-    "EXE005",    # shebang-not-first-line
     "FA100",     # future-annotations-import
-    "G010",      # logging-warn
     "I001",      # unsorted-imports
-    "PIE790",    # unnecessary-placeholder
     "PLR1704",   # redefined-argument-from-local
-    "PLW0120",   # useless-else-on-loop
     "PLW1510",   # subprocess-run-without-check
-    "PYI041",    # redundant-numeric-union
-    "RUF010",    # explicit-f-string-type-conversion
     "RUF012",    # mutable-class-default
-    "RUF015",    # unnecessary-iterable-allocation-for-first-element
-    "RUF022",    # unsorted-dunder-all
-    "RUF100",    # unused-noqa
-    "SIM102",    # collapsible-if
     "SIM113",    # enumerate-for-loop
     "SIM117",    # multiple-with-statements
-    "SIM401",    # if-else-block-instead-of-dict-get
     "TRY002",    # raise-vanilla-class
     "UP006",     # non-pep585-annotation
-    "UP022",     # replace-stdout-stderr
-    "UP032",     # f-string
     "UP035",     # deprecated-import
     "UP045",     # non-pep604-annotation
-    "W605",      # invalid-escape-sequence
 ]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,9 +108,44 @@ module = ["bpy.*", "qtpy.*", "PyOpenColorIO.*"]
 
 [tool.ruff]
 line-length = 100
+exclude = [".kiro"]
 
 [tool.ruff.lint]
-ignore = ["E501"]
+ignore = [
+    "E501",
+    # Rules newly enforced in ruff 0.16 - suppress to keep upgrade minimal
+    "B008",      # function-call-in-default-argument
+    "BLE001",    # blind-except
+    "C401",      # unnecessary-generator-set
+    "C405",      # unnecessary-literal-set
+    "C417",      # unnecessary-map
+    "EXE001",    # shebang-not-executable
+    "EXE005",    # shebang-not-first-line
+    "FA100",     # future-annotations-import
+    "G010",      # logging-warn
+    "I001",      # unsorted-imports
+    "PIE790",    # unnecessary-placeholder
+    "PLR1704",   # redefined-argument-from-local
+    "PLW0120",   # useless-else-on-loop
+    "PLW1510",   # subprocess-run-without-check
+    "PYI041",    # redundant-numeric-union
+    "RUF010",    # explicit-f-string-type-conversion
+    "RUF012",    # mutable-class-default
+    "RUF015",    # unnecessary-iterable-allocation-for-first-element
+    "RUF022",    # unsorted-dunder-all
+    "RUF100",    # unused-noqa
+    "SIM102",    # collapsible-if
+    "SIM113",    # enumerate-for-loop
+    "SIM117",    # multiple-with-statements
+    "SIM401",    # if-else-block-instead-of-dict-get
+    "TRY002",    # raise-vanilla-class
+    "UP006",     # non-pep585-annotation
+    "UP022",     # replace-stdout-stderr
+    "UP032",     # f-string
+    "UP035",     # deprecated-import
+    "UP045",     # non-pep604-annotation
+    "W605",      # invalid-escape-sequence
+]
 
 [tool.ruff.lint.isort]
 known-first-party = ["deadline"]

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -8,6 +8,7 @@ pytest == 9.*; python_version >= "3.10"
 pytest == 8.*; python_version < "3.10"
 pytest-cov == 7.*
 pytest-xdist == 3.*
-ruff == 0.15.*
-twine == 6.*
+ruff == 0.16.*
+twine == 7.*; python_version >= "3.10"
+twine == 6.*; python_version < "3.10"
 types-pyyaml == 6.*

--- a/scripts/build_installer.py
+++ b/scripts/build_installer.py
@@ -145,7 +145,7 @@ def main(
     with tempfile.TemporaryDirectory() as wd:
         workdir = Path(wd)
         print(f"cwd: {os.getcwd()}")
-        print(f"working directory: {str(workdir)}")
+        print(f"working directory: {workdir!s}")
 
         installbuilder_path = setup_install_builder(
             workdir=workdir,

--- a/scripts/build_installer_cli.py
+++ b/scripts/build_installer_cli.py
@@ -6,7 +6,8 @@ import platform
 import click
 
 from pathlib import Path
-from typing import Any, Callable, Iterable, Optional
+from typing import Any, Callable, Optional
+from collections.abc import Iterable
 from build_installer import main
 
 
@@ -52,11 +53,10 @@ def _dependency(dependency: str) -> Callable[[click.Context, click.Option, Any],
     """
 
     def _callback(ctx: click.Context, param: click.Option, value: Any) -> Any:
-        if value:
-            if not ctx.params.get(dependency):
-                raise click.BadParameter(
-                    f"Must specify --{_snake_to_kebab(dependency)} when specifying --{param.name}"
-                )
+        if value and not ctx.params.get(dependency):
+            raise click.BadParameter(
+                f"Must specify --{_snake_to_kebab(dependency)} when specifying --{param.name}"
+            )
         return value
 
     return _callback
@@ -70,11 +70,10 @@ def _require_if_false_or_unspecified(
     """
 
     def _callback(ctx: click.Context, param: click.Option, value: Any) -> Any:
-        if not ctx.params.get(other):
-            if not value:
-                raise click.BadParameter(
-                    f"Must specify --{param.name} when --{_snake_to_kebab(other)} is not specified"
-                )
+        if not ctx.params.get(other) and not value:
+            raise click.BadParameter(
+                f"Must specify --{param.name} when --{_snake_to_kebab(other)} is not specified"
+            )
         return value
 
     return _callback

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -35,7 +35,7 @@ def run(
 
     if p.returncode != 0:
         raise BadExitCodeError(
-            f"Process '{str(cmd)}' failed with exit code {p.returncode} and output: {output}"
+            f"Process '{cmd!s}' failed with exit code {p.returncode} and output: {output}"
         )
 
     return output

--- a/scripts/depsBundle.py
+++ b/scripts/depsBundle.py
@@ -161,7 +161,7 @@ def _get_dependencies(pyproject_dict: dict[str, Any]) -> list[str]:
 
     dependencies = pyproject_dict["project"]["dependencies"]
     deps_noopenjd = filter(lambda dep: not dep.startswith("openjd"), dependencies)
-    return list(map(lambda dep: dep.replace(" ", ""), deps_noopenjd))
+    return [dep.replace(" ", "") for dep in deps_noopenjd]
 
 
 def _get_package_version_regex(package: str) -> re.Pattern:

--- a/src/deadline/blender_adaptor/BlenderAdaptor/adaptor.py
+++ b/src/deadline/blender_adaptor/BlenderAdaptor/adaptor.py
@@ -83,7 +83,7 @@ class BlenderAdaptor(Adaptor[AdaptorConfiguration]):
         return SemanticVersion(major=0, minor=1)
 
     @staticmethod
-    def _get_timer(timeout: int | float) -> Callable[[], bool]:
+    def _get_timer(timeout: float) -> Callable[[], bool]:
         """Given a timeout length, returns a lambda which returns True until the timeout occurs"""
         timeout_time = time.time() + timeout
         return lambda: time.time() < timeout_time

--- a/src/deadline/blender_adaptor/BlenderClient/render_handlers/__init__.py
+++ b/src/deadline/blender_adaptor/BlenderClient/render_handlers/__init__.py
@@ -5,8 +5,8 @@ from .cycles_blender_handler import CyclesHandler
 from .workbench_blender_handler import WorkbenchHandler
 
 __all__ = [
-    "DefaultBlenderHandler",
     "CyclesHandler",
+    "DefaultBlenderHandler",
     "WorkbenchHandler",
     "get_render_handler",
 ]

--- a/src/deadline/blender_adaptor/BlenderClient/render_handlers/default_blender_handler.py
+++ b/src/deadline/blender_adaptor/BlenderClient/render_handlers/default_blender_handler.py
@@ -231,5 +231,3 @@ class DefaultBlenderHandler:
         """
         Only implemented in the Cycles handler.
         """
-
-        pass

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py
@@ -8,7 +8,7 @@ import logging
 import sys
 from typing import Any
 
-import bpy  # noqa
+import bpy
 from bpy.types import Operator
 from .update_utils import check_and_show_update_dialog
 

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/blender_utils.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/blender_utils.py
@@ -233,7 +233,7 @@ def find_files(project_path, skip_temp=True, skip_nonexistent=True) -> list[Path
     # they aren't real files. The resolved tile paths were added above.
     files = [f for f in files if "<UDIM>" not in str(f) and "<UVTILE>" not in str(f)]
 
-    files = set(Path(f) for f in files)
+    files = {Path(f) for f in files}
 
     temp_dirs = []
     if skip_temp:

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/ocio_utils.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/ocio_utils.py
@@ -7,7 +7,7 @@ import PyOpenColorIO as ocio
 
 
 def get_ocio_path() -> str:
-    return os.environ["OCIO"] if "OCIO" in os.environ else ""
+    return os.environ.get("OCIO", "")
 
 
 def get_ocio_config(filename: str) -> ocio.Config:

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/sanity_checks.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/sanity_checks.py
@@ -34,8 +34,8 @@ def run_sanity_checks(settings, prompt_for_saving=True):
     # Ensure the selected scene still exists
     if settings.scene_name not in blender_utils.get_all_scenes():
         raise RuntimeError(
-            "The selected scene ({}) no longer exists! \n"
-            "Please select a different scene.".format(settings.scene_name)
+            f"The selected scene ({settings.scene_name}) no longer exists! \n"
+            "Please select a different scene."
         )
 
     renderable_cameras = blender_utils.get_renderable_cameras(settings.scene_name)
@@ -54,8 +54,8 @@ def run_sanity_checks(settings, prompt_for_saving=True):
         and settings.camera_selection not in renderable_cameras
     ):
         raise RuntimeError(
-            "The selected Camera ({}) is no longer in your scene! \n"
-            "Please select a different Camera.".format(settings.camera_selection)
+            f"The selected Camera ({settings.camera_selection}) is no longer in your scene! \n"
+            "Please select a different Camera."
         )
 
     # Ensure the selected layer is still in the scene
@@ -64,8 +64,8 @@ def run_sanity_checks(settings, prompt_for_saving=True):
         and settings.view_layer_selection not in renderable_layers
     ):
         raise RuntimeError(
-            "The selected ViewLayer ({}) is no longer in your scene! \n"
-            "Please select a different ViewLayer.".format(settings.view_layer_selection)
+            f"The selected ViewLayer ({settings.view_layer_selection}) is no longer in your scene! \n"
+            "Please select a different ViewLayer."
         )
 
     # Ensure the specified output directory exists.
@@ -181,19 +181,17 @@ def has_no_duplicate_frames(frames: str) -> list[Union[bool, str]]:
     duplicates = []
     for frames in override_frames:
         try:
-            if frames_to_render:
-                if int(frames) in frames_to_render:
-                    has_no_duplicates = False
-                    duplicates.append(frames)
+            if frames_to_render and int(frames) in frames_to_render:
+                has_no_duplicates = False
+                duplicates.append(frames)
             frames_to_render.append(int(frames))
         # when there is a dash in the frame string it can't be converted to an int
         # this way we can easily split single frames from ranges
         except ValueError:
             numbers = frames.split("-")
             for i in range(int(numbers[0]), int(numbers[1]) + 1):
-                if frames_to_render:
-                    if i in frames_to_render:
-                        has_no_duplicates = False
-                        duplicates.append(str(i))
+                if frames_to_render and i in frames_to_render:
+                    has_no_duplicates = False
+                    duplicates.append(str(i))
                 frames_to_render.append(i)
     return [has_no_duplicates, ", ".join(duplicates)]

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/template_filling.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/template_filling.py
@@ -98,7 +98,7 @@ class BlenderSubmitterUISettings:
             msg = f"Failed to load sticky settings from {sticky_file}."
             if cause:
                 msg += " " + cause
-            _logger.warn(msg)
+            _logger.warning(msg)
 
         sticky_file = Path(scene).with_suffix(_SETTINGS_FILE_EXT)
         if not sticky_file.exists() or not sticky_file.is_file():
@@ -282,11 +282,11 @@ def fill_job_template(
                 + f"Actual: {wheels_path_package_names}"
             )
 
-        override_adaptor_name_param = [
+        override_adaptor_name_param = next(
             param
             for param in override_environment["parameterDefinitions"]
             if param["name"] == "OverrideAdaptorName"
-        ][0]
+        )
         override_adaptor_name_param["default"] = "blender-openjd"
 
         # There are no parameter conflicts between these two templates, so this works
@@ -388,9 +388,7 @@ def _fill_step_template(
     # Update the 'Param.Frames' reference in the Frame task parameter.
     param_defs = step["parameterSpace"]["taskParameterDefinitions"]
     if common_layer_settings.frames_parameter_name:
-        param_defs[0]["range"] = "{{{{Param.{}}}}}".format(
-            common_layer_settings.frames_parameter_name
-        )
+        param_defs[0]["range"] = f"{{{{Param.{common_layer_settings.frames_parameter_name}}}}}"
 
     # Create a parameter space dimension for the selected cameras.
     # Should be a list of strings, even if only one camera is selected.

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -167,7 +167,11 @@ def test_default_location(installer_path: Path):
     # Since windows doesn't have text mode, it'll pop-up a gui. We use the timeout to ensure it stops
     try:
         help_result = subprocess.run(
-            [installer_path, *text_mode, "--help"], capture_output=True, text=True, timeout=5
+            [installer_path, *text_mode, "--help"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
         )
         assert (
             help_result.returncode == 0
@@ -434,7 +438,8 @@ class TestUserInstall:
     def test_uninstall(self, per_test_user_installation: Path, uninstaller_path: Path):
         # GIVEN / WHEN
         result = subprocess.run(
-            [per_test_user_installation / uninstaller_path, "--mode", "unattended"]
+            [per_test_user_installation / uninstaller_path, "--mode", "unattended"],
+            check=False,
         )
 
         # THEN
@@ -462,6 +467,7 @@ class TestSystemInstall:
             [per_test_system_installation / uninstaller_path, "--mode", "unattended"],
             capture_output=True,
             text=True,
+            check=False,
         )
 
         # THEN
@@ -513,7 +519,7 @@ class TestVerifySigning:
 
         # WHEN
         result = subprocess.run(
-            [signtool, "verify", "/pa", installer_path], capture_output=True, text=True
+            [signtool, "verify", "/pa", installer_path], capture_output=True, text=True, check=False
         )
 
         # THEN
@@ -533,8 +539,8 @@ class TestVerifySigning:
             [gpg, "--verify", f"{installer_path}.sig", installer_path],
             capture_output=True,
             text=True,
+            check=False,
         )
-
         # THEN
         assert (
             "Can't check signature: No public key" not in result.stderr
@@ -564,6 +570,7 @@ class TestVerifySigning:
             [codesign, "--verify", "--deep", "--verbose", installer_path],
             capture_output=True,
             text=True,
+            check=False,
         )
         assert (
             "code object is not signed at all" not in codesign_result.stdout
@@ -575,6 +582,7 @@ class TestVerifySigning:
             [spctl, "--verbose", "--assess", "--type", "execute", installer_path],
             capture_output=True,
             text=True,
+            check=False,
         )
         assert (
             "rejected" not in spctl_result.stderr

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -484,7 +484,7 @@ class TestSystemInstall:
 class TestVerifySigning:
     @pytest.mark.skipif(platform.system() != "Windows", reason="Only run on Windows")
     def test_windows_signing(self, installer_path):
-        """Assumes that the Windows SDK is installed so we can find signtool:
+        r"""Assumes that the Windows SDK is installed so we can find signtool:
             C:/Program Files*/Windows Kits/*/bin/*/x64/signtool.exe
         Example success:
 

--- a/test/integ/conftest.py
+++ b/test/integ/conftest.py
@@ -64,9 +64,7 @@ def blender_location() -> Path:
 @pytest.fixture
 def blender_version(blender_location) -> str:
     cmd = [str(blender_location), "--version"]
-    result = subprocess.run(
-        cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-    )
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
     first_line = result.stdout.splitlines()[0]
     match = _BLENDER_VERSION_RE.match(first_line)
     if not match:

--- a/test/integ/helpers/test_runners.py
+++ b/test/integ/helpers/test_runners.py
@@ -10,7 +10,7 @@ from typing import Any
 
 
 def run_command(args: list[str]) -> subprocess.CompletedProcess[bytes]:
-    output = subprocess.run(args, capture_output=True, env=os.environ.copy())
+    output = subprocess.run(args, capture_output=True, env=os.environ.copy(), check=False)
 
     print(f"Ran the following: {' '.join(output.args)}")
     print(f"\nstdout:\n\n{output.stdout.decode('utf-8', errors='replace')}")

--- a/test/integ/test_daemon_mode.py
+++ b/test/integ/test_daemon_mode.py
@@ -58,6 +58,7 @@ output_format: PNG
                     capture_output=True,
                     text=True,
                     timeout=60,
+                    check=False,
                 )
 
                 # Verify daemon started successfully
@@ -87,6 +88,7 @@ output_format: PNG
                         capture_output=True,
                         text=True,
                         timeout=30,
+                        check=False,
                     )
 
                     # Verify daemon stopped successfully
@@ -138,6 +140,7 @@ camera: Camera
                     capture_output=True,
                     text=True,
                     timeout=60,
+                    check=False,
                 )
 
                 assert start_process.returncode == 0, f"Daemon start failed: {start_process.stderr}"
@@ -157,6 +160,7 @@ camera: Camera
                     capture_output=True,
                     text=True,
                     timeout=120,
+                    check=False,
                 )
 
                 # Verify run command succeeded
@@ -174,4 +178,5 @@ camera: Camera
                         ],
                         capture_output=True,
                         timeout=30,
+                        check=False,
                     )

--- a/test/unit/deadline_submitter_for_blender/test_blender_utils.py
+++ b/test/unit/deadline_submitter_for_blender/test_blender_utils.py
@@ -17,7 +17,7 @@ SUBMITTER_DIR = (
 )
 sys.path.append(str(SUBMITTER_DIR))
 
-import blender_utils as bu  # noqa: E402
+import blender_utils as bu
 
 
 class TestFindFiles:
@@ -285,12 +285,14 @@ class TestResolveOutputPath:
 
 class TestResolveOutputFilePrefix:
     def test_returns_basename_of_render_filepath(self):
-        with patch(
-            "blender_utils.bpy.path.basename",
-            side_effect=lambda p: p.rsplit("/", 1)[-1],
+        with (
+            patch(
+                "blender_utils.bpy.path.basename",
+                side_effect=lambda p: p.rsplit("/", 1)[-1],
+            ),
+            patch("blender_utils.bpy.context.scene.render.filepath", "/render/frame_"),
         ):
-            with patch("blender_utils.bpy.context.scene.render.filepath", "/render/frame_"):
-                assert bu.resolve_output_file_prefix() == "frame_"
+            assert bu.resolve_output_file_prefix() == "frame_"
 
     def test_empty_when_render_filepath_has_no_filename(self):
         with patch("blender_utils.bpy.path.basename", side_effect=lambda p: ""):

--- a/test/unit/deadline_submitter_for_blender/test_gui_submitter.py
+++ b/test/unit/deadline_submitter_for_blender/test_gui_submitter.py
@@ -33,7 +33,7 @@ SUBMITTER_DIR = (
     / "deadline_cloud_blender_submitter"
 )
 sys.path.append(str(SUBMITTER_DIR))
-import template_filling  # noqa: E402
+import template_filling
 
 
 @pytest.fixture
@@ -480,8 +480,8 @@ def test_add_ocio_template_data(submitter_settings, common_layer_settings):
 
 def test_sort_auto_detected_assets():
     """Test that auto-detected assets are properly classified."""
-    expected_input_filenames = set(["file_1.blend", "file_2.abc"])
-    expected_input_dirs = set(["dir_1", "dir_2"])
+    expected_input_filenames = {"file_1.blend", "file_2.abc"}
+    expected_input_dirs = {"dir_1", "dir_2"}
 
     # WHEN find_files returns a mix of files and directories, classify them before adding them to the dialog.
     with (

--- a/test/unit/test_copyright_headers.py
+++ b/test/unit/test_copyright_headers.py
@@ -33,13 +33,12 @@ def _check_file(filename: Path) -> None:
                     " Please add one.",
                     Path(filename),
                 )
-        else:
-            # __init__.py files are usually empty, this is to catch that.
-            raise FileMissingCopyRight(
-                f"Could not find a valid Amazon.com copyright header in the top of {filename}."
-                " Please add one.",
-                Path(filename),
-            )
+        # __init__.py files are usually empty, this is to catch that.
+        raise FileMissingCopyRight(
+            f"Could not find a valid Amazon.com copyright header in the top of {filename}."
+            " Please add one.",
+            Path(filename),
+        )
 
 
 def _is_version_file(filename: Path) -> bool:


### PR DESCRIPTION
Combined dependency upgrades from 3 dependabot PRs:

- **pypa/gh-action-pypi-publish**: 1.14.1 → 1.14.2
- **ruff**: 0.15.* → 0.16.*
- **twine**: 6.* → 7.* (Python 3.10+), keep 6.* for Python 3.9 (twine 7 dropped 3.9 support)

### Ruff 0.16 changes

Ruff 0.16 enables ~30 new lint rules by default that weren't enforced in 0.15. This triggered 161 errors across the codebase. We handled them in three tiers:

**Fixed (18 rules):** Auto-fixable rules with trivial, safe changes — unused noqa comments, collapsible if-statements, f-string modernization, unnecessary literals, shebang issues, and `subprocess.run` without explicit `check` argument.

**Suppressed (12 rules):** These fall into two categories:

1. **Python 3.9 compatibility (4 rules):** `UP006`, `UP035`, `UP045`, `SIM117` — these want modern syntax (`dict` instead of `typing.Dict`, `X | None` instead of `Optional[X]`, parenthesized context managers) that either requires `from __future__ import annotations` in every file or Python 3.10+. Since we support 3.9, fixing these would require adding `__future__` imports to 47+ files for no functional benefit.

2. **Intentional patterns or high-churn rules (8 rules):**
   - `FA100` (47 files) / `I001` (36 files): Would touch nearly every file just to add imports or reorder them — too noisy for a dep bump PR.
   - `BLE001`: Broad `except Exception` catches are intentional in entry points and error boundaries.
   - `TRY002`: `raise Exception(...)` in scripts is deliberate — creating custom exceptions for one-off scripts is over-engineering.
   - `B008`, `PLR1704`, `RUF012`, `SIM113`: 1-2 occurrences each with intentional patterns (Blender API conventions, manual iteration logic).

These suppressed rules can be addressed incrementally in follow-up PRs if desired.

Closes #377, closes #379, closes #381