### PR TITLE
fix: natively check for namedpip existance on windows

### DIFF
--- a/src/deadline/blender_adaptor/BlenderClient/blender_client.py
+++ b/src/deadline/blender_adaptor/BlenderClient/blender_client.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import ctypes
+import sys
 from types import FrameType
 from typing import Optional
 
@@ -17,6 +19,27 @@ except (ImportError, ModuleNotFoundError):
     from openjd.adaptor_runtime_client import ClientInterface
 
     from deadline.blender_adaptor.BlenderClient.render_handlers import get_render_handler
+
+
+def windows_pipe_exists(pipe_path: str) -> bool:
+    """Checks if a Windows Named Pipe exists using native kernel32 calls."""
+    if not pipe_path:
+        return False
+
+    # Standard disk file fallback
+    if sys.platform != "win32":
+        return os.path.exists(pipe_path)
+
+    # Call Win32 WaitNamedPipeW with a 0ms timeout
+    # Returns non-zero if a pipe instance exists
+    result = ctypes.windll.kernel32.WaitNamedPipeW(pipe_path, 0)
+    if result != 0:
+        return True
+
+    # GetLastError check
+    # ERROR_PIPE_BUSY (231) or ERROR_ACCESS_DENIED (5) means the pipe exists!
+    last_error = ctypes.GetLastError()
+    return last_error in (231, 5)
 
 
 class BlenderClient(ClientInterface):
@@ -44,7 +67,7 @@ def main():
             "BLENDER_ADAPTOR_SERVER_PATH does not exist"
         )
 
-    if not os.path.exists(server_path):
+    if not windows_pipe_exists(server_path):
         raise OSError(
             "BlenderClient cannot connect to the Adaptor because the server at the path defined by "
             "the environment variable BLENDER_ADAPTOR_SERVER_PATH does not exist. Got: "


### PR DESCRIPTION
Blender 5.2 switched to Python313 and with that switch the BlenderClient always exited with an Error

```
OSError: BlenderClient cannot connect to the Adaptor because the server at the path defined by the environment variable BLENDER_ADAPTOR_SERVER_PATH does not exist. Got: \\.\pipe\AdaptorServerNamedPipe_8788
```

### What was the problem/requirement? (What/Why)

See #383 for complete background. In summary - CPython changed the behaviour for `os.stat.exists()` between 311 and 313. 

**background**

> Why os.path.exists() Always Fails on Python 3.13 for Windows Pipes
> - CPython 3.13 Refactoring: In Python 3.13, CPython optimized os.stat() / os.path.exists() on Windows to use the GetFileAttributesExW Win32 API call.
> - NPFS Incompatibility: The Windows Named Pipe File System (NPFS / \\.\pipe\) does not support file attribute queries. When GetFileAttributesExW is called on a named pipe, Windows returns ERROR_FILE_NOT_FOUND (WinError 2).
> - The Result: Because GetFileAttributesExW fails, Python 3.13's os.path.exists(r"\\.\pipe\...") always evaluates to False, regardless of how long you wait or whether the pipe is active and healthy.
> The previous check worked in Python 3.10/3.11 because older CPython versions fell back to CreateFileW inside os.stat().

### What was the solution? (How)

- Implemented a helper method to check on windows explicitely if we are dealing with a pipe

### What is the impact of this change?

- Blender 5.2 will work

### How was this change tested?

- Locally 

#### Please run the integration tests and paste the results below

```
to be run
```

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

- No change

### Was this change documented?

- No

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*