### PR TITLE
docs: document pre-GUI submission hooks for Blender

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,25 @@ The Blender submitter can be installed and updated within Blender. Requires Blen
    <img alt="Screenshot of the Blender preferences window with the AWS Deadline Cloud add-on available for installation" src="./docs/user_guide/images/install-02-repo-added.png" width="300" />
 3. The add-on is now installed! You can now use the new Submit to AWS Deadline Cloud option in the Render menu. If later there's an update available, an **Update** button will appear next to the **AWS Deadline Cloud** entry in the **Get Extensions** section.
 
+## Submission Hooks
+
+The Blender submitter supports Deadline Cloud **submission hooks** — studio-provided scripts that run
+at the pre-GUI, pre-submission, and post-submission phases (for example to pre-populate the submitter
+dialog or enforce studio defaults). The submitter, and any pre-GUI hook, opens from **Render > Submit
+to AWS Deadline Cloud**.
+
+Blender has no on-disk job bundle at submission time, so hooks are sourced from the directory named by
+the `DEADLINE_HOOKS_DIR` environment variable (set it before launching Blender). Enable environment
+hooks with:
+
+```
+deadline config set settings.allow_environment_hooks true
+```
+
+For the rest — the `hooks.yaml` format, the per-phase input/output contracts, examples, and security
+considerations — see the AWS Deadline Cloud client docs:
+[**Submission Hooks**](https://github.com/aws-deadline/deadline-cloud/blob/mainline/docs/submission-hooks.md).
+
 ## Adaptor
 
 The Blender Adaptor implements the [OpenJD][openjd-adaptor-runtime] interface that allows render workloads to launch Blender and feed it commands. This gives the following benefits:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The submission-hook integration for the Blender submitter shipped in #370, but the README had no mention of it. Rather than duplicating the full hook reference in every DCC repo, this adds a short **"Submission Hooks"** section that points at the base client's canonical docs — closing the docs gap while keeping a single source of truth.

### What was the solution? (How)

Docs-only: add a brief **"Submission Hooks"** section to `README.md` stating that the Blender submitter supports Deadline Cloud submission hooks (pre-GUI, pre-/post-submission) sourced from `DEADLINE_HOOKS_DIR` (enabled via `deadline config set settings.allow_environment_hooks true`) and opened from **Render > Submit to AWS Deadline Cloud**, then linking [deadline-cloud/docs/submission-hooks.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/docs/submission-hooks.md) for the `hooks.yaml` format, per-phase contracts, examples, and security guidance.

### What is the impact of this change?

Documentation only — one file (`README.md`), no code and no behavior change.

### How was this change tested?

Reviewed the rendered Markdown and confirmed the linked base doc exists on `mainline`.

#### Please run the integration tests and paste the results below

N/A — README-only change; there is no code path to integration-test.

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

N/A — no files added/removed from `src/` and `installer/` was not modified; only `README.md` changed.

### Was this change documented?

Yes — this PR *is* the documentation.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
